### PR TITLE
fix: CI fail due to deprecated github actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,7 +33,7 @@ jobs:
           bash -x .github/workflows/scripts/free-disk-space.sh
 
       - name: Cache Python packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -24,7 +24,7 @@ jobs:
         echo $VERSION_HASH > version.txt
 
     - name: Upload version number as artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: version
         path: version.txt
@@ -52,7 +52,7 @@ jobs:
 
     # https://github.com/orgs/community/discussions/26313
       - name: Download version value artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
             name: version
             path: artifact

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Note that: The open-sourced MoE-Infinity has been redesigned for making it Huggi
 Single GPU A5000 (24GB Memory), per-token-latency (seconds) for generation with a mixed dataset that includes [FLAN](https://huggingface.co/datasets/Muennighoff/flan), [BIG-Bench](https://huggingface.co/datasets/bigbench) and [MMLU](https://huggingface.co/datasets/lukaemon/mmlu) datasets.
 Lower per-token-latency is preferable.
 
-|  | switch-large-128 | NLLB-MoE-54B | Mixtral-8x7b | DeepSeel-V2-Lite
+|  | Switch-large-128 | NLLB-MoE-54B | Mixtral-8x7b | DeepSeek-V2-Lite
 | :---: | :---: | :---: | :---: | :---: |
 | <ins>MoE-Infinity</ins> | <ins>*0.230*</ins>	| <ins>*0.239*</ins> | <ins>*0.895*</ins> | <ins>*0.181*</ins> |
 | Accelerate | 1.043 | 3.071 | 6.633 |  1.743  |


### PR DESCRIPTION


This PR updates the version of 2 github actions:
- `actions/upload-artifact: v2` and `actions/download-artifact: v2` to `v4`
- `actions/cache: v2` to `v4`