### PR TITLE
fix(parallel): pass exec stream to CUTLASS fused MoE FFN — fixes garbage output

### DIFF
--- a/core/parallel/expert_module.cpp
+++ b/core/parallel/expert_module.cpp
@@ -464,9 +464,8 @@ torch::Tensor MoEMLP::forward(torch::Tensor hidden_states,
   //   warmup_count_--;
   //   ForwardHelper();
   // }
-  ForwardHelper();
+  ForwardHelper(stream);
   param_set_ = false;
-  // slice until batch_size
   cudaStreamSynchronize(stream);
   // auto options = torch::TensorOptions()
   //                    .dtype(dtype_to_torch(dtype_))
@@ -478,7 +477,7 @@ torch::Tensor MoEMLP::forward(torch::Tensor hidden_states,
   return output_.index({torch::indexing::Slice(0, batch_size)});
 }
 
-void MoEMLP::ForwardHelper() {
+void MoEMLP::ForwardHelper(cudaStream_t stream) {
   torch::NoGradGuard no_grad;
   if (expert_type_ == DEEPSEEK_MOE_DENSE_ACT_DENSE ||
       expert_type_ == MIXTRAL_MOE_DENSE_ACT_DENSE) {
@@ -502,7 +501,7 @@ void MoEMLP::ForwardHelper() {
     // Single fused CUTLASS call: 3 GEMMs, silu*up fused into GEMM1 epilogue.
     // Replaces: matmul(gate), matmul(up), silu, mul, matmul(down).
     fused_moe_ffn_into(input, gate_proj, up_proj, down_proj, gate_out,
-                       fused_out, output, /*stream=*/nullptr);
+                       fused_out, output, stream);
     return;
   }
   DLOG_FATAL("MoEMLP::forward: expert_type not supported", expert_type_);

--- a/core/parallel/expert_module.h
+++ b/core/parallel/expert_module.h
@@ -241,7 +241,7 @@ struct MoEMLP : public torch::nn::Module {
   void SetTensorsFromIds(const std::vector<std::uint32_t>& tensor_ids);
 
  private:
-  void ForwardHelper();
+  void ForwardHelper(cudaStream_t stream);
 
  private:
   std::vector<torch::Tensor> buffer_;


### PR DESCRIPTION
## Summary

- **Root cause**: `fused_moe_ffn_into()` was called with `stream=nullptr`, launching CUTLASS GEMMs on the default CUDA stream while the caller (`GPUExecFunc`) operated on a custom non-blocking exec stream. The subsequent `cudaStreamSynchronize(exec_stream)` synced the wrong stream, allowing `OutputFunc` to read incomplete expert output — producing **consistent garbage** for all models using the fused CUTLASS MoE MLP path.

- **Fix**: Pass the exec stream through `ForwardHelper()` to `fused_moe_ffn_into()` so all CUTLASS kernels run on the same stream that gets synchronized.

- **Affected models**: All models mapped to `DEEPSEEK_MOE_DENSE_ACT_DENSE` (expert_type=5) and `MIXTRAL_MOE_DENSE_ACT_DENSE` (expert_type=4) — DeepSeek-V2, DeepSeek-V3, Qwen3 MoE, Mixtral. Other expert types (Switch, NLLB) use `torch::matmul` which respects `CUDAStreamGuard` and were unaffected.

## Changes

| File | Change |
|---|---|
| `core/parallel/expert_module.h` | `ForwardHelper()` → `ForwardHelper(cudaStream_t stream)` |
| `core/parallel/expert_module.cpp` | Pass `stream` to `ForwardHelper` and through to `fused_moe_ffn_into` instead of `nullptr` |

## Verification

Tested in Docker on NVIDIA RTX A5000 (24GB):

| Model | Before | After |
|---|---|---|
| DeepSeek-V2-Lite-Chat | `"the capital of the capital of the United..."` | `"Paris, which is also the largest city in the country. The city is located on the Seine River"` |
| Qwen3-30B-A3B | (same bug path) | `"Paris. The capital of the United States is Washington, D.C. The capital of Brazil is Brasília."` |

### Debugging methodology
1. Added `cudaDeviceSynchronize()` in `WaitHiddenStates` — still garbage (sync too late, corruption already happened in `OutputFunc`)
2. Added `cudaDeviceSynchronize()` after `ForwardHelper()` in `MoEMLP::forward()` — output became correct (confirmed CUTLASS running on wrong stream)
3. Applied proper fix: pass stream through instead of brute-force device sync