### PR TITLE
Add explicit resource release

### DIFF
--- a/core/aio/archer_tensor_index.cpp
+++ b/core/aio/archer_tensor_index.cpp
@@ -95,7 +95,7 @@ std::string TensorStorageMeta::DebugString() const
     return ss.str();
 }
 
-ArcherTensorIndex* kTensorIndex = ArcherTensorIndex::GetInstance();
+std::unique_ptr<ArcherTensorIndex> kTensorIndex(nullptr);
 
 void ArcherTensorIndex::Serialize(const char* path)
 {

--- a/core/aio/archer_tensor_index.h
+++ b/core/aio/archer_tensor_index.h
@@ -45,11 +45,9 @@ public:
     void Serialize(const char* path);
     void Deserialize(const char* path);
 
-    STATIC_GET_INSTANCE(ArcherTensorIndex)
-
-private:
     ArcherTensorIndex() = default;
     ~ArcherTensorIndex() = default;
+private:
 };
 
-extern ArcherTensorIndex* kTensorIndex;
+extern std::unique_ptr<ArcherTensorIndex> kTensorIndex;

--- a/core/prefetch/archer_prefetch_handle.h
+++ b/core/prefetch/archer_prefetch_handle.h
@@ -45,6 +45,8 @@ public:
     bool IsTensorOnDevice(const torch::Tensor& tensor) const;
     bool IsTensorOnDevice(const TensorID tensor_id) const;
 
+    void CleanUpResources();
+
     // void SetNodeCachePriority(const std::uint64_t corr_id, const float priority);
 
 private:
@@ -53,6 +55,7 @@ private:
     std::unordered_set<std::uint32_t> tensors_to_delete_;
     uint64_t last_layer_id_;
     NodePtr last_node_;
+    bool has_cleaned_up_resources_;
 
     std::unordered_map<std::uint64_t, std::unordered_set<NodePtr>> request_id_to_nodes_;
 

--- a/core/python/py_archer_prefetch.cpp
+++ b/core/python/py_archer_prefetch.cpp
@@ -68,7 +68,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         .def("prefetch_tensors", &ArcherPrefetchHandle::PrefetchTensors)
         .def("replace_cache_candidates", &ArcherPrefetchHandle::ReplaceCacheCandidates)
         .def("enqueue_prefetch", &ArcherPrefetchHandle::EnqueuePrefetch)
-        .def("fetch_tensors", &ArcherPrefetchHandle::FetchTensors);
+        .def("fetch_tensors", &ArcherPrefetchHandle::FetchTensors)
+        .def("clean_up_resources", &ArcherPrefetchHandle::CleanUpResources);
      //    .def("set_node_cache_priority", &ArcherPrefetchHandle::SetNodeCachePriority);
 
     py::class_<ExpertDispatcher>(m, "expert_dispatcher")


### PR DESCRIPTION
In the open-moe-llm-leaderboard, each task currently initializes separately. 

However, the control over resource release timing is not precise, which can lead to potential issues. Specifically, there's a risk that a new `ArcherPrefetchHandle` instance might be initialized before the previous one is properly destructed. 

To prevent this and ensure clean resource management, I propose that we explicitly release resources within the `__del__` method. To address this issue, I recommend adding an interface for explicit resource release.