### PR TITLE
CI: fix not a git repository in CI

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: Generate version number
       run: |
-        VERSION_HASH=$(git log -1 --format=%cd --date=format:%Y%m%dh%H%M%S)
+        VERSION_HASH=$(date +"%Y%m%d%H%M%S")
         echo "Generated version hash: $VERSION_HASH"
         echo $VERSION_HASH > version.txt
 


### PR DESCRIPTION
## Description
The CI failed with the following error:
```bash
$ VERSION_HASH=$(git log -1 --format=%cd --date=format:%Y%m%dh%H%M%S)
fatal: not a git repository (or any of the parent directories): .git
```

https://github.com/EfficientMoE/MoE-Infinity/actions/runs/13683972464/job/38262839872

## Motivation

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
