### PR TITLE
feat(flashinfer): integrate FlashInfer paged attention for prefill and decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,22 @@ FLASH_ATTENTION_FORCE_BUILD=TRUE pip install flash-attn
 ```
 Post-installation, MoE-Infinity will automatically integrate with FlashAttention to enhance performance.
 
+### Enable FlashInfer (Optional)
+
+Install [FlashInfer](https://flashinfer.ai/) for optimized paged attention kernels during prefill and decode. FlashInfer provides significant speedups for paged KV cache attention compared to standard PyTorch SDPA.
+
+```bash
+# For CUDA 12.4 + PyTorch 2.5:
+pip install flashinfer -i https://flashinfer.ai/whl/cu124/torch2.5/
+
+# For CUDA 12.1 + PyTorch 2.4:
+pip install flashinfer -i https://flashinfer.ai/whl/cu121/torch2.4/
+```
+
+Check the [FlashInfer installation guide](https://docs.flashinfer.ai/installation.html) for other CUDA/PyTorch version combinations.
+
+Post-installation, MoE-Infinity will automatically detect and use FlashInfer for faster paged attention in both prefill and decode phases. When FlashInfer is not installed, MoE-Infinity gracefully falls back to its built-in attention kernels with no behavior change.
+
 ## Usage and Examples
 
 We provide a simple API for diverse setups, including single GPU, multiple GPUs, and multiple nodes. The following examples show how to use MoE-Infinity to run generation on a Huggingface LLM model.

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -434,8 +434,25 @@ class MoE:
             ) and model_device.type not in ("meta", "cpu"):
                 input_tensor = input_tensor.to(model_device)
 
+        paged_attention_classes = self._get_paged_attention_classes()
+        use_paged_context = bool(
+            paged_attention_classes
+            and _attention_metadata is not None
+            and getattr(self, "_native_attention_backend", None) is not None
+        )
+
         with torch.no_grad():
-            outputs = self.model(input_tensor)
+            if not use_paged_context:
+                outputs = self.model(input_tensor)
+            else:
+                backend = self._native_attention_backend
+                for attn_cls in paged_attention_classes:
+                    attn_cls.set_paged_context(backend, _attention_metadata)
+                try:
+                    outputs = self.model(input_tensor)
+                finally:
+                    for attn_cls in paged_attention_classes:
+                        attn_cls.clear_paged_context()
 
         logits = getattr(outputs, "logits", None)
         if logits is None and isinstance(outputs, tuple) and outputs:
@@ -449,6 +466,33 @@ class MoE:
         if logits.ndim == 2:
             return logits.detach().to("cpu")
         raise RuntimeError(f"unexpected logits shape: {tuple(logits.shape)}")
+
+    def _get_paged_attention_classes(self) -> list[type[Any]]:
+        paged_class_names = {
+            "DeepseekV2PagedAttention",
+            "DeepseekV3PagedAttention",
+        }
+        classes: list[type[Any]] = []
+        seen: set[type[Any]] = set()
+
+        modules_fn = getattr(self.model, "modules", None)
+        if not callable(modules_fn):
+            return classes
+
+        for module in modules_fn():
+            cls = module.__class__
+            if cls in seen:
+                continue
+            if cls.__name__ not in paged_class_names:
+                continue
+            if not hasattr(cls, "set_paged_context") or not hasattr(
+                cls, "clear_paged_context"
+            ):
+                continue
+            seen.add(cls)
+            classes.append(cls)
+
+        return classes
 
     def _configure_hook(self, input_ids: torch.LongTensor):
         import transformers

--- a/moe_infinity/models/modeling_deepseek_v2/modeling_deepseek.py
+++ b/moe_infinity/models/modeling_deepseek_v2/modeling_deepseek.py
@@ -1325,15 +1325,132 @@ class DeepseekV2PagedAttention(DeepseekV2Attention):
     ) -> Tuple[
         torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]
     ]:
-        return super().forward(
-            hidden_states=hidden_states,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_value=past_key_value,
-            output_attentions=output_attentions,
-            use_cache=use_cache,
-            **kwargs,
+        paged_backend = self.__class__._paged_backend
+        attention_metadata = self.__class__._attention_metadata
+        if paged_backend is None or attention_metadata is None:
+            return super().forward(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                **kwargs,
+            )
+
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            )
+
+        bsz, q_len, _ = hidden_states.size()
+
+        if self.q_lora_rank is None:
+            q = self.q_proj(hidden_states)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
+        q = q.view(bsz, q_len, self.num_heads, self.q_head_dim).transpose(1, 2)
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
         )
+
+        compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
+        compressed_kv, k_pe = torch.split(
+            compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        )
+        k_pe = k_pe.view(bsz, q_len, 1, self.qk_rope_head_dim).transpose(1, 2)
+        kv = (
+            self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
+            .view(
+                bsz,
+                q_len,
+                self.num_heads,
+                self.qk_nope_head_dim + self.v_head_dim,
+            )
+            .transpose(1, 2)
+        )
+
+        k_nope, value_states = torch.split(
+            kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
+        kv_seq_len = value_states.shape[-2]
+        if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
+                    "with a layer index."
+                )
+            kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
+        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+
+        q_pe, k_pe = apply_rotary_pos_emb(q_pe, k_pe, cos, sin, position_ids)
+
+        query_states = k_pe.new_empty(
+            bsz, self.num_heads, q_len, self.q_head_dim
+        )
+        query_states[:, :, :, : self.qk_nope_head_dim] = q_nope
+        query_states[:, :, :, self.qk_nope_head_dim :] = q_pe
+
+        key_states = k_pe.new_empty(bsz, self.num_heads, q_len, self.q_head_dim)
+        key_states[:, :, :, : self.qk_nope_head_dim] = k_nope
+        key_states[:, :, :, self.qk_nope_head_dim :] = k_pe
+        if past_key_value is not None:
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        query_tokens = (
+            query_states.transpose(1, 2)
+            .contiguous()
+            .view(-1, self.num_heads, self.q_head_dim)
+        )
+        key_tokens = (
+            key_states.transpose(1, 2)
+            .contiguous()
+            .view(-1, self.num_heads, self.q_head_dim)
+        )
+        value_tokens = (
+            value_states.transpose(1, 2)
+            .contiguous()
+            .view(-1, self.num_heads, self.v_head_dim)
+        )
+
+        attn_output_tokens = paged_backend.forward(
+            query_tokens,
+            key_tokens,
+            value_tokens,
+            attention_metadata=attention_metadata,
+            scale=self.softmax_scale,
+        )
+
+        if attn_output_tokens.ndim != 3:
+            raise ValueError(
+                "paged attention backend must return rank-3 tensor"
+            )
+
+        attn_output = attn_output_tokens.view(
+            bsz,
+            q_len,
+            self.num_heads,
+            self.v_head_dim,
+        ).transpose(1, 2)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.v_head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.v_head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(
+            bsz, q_len, self.num_heads * self.v_head_dim
+        )
+        attn_output = self.o_proj(attn_output)
+
+        attn_weights = None
+        return attn_output, attn_weights, past_key_value
 
     @classmethod
     def get_kv_cache_spec_for_config(cls, config) -> dict[str, int]:

--- a/moe_infinity/models/modeling_deepseek_v3/modeling_deepseek.py
+++ b/moe_infinity/models/modeling_deepseek_v3/modeling_deepseek.py
@@ -1270,15 +1270,132 @@ class DeepseekV3PagedAttention(DeepseekV3Attention):
     ) -> Tuple[
         torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]
     ]:
-        return super().forward(
-            hidden_states=hidden_states,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_value=past_key_value,
-            output_attentions=output_attentions,
-            use_cache=use_cache,
-            **kwargs,
+        paged_backend = self.__class__._paged_backend
+        attention_metadata = self.__class__._attention_metadata
+        if paged_backend is None or attention_metadata is None:
+            return super().forward(
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_value=past_key_value,
+                output_attentions=output_attentions,
+                use_cache=use_cache,
+                **kwargs,
+            )
+
+        if "padding_mask" in kwargs:
+            warnings.warn(
+                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+            )
+
+        bsz, q_len, _ = hidden_states.size()
+
+        if self.q_lora_rank is None:
+            q = self.q_proj(hidden_states)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(hidden_states)))
+        q = q.view(bsz, q_len, self.num_heads, self.q_head_dim).transpose(1, 2)
+        q_nope, q_pe = torch.split(
+            q, [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
         )
+
+        compressed_kv = self.kv_a_proj_with_mqa(hidden_states)
+        compressed_kv, k_pe = torch.split(
+            compressed_kv, [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+        )
+        k_pe = k_pe.view(bsz, q_len, 1, self.qk_rope_head_dim).transpose(1, 2)
+        kv = (
+            self.kv_b_proj(self.kv_a_layernorm(compressed_kv))
+            .view(
+                bsz,
+                q_len,
+                self.num_heads,
+                self.qk_nope_head_dim + self.v_head_dim,
+            )
+            .transpose(1, 2)
+        )
+
+        k_nope, value_states = torch.split(
+            kv, [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
+        kv_seq_len = value_states.shape[-2]
+        if past_key_value is not None:
+            if self.layer_idx is None:
+                raise ValueError(
+                    f"The cache structure has changed since version v4.36. If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, please make sure to initialize the attention class "
+                    "with a layer index."
+                )
+            kv_seq_len += past_key_value.get_seq_length(self.layer_idx)
+        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+
+        q_pe, k_pe = apply_rotary_pos_emb(q_pe, k_pe, cos, sin, position_ids)
+
+        query_states = k_pe.new_empty(
+            bsz, self.num_heads, q_len, self.q_head_dim
+        )
+        query_states[:, :, :, : self.qk_nope_head_dim] = q_nope
+        query_states[:, :, :, self.qk_nope_head_dim :] = q_pe
+
+        key_states = k_pe.new_empty(bsz, self.num_heads, q_len, self.q_head_dim)
+        key_states[:, :, :, : self.qk_nope_head_dim] = k_nope
+        key_states[:, :, :, self.qk_nope_head_dim :] = k_pe
+        if past_key_value is not None:
+            cache_kwargs = {"sin": sin, "cos": cos}  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        query_tokens = (
+            query_states.transpose(1, 2)
+            .contiguous()
+            .view(-1, self.num_heads, self.q_head_dim)
+        )
+        key_tokens = (
+            key_states.transpose(1, 2)
+            .contiguous()
+            .view(-1, self.num_heads, self.q_head_dim)
+        )
+        value_tokens = (
+            value_states.transpose(1, 2)
+            .contiguous()
+            .view(-1, self.num_heads, self.v_head_dim)
+        )
+
+        attn_output_tokens = paged_backend.forward(
+            query_tokens,
+            key_tokens,
+            value_tokens,
+            attention_metadata=attention_metadata,
+            scale=self.softmax_scale,
+        )
+
+        if attn_output_tokens.ndim != 3:
+            raise ValueError(
+                "paged attention backend must return rank-3 tensor"
+            )
+
+        attn_output = attn_output_tokens.view(
+            bsz,
+            q_len,
+            self.num_heads,
+            self.v_head_dim,
+        ).transpose(1, 2)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.v_head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.v_head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(
+            bsz, q_len, self.num_heads * self.v_head_dim
+        )
+        attn_output = self.o_proj(attn_output)
+
+        attn_weights = None
+        return attn_output, attn_weights, past_key_value
 
     @classmethod
     def get_kv_cache_spec_for_config(cls, config) -> dict[str, int]:

--- a/moe_infinity/runtime/attention_backend.py
+++ b/moe_infinity/runtime/attention_backend.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Optional, Protocol, cast, runtime_checkable
+from typing import Any, Optional, Protocol, cast, runtime_checkable
 
 import torch
 import torch.nn.functional as F
 
 from moe_infinity.kernel.paged_attention_ops import paged_attention_fwd
+from moe_infinity.runtime import flashinfer_utils
 from moe_infinity.runtime.attention_types import (
     AttentionMetadata as RuntimeAttentionMetadata,
 )
@@ -80,6 +81,11 @@ class PagedAttentionBackend:
     device: torch.device
     k_cache: torch.Tensor
     v_cache: torch.Tensor
+    _use_flashinfer: bool
+    _fi_workspace: Optional[torch.Tensor]
+    _fi_kv_cache: Optional[torch.Tensor]
+    _fi_prefill: Optional[Any]
+    _fi_decode: Optional[Any]
 
     def __init__(
         self,
@@ -112,6 +118,49 @@ class PagedAttentionBackend:
             dtype=spec.dtype,
             device=device,
         )
+
+        self._use_flashinfer = False
+        self._fi_workspace = None
+        self._fi_kv_cache = None
+        self._fi_prefill = None
+        self._fi_decode = None
+        if flashinfer_utils.HAS_FLASHINFER:
+            flashinfer_module = cast(
+                Any,
+                flashinfer_utils.get_flashinfer_module(),
+            )
+            if flashinfer_module is not None:
+                try:
+                    workspace = flashinfer_utils.get_workspace(device)
+                    self._fi_workspace = workspace
+                    self._fi_kv_cache = torch.zeros(
+                        self.num_gpu_blocks,
+                        2,
+                        spec.block_size,
+                        spec.num_kv_heads,
+                        spec.head_dim,
+                        dtype=spec.dtype,
+                        device=device,
+                    )
+                    self._fi_prefill = (
+                        flashinfer_module.BatchPrefillWithPagedKVCacheWrapper(
+                            workspace,
+                            "NHD",
+                        )
+                    )
+                    self._fi_decode = (
+                        flashinfer_module.BatchDecodeWithPagedKVCacheWrapper(
+                            workspace,
+                            "NHD",
+                        )
+                    )
+                    self._use_flashinfer = True
+                except Exception:
+                    self._use_flashinfer = False
+                    self._fi_workspace = None
+                    self._fi_kv_cache = None
+                    self._fi_prefill = None
+                    self._fi_decode = None
 
     def write_kv(
         self,
@@ -160,6 +209,49 @@ class PagedAttentionBackend:
             )
             self.v_cache[block_id, :, :, token_offset] = v_src[i]
 
+    def write_kv_flashinfer(
+        self,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        if self._fi_kv_cache is None:
+            raise RuntimeError("FlashInfer KV cache is not initialized")
+        if key.shape != value.shape:
+            raise ValueError("key and value must have the same shape")
+        if key.ndim != 3:
+            raise ValueError(
+                "key/value must have shape [num_tokens, num_kv_heads, head_dim]"
+            )
+        if slot_mapping.ndim != 1 or slot_mapping.shape[0] != key.shape[0]:
+            raise ValueError("slot_mapping must have shape [num_tokens]")
+
+        num_tokens, num_kv_heads, head_dim = key.shape
+        if num_kv_heads != self.spec.num_kv_heads:
+            raise ValueError("num_kv_heads mismatch with cache spec")
+        if head_dim != self.spec.head_dim:
+            raise ValueError("head_dim mismatch with cache spec")
+
+        k_src = key.to(device=self.device, dtype=self.spec.dtype)
+        v_src = value.to(device=self.device, dtype=self.spec.dtype)
+        slots = slot_mapping.to(device=self.device, dtype=torch.long)
+
+        block_size = self.spec.block_size
+        for i in range(num_tokens):
+            slot = int(slots[i].item())
+            if slot < 0:
+                raise ValueError("slot_mapping contains negative slot index")
+
+            block_id = slot // block_size
+            token_offset = slot % block_size
+            if block_id >= self.num_gpu_blocks:
+                raise ValueError(
+                    "slot_mapping points past allocated GPU blocks"
+                )
+
+            self._fi_kv_cache[block_id, 0, token_offset] = k_src[i]
+            self._fi_kv_cache[block_id, 1, token_offset] = v_src[i]
+
     def forward(
         self,
         query: torch.Tensor,
@@ -188,7 +280,15 @@ class PagedAttentionBackend:
             if slot_mapping is None:
                 raise ValueError("prefill requires slot_mapping")
             self.write_kv(key, value, slot_mapping)
-            return self._prefill_forward(query, key, value, scale=scale)
+            if self._flashinfer_enabled():
+                self.write_kv_flashinfer(key, value, slot_mapping)
+            return self._prefill_forward(
+                query,
+                key,
+                value,
+                metadata=metadata,
+                scale=scale,
+            )
 
         return self._decode_forward(query, metadata, scale=scale)
 
@@ -197,11 +297,38 @@ class PagedAttentionBackend:
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
+        metadata: Optional[AttentionMetadata | RuntimeAttentionMetadata] = None,
         scale: Optional[float] = None,
     ) -> torch.Tensor:
         if query.ndim != 3 or key.ndim != 3 or value.ndim != 3:
             raise ValueError(
                 "prefill query/key/value must have shape [num_tokens, num_heads, head_dim]"
+            )
+
+        if self._flashinfer_enabled():
+            if metadata is None:
+                raise ValueError("prefill requires attention metadata")
+            if self._fi_prefill is None or self._fi_kv_cache is None:
+                raise RuntimeError(
+                    "FlashInfer prefill wrappers are unavailable"
+                )
+
+            query_src = query.to(self.device, dtype=self.spec.dtype)
+            num_qo_heads = int(query_src.shape[1])
+            qo_indptr, kv_indptr, kv_indices, kv_last_page_len = (
+                self._build_flashinfer_metadata(metadata)
+            )
+
+            self._call_prefill_plan(
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+            )
+            return cast(
+                torch.Tensor,
+                self._fi_prefill.run(query_src, self._fi_kv_cache),
             )
 
         q = (
@@ -268,6 +395,27 @@ class PagedAttentionBackend:
                 "decode query must have shape [batch_size, num_heads, head_dim]"
             )
 
+        if self._flashinfer_enabled():
+            if self._fi_decode is None or self._fi_kv_cache is None:
+                raise RuntimeError("FlashInfer decode wrappers are unavailable")
+
+            query_src = query.to(self.device, dtype=self.spec.dtype)
+            num_qo_heads = int(query_src.shape[1])
+            _, kv_indptr, kv_indices, kv_last_page_len = (
+                self._build_flashinfer_metadata(metadata)
+            )
+            self._call_decode_plan(
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                query_src.dtype,
+            )
+            return cast(
+                torch.Tensor,
+                self._fi_decode.run(query_src, self._fi_kv_cache),
+            )
+
         block_tables = self._get_block_tables(metadata)
         seq_lens = self._get_seq_lens(metadata)
         max_seq_len = self._get_max_seq_len(metadata, seq_lens)
@@ -291,6 +439,152 @@ class PagedAttentionBackend:
             block_size=self.spec.block_size,
             max_seq_len=max_seq_len,
         )
+
+    def _flashinfer_enabled(self) -> bool:
+        return bool(
+            self._use_flashinfer
+            and self._fi_prefill is not None
+            and self._fi_decode is not None
+            and self._fi_kv_cache is not None
+        )
+
+    def _build_flashinfer_metadata(
+        self,
+        metadata: AttentionMetadata | RuntimeAttentionMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        block_tables = self._get_block_tables(metadata)
+        seq_lens = self._get_seq_lens(metadata)
+        if block_tables is None or seq_lens is None:
+            raise ValueError(
+                "FlashInfer attention requires block_tables and seq_lens"
+            )
+
+        block_tables_i32 = block_tables.to(self.device, dtype=torch.int32)
+        seq_lens_i32 = seq_lens.to(self.device, dtype=torch.int32).reshape(-1)
+        batch_size = int(seq_lens_i32.shape[0])
+
+        qo_indptr = torch.zeros(
+            batch_size + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        if batch_size > 0:
+            qo_indptr[1:] = torch.cumsum(seq_lens_i32, dim=0)
+
+        block_size = int(self.spec.block_size)
+        kv_indptr_vals = [0]
+        kv_last_page_len = torch.zeros(
+            batch_size,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        kv_indices_per_seq: list[torch.Tensor] = []
+        total_pages = 0
+
+        for i in range(batch_size):
+            seq_len = int(seq_lens_i32[i].item())
+            num_pages = max((seq_len + block_size - 1) // block_size, 1)
+            if num_pages > int(block_tables_i32.shape[1]):
+                raise ValueError(
+                    "block_tables does not have enough page indices"
+                )
+            kv_indices_per_seq.append(block_tables_i32[i, :num_pages])
+            total_pages += num_pages
+            kv_indptr_vals.append(total_pages)
+
+            if seq_len <= 0:
+                kv_last_page_len[i] = 1
+            else:
+                rem = seq_len % block_size
+                kv_last_page_len[i] = block_size if rem == 0 else rem
+
+        kv_indptr = torch.tensor(
+            kv_indptr_vals,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        if total_pages == 0:
+            kv_indices = torch.empty(
+                0,
+                dtype=torch.int32,
+                device=self.device,
+            )
+        else:
+            kv_indices = torch.cat(kv_indices_per_seq, dim=0).to(
+                self.device,
+                dtype=torch.int32,
+            )
+
+        return qo_indptr, kv_indptr, kv_indices, kv_last_page_len
+
+    def _call_prefill_plan(
+        self,
+        qo_indptr: torch.Tensor,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_last_page_len: torch.Tensor,
+        num_qo_heads: int,
+    ) -> None:
+        if self._fi_prefill is None:
+            raise RuntimeError("FlashInfer prefill wrapper is unavailable")
+
+        try:
+            self._fi_prefill.plan(
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                self.spec.num_kv_heads,
+                self.spec.head_dim,
+                self.spec.block_size,
+            )
+        except TypeError:
+            self._fi_prefill.plan(
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                self.spec.num_kv_heads,
+                self.spec.head_dim,
+                self.spec.block_size,
+                causal=True,
+            )
+
+    def _call_decode_plan(
+        self,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_last_page_len: torch.Tensor,
+        num_qo_heads: int,
+        query_dtype: torch.dtype,
+    ) -> None:
+        if self._fi_decode is None:
+            raise RuntimeError("FlashInfer decode wrapper is unavailable")
+
+        try:
+            self._fi_decode.plan(
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                self.spec.num_kv_heads,
+                self.spec.head_dim,
+                self.spec.block_size,
+            )
+        except TypeError:
+            self._fi_decode.plan(
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                self.spec.num_kv_heads,
+                self.spec.head_dim,
+                self.spec.block_size,
+                pos_encoding_mode="NONE",
+                data_type=query_dtype,
+            )
 
     @classmethod
     def get_kv_cache_shape(

--- a/moe_infinity/runtime/flashinfer_utils.py
+++ b/moe_infinity/runtime/flashinfer_utils.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Final, Optional
+
+import torch
+
+try:
+    import flashinfer as _flashinfer
+
+    _has_flashinfer = True
+except Exception:
+    _flashinfer = None
+    _has_flashinfer = False
+
+
+HAS_FLASHINFER: Final[bool] = _has_flashinfer
+
+
+_WORKSPACE_SIZE_BYTES = 128 * 1024 * 1024
+_WORKSPACE_CACHE: dict[tuple[str, int | None], torch.Tensor] = {}
+
+
+def _device_key(device: torch.device) -> tuple[str, int | None]:
+    return (device.type, device.index)
+
+
+def get_workspace(device: torch.device) -> torch.Tensor:
+    key = _device_key(device)
+    workspace = _WORKSPACE_CACHE.get(key)
+    if workspace is None:
+        workspace = torch.empty(
+            _WORKSPACE_SIZE_BYTES,
+            dtype=torch.uint8,
+            device=device,
+        )
+        _WORKSPACE_CACHE[key] = workspace
+    return workspace
+
+
+def get_flashinfer_module() -> Optional[object]:
+    return _flashinfer

--- a/moe_infinity/serving/batch.py
+++ b/moe_infinity/serving/batch.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import torch
+
 from .kv_cache import PagedKVCache
 from .sequence import SamplingParams, SequenceData
 
@@ -72,6 +74,140 @@ class BatchMetadata:
         return len(self.input_token_ids)
 
 
+@dataclass
+class SplitBatchMetadata:
+    original_batch: BatchMetadata
+    prefill_batch: BatchMetadata | None
+    decode_batch: BatchMetadata | None
+    prefill_indices: list[int]
+    decode_indices: list[int]
+
+    def recombine_outputs(
+        self,
+        prefill_outputs: torch.Tensor | None,
+        decode_outputs: torch.Tensor | None,
+    ) -> torch.Tensor:
+        if self.prefill_batch is not None:
+            if prefill_outputs is None:
+                raise ValueError("prefill_outputs is required")
+            if prefill_outputs.shape[0] != self.prefill_batch.total_tokens:
+                raise ValueError(
+                    "prefill_outputs row count must match prefill_batch.total_tokens"
+                )
+        elif prefill_outputs is not None and prefill_outputs.shape[0] != 0:
+            raise ValueError("prefill_outputs must be None or empty")
+
+        if self.decode_batch is not None:
+            if decode_outputs is None:
+                raise ValueError("decode_outputs is required")
+            if decode_outputs.shape[0] != self.decode_batch.total_tokens:
+                raise ValueError(
+                    "decode_outputs row count must match decode_batch.total_tokens"
+                )
+        elif decode_outputs is not None and decode_outputs.shape[0] != 0:
+            raise ValueError("decode_outputs must be None or empty")
+
+        total_tokens = self.original_batch.total_tokens
+        sample_tensor = prefill_outputs
+        if sample_tensor is None:
+            sample_tensor = decode_outputs
+        if sample_tensor is None:
+            return torch.empty(0)
+
+        output_shape = (total_tokens, *sample_tensor.shape[1:])
+        result = torch.empty(
+            output_shape,
+            dtype=sample_tensor.dtype,
+            device=sample_tensor.device,
+        )
+
+        prefill_cursor = 0
+        decode_cursor = 0
+        for seq_idx in range(len(self.original_batch.seq_ids)):
+            seq_start = self.original_batch.token_offsets[seq_idx]
+            seq_end = self.original_batch.token_offsets[seq_idx + 1]
+            seq_len = seq_end - seq_start
+            if seq_len == 0:
+                continue
+
+            if self.original_batch.is_prefill[seq_idx]:
+                if prefill_outputs is None:
+                    raise ValueError("prefill_outputs is required")
+                source_start = prefill_cursor
+                source_end = prefill_cursor + seq_len
+                prefill_cursor = source_end
+                result[seq_start:seq_end] = prefill_outputs[
+                    source_start:source_end
+                ]
+            else:
+                if decode_outputs is None:
+                    raise ValueError("decode_outputs is required")
+                source_start = decode_cursor
+                source_end = decode_cursor + seq_len
+                decode_cursor = source_end
+                result[seq_start:seq_end] = decode_outputs[
+                    source_start:source_end
+                ]
+
+        return result
+
+
+def _slice_batch(batch: BatchMetadata, seq_indices: list[int]) -> BatchMetadata:
+    if not seq_indices:
+        raise ValueError("seq_indices must not be empty")
+
+    seq_ids = [batch.seq_ids[i] for i in seq_indices]
+    seq_lengths = [batch.seq_lengths[i] for i in seq_indices]
+    context_lengths = [batch.context_lengths[i] for i in seq_indices]
+    is_prefill = [batch.is_prefill[i] for i in seq_indices]
+    block_tables = [batch.block_tables[i] for i in seq_indices]
+    sampling_params = [batch.sampling_params[i] for i in seq_indices]
+
+    input_token_ids: list[int] = []
+    token_offsets = [0]
+    for i in seq_indices:
+        start = batch.token_offsets[i]
+        end = batch.token_offsets[i + 1]
+        tokens = batch.input_token_ids[start:end]
+        input_token_ids.extend(tokens)
+        token_offsets.append(token_offsets[-1] + len(tokens))
+
+    return BatchMetadata(
+        seq_ids=seq_ids,
+        input_token_ids=input_token_ids,
+        seq_lengths=seq_lengths,
+        context_lengths=context_lengths,
+        is_prefill=is_prefill,
+        block_tables=block_tables,
+        token_offsets=token_offsets,
+        sampling_params=sampling_params,
+    )
+
+
+def split_prefill_decode_batch(batch: BatchMetadata) -> SplitBatchMetadata:
+    prefill_indices = [
+        idx for idx, is_prefill in enumerate(batch.is_prefill) if is_prefill
+    ]
+    decode_indices = [
+        idx for idx, is_prefill in enumerate(batch.is_prefill) if not is_prefill
+    ]
+
+    prefill_batch = (
+        _slice_batch(batch, prefill_indices) if prefill_indices else None
+    )
+    decode_batch = (
+        _slice_batch(batch, decode_indices) if decode_indices else None
+    )
+
+    return SplitBatchMetadata(
+        original_batch=batch,
+        prefill_batch=prefill_batch,
+        decode_batch=decode_batch,
+        prefill_indices=prefill_indices,
+        decode_indices=decode_indices,
+    )
+
+
 class BatchBuilder:
     @staticmethod
     def from_scheduler_output(
@@ -131,4 +267,10 @@ class BatchBuilder:
         )
 
 
-__all__ = ["BatchBuilder", "BatchMetadata", "SchedulerOutput"]
+__all__ = [
+    "BatchBuilder",
+    "BatchMetadata",
+    "SchedulerOutput",
+    "SplitBatchMetadata",
+    "split_prefill_decode_batch",
+]

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -1,22 +1,39 @@
 from __future__ import annotations
 
 import heapq
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from math import ceil
+from typing import Protocol, cast
 
 import torch
 
-try:
-    import flashinfer
-    from flashinfer import (
-        BatchDecodeWithPagedKVCacheWrapper,
-        BatchPrefillWithPagedKVCacheWrapper,
-    )
-except ImportError:
-    flashinfer = None
-    BatchDecodeWithPagedKVCacheWrapper = None
-    BatchPrefillWithPagedKVCacheWrapper = None
+from moe_infinity.runtime import flashinfer_utils
 
-HAS_FLASHINFER = flashinfer is not None
+
+class _FlashinferPrefillWrapperLike(Protocol):
+    def plan(self, *args: object, **kwargs: object) -> None: ...
+
+    def run(
+        self, query: torch.Tensor, kv_cache: torch.Tensor
+    ) -> torch.Tensor: ...
+
+
+class _FlashinferDecodeWrapperLike(Protocol):
+    def plan(self, *args: object, **kwargs: object) -> None: ...
+
+    def run(
+        self, query: torch.Tensor, kv_cache: torch.Tensor
+    ) -> torch.Tensor: ...
+
+
+class _FlashinferModuleLike(Protocol):
+    BatchPrefillWithPagedKVCacheWrapper: Callable[
+        [torch.Tensor, str], _FlashinferPrefillWrapperLike
+    ]
+    BatchDecodeWithPagedKVCacheWrapper: Callable[
+        [torch.Tensor, str], _FlashinferDecodeWrapperLike
+    ]
 
 
 @dataclass
@@ -119,6 +136,14 @@ class PagedKVCache:
     )
     _swapped_out_sequences: set[int] = field(init=False, default_factory=set)
     _kv_cache: torch.Tensor = field(init=False)
+    _use_flashinfer: bool = field(init=False, default=False)
+    _fi_workspace: torch.Tensor | None = field(init=False, default=None)
+    _fi_prefill: _FlashinferPrefillWrapperLike | None = field(
+        init=False, default=None
+    )
+    _fi_decode: _FlashinferDecodeWrapperLike | None = field(
+        init=False, default=None
+    )
 
     def __post_init__(self) -> None:
         if self.num_layers <= 0:
@@ -146,6 +171,36 @@ class PagedKVCache:
             dtype=self.dtype,
             device=self.device,
         )
+
+        self._use_flashinfer = False
+        self._fi_workspace = None
+        self._fi_prefill = None
+        self._fi_decode = None
+        if flashinfer_utils.HAS_FLASHINFER:
+            flashinfer_module = flashinfer_utils.get_flashinfer_module()
+            if flashinfer_module is not None:
+                try:
+                    fi_module = cast(_FlashinferModuleLike, flashinfer_module)
+                    workspace = flashinfer_utils.get_workspace(self.device)
+                    self._fi_workspace = workspace
+                    self._fi_prefill = (
+                        fi_module.BatchPrefillWithPagedKVCacheWrapper(
+                            workspace,
+                            "NHD",
+                        )
+                    )
+                    self._fi_decode = (
+                        fi_module.BatchDecodeWithPagedKVCacheWrapper(
+                            workspace,
+                            "NHD",
+                        )
+                    )
+                    self._use_flashinfer = True
+                except Exception:
+                    self._use_flashinfer = False
+                    self._fi_workspace = None
+                    self._fi_prefill = None
+                    self._fi_decode = None
 
     def allocate_sequence(self, seq_id: int, num_tokens: int) -> None:
         if seq_id in self._sequence_tables:
@@ -177,10 +232,15 @@ class PagedKVCache:
         self._swapped_out_sequences.discard(seq_id)
 
     def free_gpu_blocks(self, seq_id: int) -> None:
-        if seq_id not in self._sequence_tables:
+        block_table = self._sequence_tables.get(seq_id)
+        if block_table is None:
             return
 
-        return
+        block_ids = block_table.get_block_ids()
+        if block_ids:
+            self.block_allocator.free(block_ids)
+            block_table._block_ids = []
+        # _num_tokens preserved so swap_in knows how many blocks to re-allocate
 
     def get_block_table(self, seq_id: int) -> list[int]:
         block_table = self._require_sequence(seq_id)
@@ -202,13 +262,18 @@ class PagedKVCache:
         self._swapped_out_sequences.add(seq_id)
 
     def swap_in(self, seq_id: int) -> None:
-        _ = self._require_sequence(seq_id)
+        block_table = self._require_sequence(seq_id)
         if seq_id not in self._swapped_out_sequences:
             return
 
+        if not block_table.get_block_ids() and block_table._num_tokens > 0:
+            needed = ceil(block_table._num_tokens / block_table.block_size)
+            new_blocks = self.block_allocator.allocate(needed)
+            block_table._block_ids = new_blocks
+
         cpu_buffer = self._swapped_cpu_buffers.pop(seq_id, None)
         if cpu_buffer is not None:
-            block_ids = self.get_block_table(seq_id)
+            block_ids = block_table.get_block_ids()
             if block_ids:
                 self._kv_cache[:, block_ids, ...] = cpu_buffer.to(
                     device=self._kv_cache.device,
@@ -224,16 +289,59 @@ class PagedKVCache:
         value: torch.Tensor,
         attn_mask: torch.Tensor | None = None,
         is_causal: bool = True,
+        layer_idx: int = 0,
     ) -> torch.Tensor:
         # Use FlashInfer paged attention if available, else fall back to torch SDPA.
-        if HAS_FLASHINFER:
-            # FlashInfer path (future: use BatchDecodeWithPagedKVCacheWrapper).
-            _ = (
-                flashinfer,
-                BatchPrefillWithPagedKVCacheWrapper,
-                BatchDecodeWithPagedKVCacheWrapper,
+        if self._flashinfer_enabled():
+            layer_kv_cache = self._kv_cache[layer_idx]
+            query_src = query.to(self.device, dtype=self._kv_cache.dtype)
+            query_tokens = int(query_src.shape[-2])
+            kv_tokens = int(key.shape[-2])
+            num_qo_heads = int(query_src.shape[-3])
+            batch_size = int(query_src.shape[0]) if query_src.ndim >= 4 else 1
+            block_size = int(self.block_size)
+
+            kv_indptr, kv_indices, kv_last_page_len = (
+                self._build_flashinfer_paged_metadata(
+                    batch_size=batch_size,
+                    kv_tokens=kv_tokens,
+                    block_size=block_size,
+                )
             )
-            pass  # currently falls through to SDPA until integration complete
+
+            if query_tokens > 1:
+                if self._fi_prefill is None:
+                    raise RuntimeError(
+                        "FlashInfer prefill wrapper is unavailable"
+                    )
+                qo_indptr = self._build_qo_indptr(
+                    batch_size=batch_size,
+                    query_tokens=query_tokens,
+                )
+                self._fi_prefill.plan(
+                    qo_indptr,
+                    kv_indptr,
+                    kv_indices,
+                    kv_last_page_len,
+                    num_qo_heads,
+                    self.num_heads,
+                    self.head_dim,
+                    block_size,
+                )
+                return self._fi_prefill.run(query_src, layer_kv_cache)
+
+            if self._fi_decode is None:
+                raise RuntimeError("FlashInfer decode wrapper is unavailable")
+            self._fi_decode.plan(
+                kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_qo_heads,
+                self.num_heads,
+                self.head_dim,
+                block_size,
+            )
+            return self._fi_decode.run(query_src, layer_kv_cache)
 
         return torch.nn.functional.scaled_dot_product_attention(
             query,
@@ -243,6 +351,63 @@ class PagedKVCache:
             dropout_p=0.0,
             is_causal=is_causal,
         )
+
+    def _flashinfer_enabled(self) -> bool:
+        return bool(
+            self._use_flashinfer
+            and self._fi_prefill is not None
+            and self._fi_decode is not None
+        )
+
+    def _build_qo_indptr(
+        self,
+        batch_size: int,
+        query_tokens: int,
+    ) -> torch.Tensor:
+        qo_indptr = torch.zeros(
+            batch_size + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        if batch_size > 0:
+            qo_indptr[1:] = torch.arange(
+                query_tokens,
+                query_tokens * (batch_size + 1),
+                query_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+        return qo_indptr
+
+    def _build_flashinfer_paged_metadata(
+        self,
+        batch_size: int,
+        kv_tokens: int,
+        block_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        num_pages = max((max(kv_tokens, 1) + block_size - 1) // block_size, 1)
+        kv_indptr_vals = [idx * num_pages for idx in range(batch_size + 1)]
+        kv_indptr = torch.tensor(
+            kv_indptr_vals,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        kv_indices = torch.arange(
+            num_pages,
+            dtype=torch.int32,
+            device=self.device,
+        ).repeat(batch_size)
+        rem = kv_tokens % block_size
+        last_page_len = (
+            block_size if rem == 0 and kv_tokens > 0 else max(rem, 1)
+        )
+        kv_last_page_len = torch.full(
+            (batch_size,),
+            fill_value=int(last_page_len),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        return kv_indptr, kv_indices, kv_last_page_len
 
     def _require_sequence(self, seq_id: int) -> BlockTable:
         block_table = self._sequence_tables.get(seq_id)

--- a/moe_infinity/serving/model_runner.py
+++ b/moe_infinity/serving/model_runner.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Optional, Protocol, runtime_checkable
+from collections.abc import Iterable, Mapping
+from typing import Any, Optional, Protocol, runtime_checkable
 
 import torch
+
+from moe_infinity.runtime.attention_types import (
+    AttentionMetadata as RuntimeAttentionMetadata,
+)
 
 from .batch import BatchMetadata
 
@@ -113,8 +117,24 @@ class ModelRunner:
         if not callable(forward_fn):
             raise ValueError("model must define callable forward()")
 
+        paged_attention_classes = self._get_paged_attention_classes()
+        backend = self._get_attention_backend()
+        use_paged_context = bool(
+            paged_attention_classes and backend is not None
+        )
+
         with torch.no_grad():
-            outputs = forward_fn(**forward_kwargs)
+            if not use_paged_context:
+                outputs = forward_fn(**forward_kwargs)
+            else:
+                metadata = self._build_runtime_attention_metadata(batch)
+                for attn_cls in paged_attention_classes:
+                    attn_cls.set_paged_context(backend, metadata)
+                try:
+                    outputs = forward_fn(**forward_kwargs)
+                finally:
+                    for attn_cls in paged_attention_classes:
+                        attn_cls.clear_paged_context()
 
         logits = self._extract_logits(outputs)
         if logits.dim() == 3:
@@ -159,6 +179,138 @@ class ModelRunner:
         return torch.empty(
             (0, vocab_size), dtype=torch.float32, device=self.device
         )
+
+    def _build_runtime_attention_metadata(
+        self, batch: BatchMetadata
+    ) -> RuntimeAttentionMetadata:
+        block_size = self._resolve_block_size()
+        max_blocks = max((len(row) for row in batch.block_tables), default=0)
+        block_tables = torch.zeros(
+            (len(batch.block_tables), max_blocks),
+            dtype=torch.int32,
+            device=self.device,
+        )
+        for row_idx, row in enumerate(batch.block_tables):
+            if row:
+                block_tables[row_idx, : len(row)] = torch.tensor(
+                    row,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+
+        seq_lens_values = [
+            context_len + seq_len
+            for context_len, seq_len in zip(
+                batch.context_lengths, batch.seq_lengths
+            )
+        ]
+        seq_lens = torch.tensor(
+            seq_lens_values,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        slot_mapping = torch.tensor(
+            self._build_slot_mapping(batch, block_size),
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+        num_prefill_tokens = sum(
+            seq_len
+            for seq_len, is_prefill in zip(batch.seq_lengths, batch.is_prefill)
+            if is_prefill
+        )
+        num_decode_tokens = batch.total_tokens - num_prefill_tokens
+
+        return RuntimeAttentionMetadata(
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max(seq_lens_values, default=0),
+            num_prefill_tokens=num_prefill_tokens,
+            num_decode_tokens=num_decode_tokens,
+            slot_mapping=slot_mapping,
+            is_prefill=bool(batch.is_prefill and all(batch.is_prefill)),
+        )
+
+    @staticmethod
+    def _build_slot_mapping(batch: BatchMetadata, block_size: int) -> list[int]:
+        slots: list[int] = []
+        for seq_idx, seq_len in enumerate(batch.seq_lengths):
+            block_table = batch.block_tables[seq_idx]
+            context_len = batch.context_lengths[seq_idx]
+            for token_idx in range(seq_len):
+                token_pos = context_len + token_idx
+                block_idx = token_pos // block_size
+                token_offset = token_pos % block_size
+                if block_idx >= len(block_table):
+                    raise ValueError(
+                        "batch metadata block table is too short for sequence length"
+                    )
+                slots.append(block_table[block_idx] * block_size + token_offset)
+        return slots
+
+    def _resolve_block_size(self) -> int:
+        kv_cache = getattr(self.engine, "kv_cache", None)
+        block_size = getattr(kv_cache, "block_size", None)
+        if isinstance(block_size, int) and block_size > 0:
+            return block_size
+
+        backend = self._get_attention_backend()
+        spec = getattr(backend, "spec", None)
+        spec_block_size = getattr(spec, "block_size", None)
+        if isinstance(spec_block_size, int) and spec_block_size > 0:
+            return spec_block_size
+
+        return 1
+
+    def _get_attention_backend(self) -> object | None:
+        getter = getattr(self.engine, "get_attention_backend", None)
+        if callable(getter):
+            backend = getter()
+            if backend is not None:
+                return backend
+
+        for attr_name in (
+            "attention_backend",
+            "_attention_backend",
+            "_native_attention_backend",
+        ):
+            backend = getattr(self.engine, attr_name, None)
+            if backend is not None:
+                return backend
+        return None
+
+    def _get_paged_attention_classes(self) -> list[type[Any]]:
+        paged_class_names = {
+            "DeepseekV2PagedAttention",
+            "DeepseekV3PagedAttention",
+        }
+        classes: list[type[Any]] = []
+        seen: set[type[Any]] = set()
+
+        modules_fn = getattr(self.model, "modules", None)
+        if not callable(modules_fn):
+            return classes
+
+        modules = modules_fn()
+        if not isinstance(modules, Iterable):
+            return classes
+
+        for module in modules:
+            cls = module.__class__
+            if cls in seen:
+                continue
+            if cls.__name__ not in paged_class_names:
+                continue
+            if not hasattr(cls, "set_paged_context") or not hasattr(
+                cls, "clear_paged_context"
+            ):
+                continue
+            seen.add(cls)
+            classes.append(cls)
+
+        return classes
 
     def _resolve_vocab_size(self) -> int:
         config = getattr(self.model, "config", None)

--- a/setup.py
+++ b/setup.py
@@ -263,6 +263,9 @@ setup(
     packages=find_packages(exclude=["extensions", "extensions.*"]),
     include_package_data=True,
     install_requires=install_requires,
+    extras_require={
+        "flashinfer": ["flashinfer"],
+    },
     author="EfficientMoE Team",
     long_description=read_readme(),
     long_description_content_type="text/markdown",

--- a/tests/python/integration/test_deepseek_v2_paged.py
+++ b/tests/python/integration/test_deepseek_v2_paged.py
@@ -1,3 +1,4 @@
+import importlib.machinery
 import importlib.util
 import sys
 import types
@@ -7,6 +8,18 @@ from types import ModuleType, SimpleNamespace
 import torch
 
 from moe_infinity.runtime.attention_types import KVCacheSpec
+
+if (
+    "flash_attn" not in sys.modules
+    or getattr(sys.modules["flash_attn"], "__spec__", None) is None
+):
+    flash_attn_stub = sys.modules.get(
+        "flash_attn", types.ModuleType("flash_attn")
+    )
+    flash_attn_stub.__spec__ = importlib.machinery.ModuleSpec(
+        name="flash_attn", loader=None
+    )
+    sys.modules["flash_attn"] = flash_attn_stub
 
 
 def _load_deepseek_v2_modeling_module() -> ModuleType:

--- a/tests/python/integration/test_flashinfer_e2e.py
+++ b/tests/python/integration/test_flashinfer_e2e.py
@@ -1,0 +1,449 @@
+# pyright: reportAny=false, reportExplicitAny=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportGeneralTypeIssues=false, reportUnannotatedClassAttribute=false, reportPrivateUsage=false, reportImplicitOverride=false, reportUnusedCallResult=false, reportUnusedFunction=false, reportUnknownArgumentType=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+import types
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from moe_infinity.runtime.attention_backend import PagedAttentionBackend
+from moe_infinity.runtime.attention_types import KVCacheSpec
+from moe_infinity.runtime.flashinfer_utils import HAS_FLASHINFER
+from moe_infinity.serving.batch import BatchMetadata, split_prefill_decode_batch
+from moe_infinity.serving.engine import ContinuousBatchingEngine
+from moe_infinity.serving.model_runner import ModelRunner
+from moe_infinity.serving.sequence import SamplingParams
+
+
+class _MockExpertTracer:
+    def __init__(self) -> None:
+        self._next = 0
+
+    def create_entry(self) -> int:
+        entry = self._next
+        self._next += 1
+        return entry
+
+
+class _MockOffloadEngine:
+    def __init__(self, attention_backend: object | None) -> None:
+        self.request_id = 0
+        self.expert_tracer = _MockExpertTracer()
+        self.expert_layer_modules = [types.SimpleNamespace(seq_id_list=[])]
+        self._attention_backend = attention_backend
+
+    def _generate_request_id(self) -> int:
+        rid = self.request_id
+        self.request_id += 1
+        return rid
+
+    def get_attention_backend(self) -> object | None:
+        return self._attention_backend
+
+
+@dataclass
+class _ForwardEvent:
+    had_context: bool
+    is_prefill: bool
+
+
+class DeepseekV3PagedAttention(torch.nn.Module):
+    _backend: object | None = None
+    _metadata: object | None = None
+    lifecycle_events: list[str] = []
+    forward_events: list[_ForwardEvent] = []
+
+    def __init__(
+        self, num_heads: int = 2, num_kv_heads: int = 2, head_dim: int = 8
+    ) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = head_dim
+
+    @classmethod
+    def set_paged_context(cls, backend: object, metadata: object) -> None:
+        cls._backend = backend
+        cls._metadata = metadata
+        cls.lifecycle_events.append("set")
+
+    @classmethod
+    def clear_paged_context(cls) -> None:
+        cls.lifecycle_events.append("clear")
+        cls._backend = None
+        cls._metadata = None
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        scale: float | None = None,
+    ) -> torch.Tensor:
+        metadata = type(self)._metadata
+        backend = type(self)._backend
+        is_prefill = bool(getattr(metadata, "is_prefill", False))
+        type(self).forward_events.append(
+            _ForwardEvent(
+                had_context=backend is not None and metadata is not None,
+                is_prefill=is_prefill,
+            )
+        )
+        if backend is None or metadata is None:
+            return torch.zeros_like(query)
+
+        backend_forward = getattr(backend, "forward")
+        return backend_forward(
+            query=query,
+            key=key,
+            value=value,
+            attention_metadata=metadata,
+            scale=scale,
+        )
+
+
+class _MockPagedModel(torch.nn.Module):
+    def __init__(self, vocab_size: int, device: torch.device) -> None:
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.config = types.SimpleNamespace(
+            vocab_size=vocab_size, eos_token_id=-1
+        )
+        self.device = device
+        self.attn = DeepseekV3PagedAttention()
+
+    def eval(self) -> "_MockPagedModel":
+        return self
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        use_cache: bool = True,
+        past_key_values: object = None,
+    ) -> object:
+        _ = (position_ids, use_cache, past_key_values)
+
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
+
+        token_mask = attention_mask.to(dtype=torch.bool)
+        packed_tokens = input_ids[token_mask]
+        num_tokens = int(packed_tokens.numel())
+
+        query = torch.zeros(
+            (num_tokens, self.attn.num_heads, self.attn.head_dim),
+            dtype=torch.float32,
+            device=input_ids.device,
+        )
+        if num_tokens > 0:
+            query = query + packed_tokens.to(dtype=torch.float32).view(-1, 1, 1)
+
+        key = query[:, : self.attn.num_kv_heads, :].clone()
+        value = key + 0.5
+        attn_out = self.attn(query=query, key=key, value=value, scale=1.0)
+
+        batch_size, seq_len = input_ids.shape
+        logits = torch.full(
+            (batch_size, seq_len, self.vocab_size),
+            fill_value=-1e9,
+            dtype=torch.float32,
+            device=input_ids.device,
+        )
+        next_ids = ((input_ids + 1) % self.vocab_size).to(dtype=torch.long)
+        peak_logit = (
+            float(attn_out.mean().item()) if attn_out.numel() > 0 else 0.0
+        )
+        logits.scatter_(2, next_ids.unsqueeze(-1), peak_logit)
+        return types.SimpleNamespace(logits=logits)
+
+
+class _FakeFlashInferRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def run(self, query: torch.Tensor, kv_cache: torch.Tensor) -> torch.Tensor:
+        _ = kv_cache
+        self.calls += 1
+        return torch.zeros_like(query)
+
+
+def _make_backend(
+    device: torch.device, dtype: torch.dtype
+) -> PagedAttentionBackend:
+    spec = KVCacheSpec(
+        num_kv_heads=2,
+        head_dim=8,
+        dtype=dtype,
+        block_size=8,
+    )
+    return PagedAttentionBackend(spec=spec, num_gpu_blocks=16, device=device)
+
+
+def _make_engine_config(dtype: str) -> dict[str, object]:
+    return {
+        "device_memory_ratio": 0.5,
+        "kv_cache_ratio": 0.5,
+        "max_batch_size": 8,
+        "max_tokens_per_step": 16,
+        "block_size": 8,
+        "num_layers": 1,
+        "num_kv_heads": 2,
+        "head_dim": 8,
+        "dtype": dtype,
+        "eos_token_id": -1,
+        "num_kv_blocks": 16,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock_paged_attention() -> None:
+    DeepseekV3PagedAttention._backend = None
+    DeepseekV3PagedAttention._metadata = None
+    DeepseekV3PagedAttention.lifecycle_events = []
+    DeepseekV3PagedAttention.forward_events = []
+
+
+@pytest.mark.skipif(
+    not (HAS_FLASHINFER and torch.cuda.is_available()),
+    reason="requires FlashInfer and CUDA",
+)
+def test_e2e_flashinfer_prefill_decode_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = torch.device("cuda")
+    backend = _make_backend(device=device, dtype=torch.float16)
+    if backend._fi_kv_cache is None:
+        pytest.skip("FlashInfer backend did not initialize KV cache")
+
+    fake_prefill = _FakeFlashInferRunner()
+    fake_decode = _FakeFlashInferRunner()
+    backend._fi_prefill = fake_prefill
+    backend._fi_decode = fake_decode
+    backend._use_flashinfer = True
+
+    plan_calls: list[str] = []
+    monkeypatch.setattr(
+        backend,
+        "_call_prefill_plan",
+        lambda *args, **kwargs: plan_calls.append("prefill"),
+    )
+    monkeypatch.setattr(
+        backend,
+        "_call_decode_plan",
+        lambda *args, **kwargs: plan_calls.append("decode"),
+    )
+
+    engine = ContinuousBatchingEngine(
+        model=_MockPagedModel(vocab_size=97, device=device),
+        engine=_MockOffloadEngine(attention_backend=backend),
+        config=_make_engine_config(dtype="float16"),
+        tokenizer=None,
+    )
+
+    engine.add_request(
+        request_id="flashinfer-req",
+        prompt_token_ids=[10, 11],
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=3),
+    )
+
+    first = engine.step()
+    second = engine.step()
+    third = engine.step()
+    all_outputs = [*first, *second, *third]
+
+    assert len(all_outputs) == 3
+    assert [output.token_id for output in all_outputs] == [12, 13, 14]
+    assert all(0 <= output.token_id < 97 for output in all_outputs)
+    assert all(isinstance(output.token_id, int) for output in all_outputs)
+    assert all_outputs[-1].finished is True
+    assert not engine.has_pending_requests()
+
+    assert "prefill" in plan_calls
+    assert "decode" in plan_calls
+    assert fake_prefill.calls >= 1
+    assert fake_decode.calls >= 1
+
+
+def test_e2e_serving_engine_without_flashinfer() -> None:
+    device = torch.device("cpu")
+    backend = _make_backend(device=device, dtype=torch.float32)
+    backend._use_flashinfer = False
+    backend._fi_prefill = None
+    backend._fi_decode = None
+    backend._fi_kv_cache = None
+
+    engine = ContinuousBatchingEngine(
+        model=_MockPagedModel(vocab_size=64, device=device),
+        engine=_MockOffloadEngine(attention_backend=backend),
+        config=_make_engine_config(dtype="float32"),
+        tokenizer=None,
+    )
+
+    engine.add_request(
+        request_id="sdpa-req",
+        prompt_token_ids=[5, 6],
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=4),
+    )
+
+    outputs = engine.run_until_done()
+
+    assert outputs["sdpa-req"] == [7, 8, 9, 10]
+    assert backend._flashinfer_enabled() is False
+    assert DeepseekV3PagedAttention.forward_events
+    assert any(
+        event.is_prefill for event in DeepseekV3PagedAttention.forward_events
+    )
+    assert any(
+        not event.is_prefill
+        for event in DeepseekV3PagedAttention.forward_events
+    )
+
+
+def test_e2e_batch_splitting_with_mixed_sequences() -> None:
+    batch = BatchMetadata(
+        seq_ids=[101, 102, 103],
+        input_token_ids=[11, 12, 21, 31, 32, 33],
+        seq_lengths=[2, 1, 3],
+        context_lengths=[0, 4, 1],
+        is_prefill=[True, False, True],
+        block_tables=[[0], [4, 5], [2]],
+        token_offsets=[0, 2, 3, 6],
+        sampling_params=[SamplingParams(), SamplingParams(), SamplingParams()],
+    )
+
+    split = split_prefill_decode_batch(batch)
+    assert split.prefill_indices == [0, 2]
+    assert split.decode_indices == [1]
+    assert split.prefill_batch is not None
+    assert split.decode_batch is not None
+
+    assert split.prefill_batch.input_token_ids == [11, 12, 31, 32, 33]
+    assert split.prefill_batch.token_offsets == [0, 2, 5]
+    assert split.decode_batch.input_token_ids == [21]
+    assert split.decode_batch.token_offsets == [0, 1]
+
+    prefill_out = torch.tensor(
+        [[100], [101], [102], [103], [104]],
+        dtype=torch.float32,
+    )
+    decode_out = torch.tensor([[200]], dtype=torch.float32)
+
+    recombined = split.recombine_outputs(
+        prefill_outputs=prefill_out,
+        decode_outputs=decode_out,
+    )
+
+    expected = torch.tensor(
+        [[100], [101], [200], [102], [103], [104]],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(recombined, expected)
+
+
+def test_e2e_paged_context_lifecycle_with_mock_model() -> None:
+    events: list[str] = []
+
+    class DeepseekV2PagedAttention(torch.nn.Module):
+        _backend: object | None = None
+        _metadata: object | None = None
+
+        @classmethod
+        def set_paged_context(cls, backend: object, metadata: object) -> None:
+            cls._backend = backend
+            cls._metadata = metadata
+            events.append("set")
+
+        @classmethod
+        def clear_paged_context(cls) -> None:
+            events.append("clear")
+            cls._backend = None
+            cls._metadata = None
+
+        def forward(
+            self,
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+        ) -> torch.Tensor:
+            backend_forward = getattr(type(self)._backend, "forward")
+            return backend_forward(
+                query=query,
+                key=key,
+                value=value,
+                attention_metadata=type(self)._metadata,
+            )
+
+    class _LifecycleBackend:
+        def __init__(self) -> None:
+            self.spec = types.SimpleNamespace(block_size=4)
+
+        def forward(
+            self,
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+            attention_metadata: object,
+            scale: float | None = None,
+        ) -> torch.Tensor:
+            _ = (key, value, attention_metadata, scale)
+            return torch.zeros_like(query)
+
+    class _LifecycleModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = types.SimpleNamespace(vocab_size=32)
+            self.attn = DeepseekV2PagedAttention()
+
+        def eval(self) -> "_LifecycleModel":
+            return self
+
+        def forward(
+            self,
+            input_ids: torch.Tensor,
+            position_ids: torch.Tensor | None = None,
+            attention_mask: torch.Tensor | None = None,
+            use_cache: bool = True,
+            past_key_values: object = None,
+        ) -> object:
+            _ = (position_ids, use_cache, past_key_values)
+            events.append("forward")
+
+            if attention_mask is None:
+                attention_mask = torch.ones_like(input_ids)
+
+            packed = input_ids[attention_mask.to(dtype=torch.bool)]
+            num_tokens = int(packed.numel())
+            q = torch.zeros((num_tokens, 2, 8), dtype=torch.float32)
+            k = torch.zeros((num_tokens, 2, 8), dtype=torch.float32)
+            v = torch.zeros((num_tokens, 2, 8), dtype=torch.float32)
+            _ = self.attn(q, k, v)
+
+            batch_size, seq_len = input_ids.shape
+            logits = torch.full((batch_size, seq_len, 32), -1e9)
+            next_ids = ((input_ids + 1) % 32).to(dtype=torch.long)
+            logits.scatter_(2, next_ids.unsqueeze(-1), 0.0)
+            return types.SimpleNamespace(logits=logits)
+
+    model = _LifecycleModel()
+    backend = _LifecycleBackend()
+    runner = ModelRunner(model=model, engine=_MockOffloadEngine(backend))
+
+    batch = BatchMetadata(
+        seq_ids=[1],
+        input_token_ids=[9, 10],
+        seq_lengths=[2],
+        context_lengths=[0],
+        is_prefill=[True],
+        block_tables=[[0]],
+        token_offsets=[0, 2],
+        sampling_params=[SamplingParams(temperature=0.0)],
+    )
+
+    logits = runner.execute(batch)
+
+    assert logits.shape == (2, 32)
+    assert events == ["set", "forward", "clear"]

--- a/tests/python/integration/test_flashinfer_model_attention.py
+++ b/tests/python/integration/test_flashinfer_model_attention.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = Path(__file__).resolve().parents[3]
+
+if (
+    "flash_attn" not in sys.modules
+    or getattr(sys.modules["flash_attn"], "__spec__", None) is None
+):
+    flash_attn_stub = sys.modules.get(
+        "flash_attn", types.ModuleType("flash_attn")
+    )
+    flash_attn_stub.__spec__ = importlib.machinery.ModuleSpec(
+        name="flash_attn", loader=None
+    )
+    sys.modules["flash_attn"] = flash_attn_stub
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(module_name: str, file_path: Path):
+    existing = sys.modules.get(module_name)
+    if existing is not None:
+        return existing
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("moe_infinity", ROOT / "moe_infinity")
+_ensure_package("moe_infinity.models", ROOT / "moe_infinity" / "models")
+_ensure_package(
+    "moe_infinity.models.modeling_deepseek_v2",
+    ROOT / "moe_infinity" / "models" / "modeling_deepseek_v2",
+)
+_ensure_package(
+    "moe_infinity.models.modeling_deepseek_v3",
+    ROOT / "moe_infinity" / "models" / "modeling_deepseek_v3",
+)
+
+v2_config_module = _load_module(
+    "moe_infinity.models.modeling_deepseek_v2.configuration_deepseek",
+    ROOT
+    / "moe_infinity"
+    / "models"
+    / "modeling_deepseek_v2"
+    / "configuration_deepseek.py",
+)
+v2_modeling = _load_module(
+    "moe_infinity.models.modeling_deepseek_v2.modeling_deepseek",
+    ROOT
+    / "moe_infinity"
+    / "models"
+    / "modeling_deepseek_v2"
+    / "modeling_deepseek.py",
+)
+v3_config_module = _load_module(
+    "moe_infinity.models.modeling_deepseek_v3.configuration_deepseek",
+    ROOT
+    / "moe_infinity"
+    / "models"
+    / "modeling_deepseek_v3"
+    / "configuration_deepseek.py",
+)
+v3_modeling = _load_module(
+    "moe_infinity.models.modeling_deepseek_v3.modeling_deepseek",
+    ROOT
+    / "moe_infinity"
+    / "models"
+    / "modeling_deepseek_v3"
+    / "modeling_deepseek.py",
+)
+
+DeepseekV2Config = v2_config_module.DeepseekV2Config
+DeepseekV3Config = v3_config_module.DeepseekV3Config
+
+
+@dataclass
+class _BackendCall:
+    query: torch.Tensor
+    key: torch.Tensor
+    value: torch.Tensor
+    attention_metadata: object
+    scale: float | None
+
+
+class _RecordingBackend:
+    def __init__(self, fill_value: float = 0.5) -> None:
+        self.fill_value = fill_value
+        self.calls: list[_BackendCall] = []
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: object = None,
+        attn_metadata: object = None,
+        attention_metadata: object = None,
+        scale: float | None = None,
+    ) -> torch.Tensor:
+        _ = (kv_cache, attn_metadata)
+        self.calls.append(
+            _BackendCall(
+                query=query,
+                key=key,
+                value=value,
+                attention_metadata=attention_metadata,
+                scale=scale,
+            )
+        )
+        return torch.full(
+            (query.shape[0], query.shape[1], value.shape[2]),
+            fill_value=self.fill_value,
+            dtype=query.dtype,
+            device=query.device,
+        )
+
+
+def _make_v2_attention():
+    config = DeepseekV2Config(
+        hidden_size=16,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+        q_lora_rank=None,
+        kv_lora_rank=4,
+        qk_rope_head_dim=4,
+        qk_nope_head_dim=4,
+        v_head_dim=4,
+        attention_dropout=0.0,
+    )
+    return v2_modeling.DeepseekV2PagedAttention(config, layer_idx=0).eval()
+
+
+def _make_v3_attention():
+    config = DeepseekV3Config(
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=8,
+        num_hidden_layers=2,
+        num_nextn_predict_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=32,
+        q_lora_rank=None,
+        kv_lora_rank=4,
+        qk_rope_head_dim=4,
+        qk_nope_head_dim=4,
+        v_head_dim=4,
+        n_shared_experts=None,
+        n_routed_experts=None,
+        num_experts_per_tok=None,
+        n_group=None,
+        topk_group=None,
+        attention_dropout=0.0,
+    )
+    return v3_modeling.DeepseekV3PagedAttention(config, layer_idx=0).eval()
+
+
+@pytest.fixture(autouse=True)
+def _clear_paged_context():
+    v2_modeling.DeepseekV2PagedAttention.clear_paged_context()
+    v3_modeling.DeepseekV3PagedAttention.clear_paged_context()
+    yield
+    v2_modeling.DeepseekV2PagedAttention.clear_paged_context()
+    v3_modeling.DeepseekV3PagedAttention.clear_paged_context()
+
+
+def test_deepseek_v3_paged_attention_uses_backend() -> None:
+    attn = _make_v3_attention()
+    backend = _RecordingBackend(fill_value=0.25)
+    metadata = object()
+    v3_modeling.DeepseekV3PagedAttention.set_paged_context(backend, metadata)
+
+    hidden_states = torch.randn(1, 3, attn.hidden_size)
+    attention_mask = torch.zeros(1, 1, 3, 3)
+    position_ids = torch.arange(3, dtype=torch.long).unsqueeze(0)
+
+    outputs, attn_weights, past_key_value = attn(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        use_cache=False,
+    )
+
+    assert outputs.shape == hidden_states.shape
+    assert attn_weights is None
+    assert past_key_value is None
+    assert len(backend.calls) == 1
+    call = backend.calls[0]
+    assert call.attention_metadata is metadata
+    assert call.query.shape == (3, attn.num_heads, attn.q_head_dim)
+    assert call.key.shape == (3, attn.num_heads, attn.q_head_dim)
+    assert call.value.shape == (3, attn.num_heads, attn.v_head_dim)
+    assert call.scale == pytest.approx(attn.softmax_scale)
+
+
+def test_deepseek_v3_paged_attention_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = (
+        torch.randn(1, 1, 1),
+        torch.randn(1, 1, 1, 1),
+        object(),
+    )
+
+    def _fake_super_forward(*args, **kwargs):
+        _ = (args, kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        v3_modeling.DeepseekV3Attention, "forward", _fake_super_forward
+    )
+    v3_modeling.DeepseekV3PagedAttention.clear_paged_context()
+
+    attn = v3_modeling.DeepseekV3PagedAttention.__new__(
+        v3_modeling.DeepseekV3PagedAttention
+    )
+    torch.nn.Module.__init__(attn)
+
+    outputs = attn.forward(hidden_states=torch.zeros(1, 1, 1))
+    assert outputs is sentinel
+
+
+def test_deepseek_v2_paged_attention_uses_backend() -> None:
+    attn = _make_v2_attention()
+    backend = _RecordingBackend(fill_value=1.5)
+    metadata = object()
+    v2_modeling.DeepseekV2PagedAttention.set_paged_context(backend, metadata)
+
+    hidden_states = torch.randn(1, 3, attn.hidden_size)
+    attention_mask = torch.zeros(1, 1, 3, 3)
+    position_ids = torch.arange(3, dtype=torch.long).unsqueeze(0)
+
+    outputs, attn_weights, past_key_value = attn(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        use_cache=False,
+    )
+
+    assert outputs.shape == hidden_states.shape
+    assert attn_weights is None
+    assert past_key_value is None
+    assert len(backend.calls) == 1
+    call = backend.calls[0]
+    assert call.attention_metadata is metadata
+    assert call.query.shape == (3, attn.num_heads, attn.q_head_dim)
+    assert call.key.shape == (3, attn.num_heads, attn.q_head_dim)
+    assert call.value.shape == (3, attn.num_heads, attn.v_head_dim)
+    assert call.scale == pytest.approx(attn.softmax_scale)
+
+
+def test_deepseek_v2_paged_attention_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = (
+        torch.randn(1, 1, 1),
+        torch.randn(1, 1, 1, 1),
+        object(),
+    )
+
+    def _fake_super_forward(*args, **kwargs):
+        _ = (args, kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        v2_modeling.DeepseekV2Attention, "forward", _fake_super_forward
+    )
+    v2_modeling.DeepseekV2PagedAttention.clear_paged_context()
+
+    attn = v2_modeling.DeepseekV2PagedAttention.__new__(
+        v2_modeling.DeepseekV2PagedAttention
+    )
+    torch.nn.Module.__init__(attn)
+
+    outputs = attn.forward(hidden_states=torch.zeros(1, 1, 1))
+    assert outputs is sentinel

--- a/tests/python/integration/test_flashinfer_offload_wiring.py
+++ b/tests/python/integration/test_flashinfer_offload_wiring.py
@@ -1,0 +1,143 @@
+# pyright: reportAny=false, reportExplicitAny=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportGeneralTypeIssues=false, reportUnannotatedClassAttribute=false, reportPrivateUsage=false, reportImplicitOverride=false
+
+from __future__ import annotations
+
+import types
+from typing import Any
+
+import pytest
+import torch
+
+from moe_infinity.engine.generation_loop import GenerationEngine
+from moe_infinity.memory.kv_cache_manager import KVCacheManager
+from moe_infinity.runtime.attention_types import AttentionMetadata, KVCacheSpec
+
+
+def _build_moe_with_model(model: torch.nn.Module) -> Any:
+    from moe_infinity.entrypoints.big_modeling import MoE
+
+    moe = MoE.__new__(MoE)
+    moe.model = model
+    moe._native_attention_backend = object()
+    return moe
+
+
+def test_native_model_forward_uses_attention_metadata() -> None:
+    events: list[tuple[object, ...]] = []
+
+    class DeepseekV3PagedAttention(torch.nn.Module):
+        @classmethod
+        def set_paged_context(cls, backend: object, metadata: object) -> None:
+            events.append(("set", backend, metadata))
+
+        @classmethod
+        def clear_paged_context(cls) -> None:
+            events.append(("clear",))
+
+        def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            return hidden_states
+
+    class MockModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attn = DeepseekV3PagedAttention()
+
+        def forward(self, input_ids: torch.Tensor) -> object:
+            events.append(("model",))
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, 32, dtype=torch.float32)
+            return types.SimpleNamespace(logits=logits)
+
+    moe = _build_moe_with_model(MockModel())
+    metadata = object()
+    logits = moe._native_model_forward([1, 2, 3], metadata)
+
+    assert logits.shape == (3, 32)
+    assert events[0][0] == "set"
+    assert events[0][1] is moe._native_attention_backend
+    assert events[0][2] is metadata
+    assert events[1] == ("model",)
+    assert events[2] == ("clear",)
+
+
+def test_native_model_forward_ignores_metadata_for_non_paged_models() -> None:
+    class MockModel(torch.nn.Module):
+        def forward(self, input_ids: torch.Tensor) -> object:
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, 8, dtype=torch.float32)
+            return types.SimpleNamespace(logits=logits)
+
+    moe = _build_moe_with_model(MockModel())
+    logits = moe._native_model_forward([9, 10], object())
+    assert logits.shape == (2, 8)
+
+
+def test_native_model_forward_clears_context_on_exception() -> None:
+    events: list[tuple[str]] = []
+
+    class DeepseekV2PagedAttention(torch.nn.Module):
+        @classmethod
+        def set_paged_context(cls, backend: object, metadata: object) -> None:
+            _ = (backend, metadata)
+            events.append(("set",))
+
+        @classmethod
+        def clear_paged_context(cls) -> None:
+            events.append(("clear",))
+
+        def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+            return hidden_states
+
+    class FailingModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attn = DeepseekV2PagedAttention()
+
+        def forward(self, input_ids: torch.Tensor) -> object:
+            _ = input_ids
+            raise RuntimeError("boom")
+
+    moe = _build_moe_with_model(FailingModel())
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _ = moe._native_model_forward([1], object())
+
+    assert events == [("set",), ("clear",)]
+
+
+def test_generation_loop_passes_metadata_to_forward() -> None:
+    observed: list[AttentionMetadata] = []
+
+    def mock_forward(
+        token_ids: list[int],
+        metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        observed.append(metadata)
+        logits = torch.full((len(token_ids), 64), -1e9, dtype=torch.float32)
+        logits[:, 5] = 0.0
+        return logits
+
+    spec = KVCacheSpec(
+        num_kv_heads=2,
+        head_dim=8,
+        dtype=torch.float32,
+        block_size=4,
+    )
+    mgr = KVCacheManager(num_gpu_blocks=16, num_cpu_blocks=32, block_size=4)
+    engine = GenerationEngine(
+        kv_cache_manager=mgr,
+        kv_spec=spec,
+        num_layers=2,
+        vocab_size=64,
+        model_forward_fn=mock_forward,
+        eos_token_id=2,
+    )
+
+    _ = engine.generate(prompt_token_ids=[1, 3], request_id="rid")
+
+    assert len(observed) >= 2
+    assert observed[0].is_prefill is True
+    assert observed[0].num_prefill_tokens == 2
+    assert observed[0].num_decode_tokens == 0
+    assert all(meta.num_decode_tokens == 1 for meta in observed[1:])
+    assert all(meta.is_prefill is False for meta in observed[1:])

--- a/tests/python/serving/test_flashinfer_kv_cache.py
+++ b/tests/python/serving/test_flashinfer_kv_cache.py
@@ -1,0 +1,187 @@
+# pyright: reportAny=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnannotatedClassAttribute=false, reportImplicitOverride=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+ROOT = str(Path(__file__).resolve().parents[3])
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+KV_CACHE_PATH = Path(ROOT) / "moe_infinity" / "serving" / "kv_cache.py"
+
+
+class _FakePrefillWrapper:
+    def __init__(self, workspace: torch.Tensor, layout: str) -> None:
+        self.workspace = workspace
+        self.layout = layout
+        self.plan_args = None
+        self.run_args = None
+
+    def plan(self, *args, **kwargs) -> None:
+        self.plan_args = (args, kwargs)
+
+    def run(self, query: torch.Tensor, kv_cache: torch.Tensor) -> torch.Tensor:
+        self.run_args = (query, kv_cache)
+        return torch.full_like(query, 7.0)
+
+
+class _FakeDecodeWrapper:
+    def __init__(self, workspace: torch.Tensor, layout: str) -> None:
+        self.workspace = workspace
+        self.layout = layout
+        self.plan_args = None
+        self.run_args = None
+
+    def plan(self, *args, **kwargs) -> None:
+        self.plan_args = (args, kwargs)
+
+    def run(self, query: torch.Tensor, kv_cache: torch.Tensor) -> torch.Tensor:
+        self.run_args = (query, kv_cache)
+        return torch.full_like(query, 11.0)
+
+
+def _load_module(module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, KV_CACHE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_compute_attention_uses_flashinfer_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kv_cache_module = _load_module("test_flashinfer_serving_kv_cache_uses_fi")
+    fake_module = type(
+        "_FakeFlashInferModule",
+        (),
+        {
+            "BatchPrefillWithPagedKVCacheWrapper": _FakePrefillWrapper,
+            "BatchDecodeWithPagedKVCacheWrapper": _FakeDecodeWrapper,
+        },
+    )
+
+    monkeypatch.setattr(
+        kv_cache_module.flashinfer_utils, "HAS_FLASHINFER", True
+    )
+    monkeypatch.setattr(
+        kv_cache_module.flashinfer_utils,
+        "get_flashinfer_module",
+        lambda: fake_module,
+    )
+
+    def _fake_workspace(device: torch.device) -> torch.Tensor:
+        return torch.empty(1024, dtype=torch.uint8, device=device)
+
+    monkeypatch.setattr(
+        kv_cache_module.flashinfer_utils,
+        "get_workspace",
+        _fake_workspace,
+    )
+
+    cache = kv_cache_module.PagedKVCache(
+        num_blocks=4,
+        block_size=4,
+        num_layers=2,
+        num_heads=2,
+        head_dim=8,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+
+    prefill_out = cache._compute_attention(
+        query=torch.randn(1, 2, 3, 8),
+        key=torch.randn(1, 2, 3, 8),
+        value=torch.randn(1, 2, 3, 8),
+        is_causal=True,
+        layer_idx=1,
+    )
+    decode_out = cache._compute_attention(
+        query=torch.randn(1, 2, 1, 8),
+        key=torch.randn(1, 2, 4, 8),
+        value=torch.randn(1, 2, 4, 8),
+        is_causal=True,
+        layer_idx=1,
+    )
+
+    assert torch.all(prefill_out == 7.0)
+    assert torch.all(decode_out == 11.0)
+    assert cache._fi_prefill is not None
+    assert cache._fi_decode is not None
+
+    prefill_plan_args = cache._fi_prefill.plan_args[0]
+    assert prefill_plan_args[0].dtype == torch.int32
+    assert prefill_plan_args[1].dtype == torch.int32
+    assert prefill_plan_args[2].dtype == torch.int32
+    assert prefill_plan_args[3].dtype == torch.int32
+
+    decode_plan_args = cache._fi_decode.plan_args[0]
+    assert decode_plan_args[0].dtype == torch.int32
+    assert decode_plan_args[1].dtype == torch.int32
+    assert decode_plan_args[2].dtype == torch.int32
+
+    assert cache._fi_prefill.run_args is not None
+    assert cache._fi_decode.run_args is not None
+    assert cache._fi_prefill.run_args[1].shape == cache._kv_cache[1].shape
+    assert cache._fi_decode.run_args[1].shape == cache._kv_cache[1].shape
+    torch.testing.assert_close(
+        cache._fi_prefill.run_args[1], cache._kv_cache[1]
+    )
+    torch.testing.assert_close(cache._fi_decode.run_args[1], cache._kv_cache[1])
+
+
+def test_compute_attention_falls_back_without_flashinfer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    kv_cache_module = _load_module("test_flashinfer_serving_kv_cache_fallback")
+    monkeypatch.setattr(
+        kv_cache_module.flashinfer_utils,
+        "HAS_FLASHINFER",
+        False,
+    )
+
+    cache = kv_cache_module.PagedKVCache(
+        num_blocks=4,
+        block_size=4,
+        num_layers=1,
+        num_heads=2,
+        head_dim=8,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+
+    query = torch.randn(1, 2, 3, 8)
+    key = torch.randn(1, 2, 3, 8)
+    value = torch.randn(1, 2, 3, 8)
+
+    output = cache._compute_attention(query=query, key=key, value=value)
+    expected = torch.nn.functional.scaled_dot_product_attention(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=True,
+    )
+    torch.testing.assert_close(output, expected)
+
+
+def test_kv_cache_tensor_layout_compatible_with_flashinfer() -> None:
+    kv_cache_module = _load_module("test_flashinfer_serving_kv_cache_layout")
+    cache = kv_cache_module.PagedKVCache(
+        num_blocks=8,
+        block_size=16,
+        num_layers=3,
+        num_heads=4,
+        head_dim=32,
+        dtype=torch.float16,
+        device=torch.device("cpu"),
+    )
+
+    assert cache._kv_cache.shape == (3, 8, 2, 16, 4, 32)
+    assert cache._kv_cache[0].shape == (8, 2, 16, 4, 32)

--- a/tests/python/serving/test_flashinfer_mixed_batch.py
+++ b/tests/python/serving/test_flashinfer_mixed_batch.py
@@ -1,0 +1,185 @@
+# pyright: reportAny=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnannotatedClassAttribute=false, reportImplicitOverride=false, reportMissingParameterType=false, reportUnknownParameterType=false
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+from moe_infinity.runtime.flashinfer_utils import HAS_FLASHINFER
+
+ROOT = Path(__file__).resolve().parents[3]
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("moe_infinity", ROOT / "moe_infinity")
+_ensure_package("moe_infinity.serving", ROOT / "moe_infinity" / "serving")
+
+_SEQUENCE_MODULE = _load_module(
+    "moe_infinity.serving.sequence",
+    ROOT / "moe_infinity" / "serving" / "sequence.py",
+)
+_BATCH_MODULE = _load_module(
+    "moe_infinity.serving.batch",
+    ROOT / "moe_infinity" / "serving" / "batch.py",
+)
+
+SamplingParams = _SEQUENCE_MODULE.SamplingParams
+BatchMetadata = _BATCH_MODULE.BatchMetadata
+split_prefill_decode_batch = _BATCH_MODULE.split_prefill_decode_batch
+
+
+def _make_batch(is_prefill: list[bool]) -> BatchMetadata:
+    seq_ids = [10 + idx for idx in range(len(is_prefill))]
+    seq_lengths = [idx + 1 for idx in range(len(is_prefill))]
+    context_lengths = [idx * 3 for idx in range(len(is_prefill))]
+    block_tables = [[idx] for idx in range(len(is_prefill))]
+    sampling_params = [SamplingParams() for _ in is_prefill]
+
+    input_token_ids: list[int] = []
+    token_offsets = [0]
+    next_token = 100
+    for seq_len in seq_lengths:
+        input_token_ids.extend(list(range(next_token, next_token + seq_len)))
+        next_token += seq_len
+        token_offsets.append(len(input_token_ids))
+
+    return BatchMetadata(
+        seq_ids=seq_ids,
+        input_token_ids=input_token_ids,
+        seq_lengths=seq_lengths,
+        context_lengths=context_lengths,
+        is_prefill=is_prefill,
+        block_tables=block_tables,
+        token_offsets=token_offsets,
+        sampling_params=sampling_params,
+    )
+
+
+def test_split_prefill_decode_partitions_correctly() -> None:
+    batch = _make_batch([True, False, True, False, False])
+
+    split = split_prefill_decode_batch(batch)
+
+    assert split.prefill_indices == [0, 2]
+    assert split.decode_indices == [1, 3, 4]
+    assert split.prefill_batch is not None
+    assert split.decode_batch is not None
+    assert split.prefill_batch.seq_ids == [10, 12]
+    assert split.prefill_batch.seq_lengths == [1, 3]
+    assert split.prefill_batch.input_token_ids == [100, 103, 104, 105]
+    assert split.prefill_batch.token_offsets == [0, 1, 4]
+    assert split.decode_batch.seq_ids == [11, 13, 14]
+    assert split.decode_batch.seq_lengths == [2, 4, 5]
+    assert split.decode_batch.input_token_ids == [
+        101,
+        102,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+    ]
+    assert split.decode_batch.token_offsets == [0, 2, 6, 11]
+
+
+def test_split_all_prefill_returns_single_batch() -> None:
+    batch = _make_batch([True, True, True])
+
+    split = split_prefill_decode_batch(batch)
+
+    assert split.prefill_indices == [0, 1, 2]
+    assert split.decode_indices == []
+    assert split.prefill_batch is not None
+    assert split.decode_batch is None
+    assert split.prefill_batch.seq_ids == batch.seq_ids
+    assert split.prefill_batch.input_token_ids == batch.input_token_ids
+    assert split.prefill_batch.token_offsets == batch.token_offsets
+
+
+def test_split_all_decode_returns_single_batch() -> None:
+    batch = _make_batch([False, False, False])
+
+    split = split_prefill_decode_batch(batch)
+
+    assert split.prefill_indices == []
+    assert split.decode_indices == [0, 1, 2]
+    assert split.prefill_batch is None
+    assert split.decode_batch is not None
+    assert split.decode_batch.seq_ids == batch.seq_ids
+    assert split.decode_batch.input_token_ids == batch.input_token_ids
+    assert split.decode_batch.token_offsets == batch.token_offsets
+
+
+def test_recombine_outputs_preserves_sequence_order() -> None:
+    batch = _make_batch([True, False, True, False])
+    split = split_prefill_decode_batch(batch)
+
+    prefill_outputs = torch.arange(0, 1 + 3, dtype=torch.float32).unsqueeze(1)
+    decode_outputs = torch.arange(
+        100, 100 + (2 + 4), dtype=torch.float32
+    ).unsqueeze(1)
+
+    recombined = split.recombine_outputs(prefill_outputs, decode_outputs)
+
+    expected = torch.tensor(
+        [
+            [0.0],
+            [100.0],
+            [101.0],
+            [1.0],
+            [2.0],
+            [3.0],
+            [102.0],
+            [103.0],
+            [104.0],
+            [105.0],
+        ],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(recombined, expected)
+
+
+@pytest.mark.skipif(
+    not HAS_FLASHINFER or not torch.cuda.is_available(),
+    reason="requires flashinfer + CUDA",
+)
+def test_mixed_batch_flashinfer_correctness() -> None:
+    batch = _make_batch([True, False, True])
+    split = split_prefill_decode_batch(batch)
+
+    full_outputs = torch.randn(batch.total_tokens, 8, device="cuda")
+    assert split.prefill_batch is not None
+    assert split.decode_batch is not None
+
+    prefill_rows = split.prefill_batch.total_tokens
+    prefill_outputs = full_outputs[:prefill_rows]
+    decode_outputs = full_outputs[prefill_rows:]
+    recombined = split.recombine_outputs(prefill_outputs, decode_outputs)
+
+    torch.testing.assert_close(recombined, full_outputs)

--- a/tests/python/serving/test_flashinfer_model_runner.py
+++ b/tests/python/serving/test_flashinfer_model_runner.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+from moe_infinity.runtime.attention_types import AttentionMetadata
+
+ROOT = Path(__file__).resolve().parents[3]
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("moe_infinity", ROOT / "moe_infinity")
+_ensure_package("moe_infinity.serving", ROOT / "moe_infinity" / "serving")
+
+_SEQUENCE_MODULE = _load_module(
+    "moe_infinity.serving.sequence",
+    ROOT / "moe_infinity" / "serving" / "sequence.py",
+)
+_BATCH_MODULE = _load_module(
+    "moe_infinity.serving.batch",
+    ROOT / "moe_infinity" / "serving" / "batch.py",
+)
+_MODEL_RUNNER_MODULE = _load_module(
+    "moe_infinity.serving.model_runner",
+    ROOT / "moe_infinity" / "serving" / "model_runner.py",
+)
+
+SamplingParams = _SEQUENCE_MODULE.SamplingParams
+BatchMetadata = _BATCH_MODULE.BatchMetadata
+ModelRunner = _MODEL_RUNNER_MODULE.ModelRunner
+
+
+class _MockOutput:
+    def __init__(self, logits: torch.Tensor) -> None:
+        self.logits = logits
+
+
+class _MockExpertTracer:
+    def __init__(self) -> None:
+        self.created: list[int] = []
+
+    def create_entry(self) -> int:
+        idx = len(self.created)
+        self.created.append(idx)
+        return idx
+
+
+class _MockEngine:
+    def __init__(self, backend: object | None, block_size: int = 4) -> None:
+        self.request_id = 0
+        self.expert_tracer = _MockExpertTracer()
+        self.expert_layer_modules = [types.SimpleNamespace(seq_id_list=[])]
+        self._attention_backend = backend
+        self.kv_cache = types.SimpleNamespace(block_size=block_size)
+
+    def _generate_request_id(self) -> int:
+        request_id = self.request_id
+        self.request_id += 1
+        return request_id
+
+    def get_attention_backend(self) -> object | None:
+        return self._attention_backend
+
+
+def _make_prefill_batch() -> BatchMetadata:
+    return BatchMetadata(
+        seq_ids=[1, 2],
+        input_token_ids=[100, 101, 200],
+        seq_lengths=[2, 1],
+        context_lengths=[0, 0],
+        is_prefill=[True, True],
+        block_tables=[[10], [20]],
+        token_offsets=[0, 2, 3],
+        sampling_params=[SamplingParams(), SamplingParams()],
+    )
+
+
+def _make_decode_batch() -> BatchMetadata:
+    return BatchMetadata(
+        seq_ids=[9],
+        input_token_ids=[55],
+        seq_lengths=[1],
+        context_lengths=[3],
+        is_prefill=[False],
+        block_tables=[[7]],
+        token_offsets=[0, 1],
+        sampling_params=[SamplingParams()],
+    )
+
+
+def _make_paged_model(events: list[tuple[object, ...]]) -> torch.nn.Module:
+    class DeepseekV3PagedAttention(torch.nn.Module):
+        @classmethod
+        def set_paged_context(cls, backend: object, metadata: object) -> None:
+            events.append(("set", backend, metadata))
+
+        @classmethod
+        def clear_paged_context(cls) -> None:
+            events.append(("clear",))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x
+
+    class Model(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attn = DeepseekV3PagedAttention()
+
+        def forward(
+            self, input_ids: torch.Tensor, **kwargs: object
+        ) -> _MockOutput:
+            _ = kwargs
+            events.append(("model_forward",))
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, 32, dtype=torch.float32)
+            return _MockOutput(logits)
+
+    return Model()
+
+
+def test_model_runner_sets_and_clears_paged_context() -> None:
+    events: list[tuple[object, ...]] = []
+    backend = object()
+    model = _make_paged_model(events)
+    runner = ModelRunner(
+        model, _MockEngine(backend), device=torch.device("cpu")
+    )
+
+    logits = runner.execute(_make_prefill_batch())
+
+    assert logits.shape == (3, 32)
+    assert events[0][0] == "set"
+    assert events[0][1] is backend
+    metadata = events[0][2]
+    assert isinstance(metadata, AttentionMetadata)
+    assert metadata.block_tables.dtype == torch.int32
+    assert metadata.block_tables.tolist() == [[10], [20]]
+    assert metadata.seq_lens.tolist() == [2, 1]
+    assert metadata.max_seq_len == 2
+    assert metadata.num_prefill_tokens == 3
+    assert metadata.num_decode_tokens == 0
+    assert metadata.slot_mapping.tolist() == [40, 41, 80]
+    assert metadata.is_prefill is True
+    assert events[1] == ("model_forward",)
+    assert events[2] == ("clear",)
+
+
+def test_model_runner_clears_paged_context_on_exception() -> None:
+    events: list[tuple[object, ...]] = []
+    backend = object()
+
+    class DeepseekV2PagedAttention(torch.nn.Module):
+        @classmethod
+        def set_paged_context(cls, backend: object, metadata: object) -> None:
+            events.append(("set", backend, metadata))
+
+        @classmethod
+        def clear_paged_context(cls) -> None:
+            events.append(("clear",))
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return x
+
+    class FailingModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attn = DeepseekV2PagedAttention()
+
+        def forward(
+            self, input_ids: torch.Tensor, **kwargs: object
+        ) -> _MockOutput:
+            _ = (input_ids, kwargs)
+            events.append(("model_forward",))
+            raise RuntimeError("boom")
+
+    runner = ModelRunner(
+        FailingModel(),
+        _MockEngine(backend),
+        device=torch.device("cpu"),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _ = runner.execute(_make_decode_batch())
+
+    assert events[0][0] == "set"
+    assert events[1] == ("model_forward",)
+    assert events[2] == ("clear",)
+
+
+def test_model_runner_skips_paged_context_for_non_paged_models() -> None:
+    class Model(torch.nn.Module):
+        def forward(
+            self, input_ids: torch.Tensor, **kwargs: object
+        ) -> _MockOutput:
+            _ = kwargs
+            batch, seq_len = input_ids.shape
+            logits = torch.zeros(batch, seq_len, 16, dtype=torch.float32)
+            return _MockOutput(logits)
+
+    runner = ModelRunner(
+        Model(),
+        _MockEngine(backend=object()),
+        device=torch.device("cpu"),
+    )
+
+    logits = runner.execute(_make_prefill_batch())
+    assert logits.shape == (3, 16)

--- a/tests/python/unit/test_flashinfer_attention_backend.py
+++ b/tests/python/unit/test_flashinfer_attention_backend.py
@@ -1,0 +1,298 @@
+import types
+
+import pytest
+import torch
+
+from moe_infinity.runtime import attention_backend as attention_backend_module
+from moe_infinity.runtime import flashinfer_utils
+from moe_infinity.runtime.attention_types import AttentionMetadata, KVCacheSpec
+
+
+class _FakePrefillWrapper:
+    def __init__(self, workspace: torch.Tensor, layout: str) -> None:
+        self.workspace = workspace
+        self.layout = layout
+        self.plan_args = None
+        self.run_args = None
+
+    def plan(self, *args, **kwargs) -> None:
+        self.plan_args = (args, kwargs)
+
+    def run(self, query: torch.Tensor, kv_cache: torch.Tensor) -> torch.Tensor:
+        self.run_args = (query, kv_cache)
+        return torch.zeros_like(query)
+
+
+class _FakeDecodeWrapper:
+    def __init__(self, workspace: torch.Tensor, layout: str) -> None:
+        self.workspace = workspace
+        self.layout = layout
+        self.plan_args = None
+        self.run_args = None
+
+    def plan(self, *args, **kwargs) -> None:
+        self.plan_args = (args, kwargs)
+
+    def run(self, query: torch.Tensor, kv_cache: torch.Tensor) -> torch.Tensor:
+        self.run_args = (query, kv_cache)
+        return torch.zeros_like(query)
+
+
+def _spec() -> KVCacheSpec:
+    return KVCacheSpec(
+        num_kv_heads=2,
+        head_dim=8,
+        dtype=torch.float32,
+        block_size=4,
+    )
+
+
+def _prefill_metadata(num_tokens: int) -> AttentionMetadata:
+    return AttentionMetadata(
+        block_tables=torch.tensor([[0]], dtype=torch.int64),
+        seq_lens=torch.tensor([num_tokens], dtype=torch.int64),
+        max_seq_len=num_tokens,
+        num_prefill_tokens=num_tokens,
+        num_decode_tokens=0,
+        slot_mapping=torch.arange(num_tokens, dtype=torch.long),
+        is_prefill=True,
+    )
+
+
+def _decode_metadata(seq_len: int) -> AttentionMetadata:
+    return AttentionMetadata(
+        block_tables=torch.tensor([[0]], dtype=torch.int64),
+        seq_lens=torch.tensor([seq_len], dtype=torch.int64),
+        max_seq_len=seq_len,
+        num_prefill_tokens=0,
+        num_decode_tokens=1,
+        slot_mapping=torch.tensor([seq_len - 1], dtype=torch.long),
+        is_prefill=False,
+    )
+
+
+def _enable_fake_flashinfer(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_module = types.SimpleNamespace(
+        BatchPrefillWithPagedKVCacheWrapper=_FakePrefillWrapper,
+        BatchDecodeWithPagedKVCacheWrapper=_FakeDecodeWrapper,
+    )
+    monkeypatch.setattr(
+        attention_backend_module.flashinfer_utils,
+        "HAS_FLASHINFER",
+        True,
+    )
+    monkeypatch.setattr(
+        attention_backend_module.flashinfer_utils,
+        "get_flashinfer_module",
+        lambda: fake_module,
+    )
+    monkeypatch.setattr(
+        attention_backend_module.flashinfer_utils,
+        "get_workspace",
+        lambda device: torch.empty(
+            1024,
+            dtype=torch.uint8,
+            device=device,
+        ),
+    )
+
+
+def test_flashinfer_kv_cache_layout_nhd_with_mocked_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_fake_flashinfer(monkeypatch)
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=_spec(),
+        num_gpu_blocks=10,
+        device=torch.device("cpu"),
+    )
+    assert backend._fi_kv_cache is not None
+    assert backend._fi_kv_cache.shape == (10, 2, 4, 2, 8)
+
+
+def test_flashinfer_prefill_metadata_is_int32_with_mocked_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_fake_flashinfer(monkeypatch)
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=_spec(),
+        num_gpu_blocks=4,
+        device=torch.device("cpu"),
+    )
+
+    query = torch.randn(4, 4, 8)
+    key = torch.randn(4, 2, 8)
+    value = torch.randn(4, 2, 8)
+    out = backend.forward(
+        query=query,
+        key=key,
+        value=value,
+        attention_metadata=_prefill_metadata(num_tokens=4),
+    )
+
+    assert out.shape == (4, 4, 8)
+    assert backend._fi_prefill is not None
+    assert backend._fi_prefill.plan_args is not None
+    plan_args = backend._fi_prefill.plan_args[0]
+    assert plan_args[0].dtype == torch.int32
+    assert plan_args[1].dtype == torch.int32
+    assert plan_args[2].dtype == torch.int32
+    assert plan_args[3].dtype == torch.int32
+
+
+def test_flashinfer_decode_metadata_is_int32_with_mocked_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_fake_flashinfer(monkeypatch)
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=_spec(),
+        num_gpu_blocks=4,
+        device=torch.device("cpu"),
+    )
+
+    key = torch.randn(4, 2, 8)
+    value = torch.randn(4, 2, 8)
+    backend.write_kv_flashinfer(
+        key=key,
+        value=value,
+        slot_mapping=torch.arange(4, dtype=torch.long),
+    )
+
+    out = backend.forward(
+        query=torch.randn(1, 4, 8),
+        key=key[:1],
+        value=value[:1],
+        attention_metadata=_decode_metadata(seq_len=4),
+    )
+    assert out.shape == (1, 4, 8)
+    assert backend._fi_decode is not None
+    assert backend._fi_decode.plan_args is not None
+    plan_args = backend._fi_decode.plan_args[0]
+    assert plan_args[0].dtype == torch.int32
+    assert plan_args[1].dtype == torch.int32
+    assert plan_args[2].dtype == torch.int32
+
+
+def test_write_kv_flashinfer_writes_expected_layout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_fake_flashinfer(monkeypatch)
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=_spec(),
+        num_gpu_blocks=2,
+        device=torch.device("cpu"),
+    )
+
+    key = torch.arange(3 * 2 * 8, dtype=torch.float32).reshape(3, 2, 8)
+    value = key + 1000.0
+    slot_mapping = torch.tensor([0, 3, 4], dtype=torch.long)
+
+    backend.write_kv_flashinfer(key=key, value=value, slot_mapping=slot_mapping)
+    assert backend._fi_kv_cache is not None
+    for i in range(slot_mapping.shape[0]):
+        slot = int(slot_mapping[i].item())
+        block_id = slot // backend.spec.block_size
+        token_offset = slot % backend.spec.block_size
+        torch.testing.assert_close(
+            backend._fi_kv_cache[block_id, 0, token_offset], key[i]
+        )
+        torch.testing.assert_close(
+            backend._fi_kv_cache[block_id, 1, token_offset], value[i]
+        )
+
+
+def test_fallback_prefill_without_flashinfer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        attention_backend_module.flashinfer_utils,
+        "HAS_FLASHINFER",
+        False,
+    )
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=_spec(),
+        num_gpu_blocks=10,
+        device=torch.device("cpu"),
+    )
+
+    out = backend.forward(
+        query=torch.randn(4, 4, 8),
+        key=torch.randn(4, 2, 8),
+        value=torch.randn(4, 2, 8),
+        attention_metadata=_prefill_metadata(num_tokens=4),
+    )
+    assert out.shape == (4, 4, 8)
+    assert backend._fi_prefill is None
+
+
+def test_fallback_decode_without_flashinfer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        attention_backend_module.flashinfer_utils,
+        "HAS_FLASHINFER",
+        False,
+    )
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=_spec(),
+        num_gpu_blocks=10,
+        device=torch.device("cpu"),
+    )
+    key = torch.randn(4, 2, 8)
+    value = torch.randn(4, 2, 8)
+    backend.write_kv(key=key, value=value, slot_mapping=torch.arange(4))
+
+    out = backend.forward(
+        query=torch.randn(1, 4, 8),
+        key=key[:1],
+        value=value[:1],
+        attention_metadata=_decode_metadata(seq_len=4),
+    )
+    assert out.shape == (1, 4, 8)
+    assert backend._fi_decode is None
+
+
+@pytest.mark.skipif(
+    not flashinfer_utils.HAS_FLASHINFER or not torch.cuda.is_available(),
+    reason="requires flashinfer + CUDA",
+)
+def test_flashinfer_workspace_reuse_across_batches() -> None:
+    backend = attention_backend_module.PagedAttentionBackend(
+        spec=KVCacheSpec(
+            num_kv_heads=2,
+            head_dim=16,
+            dtype=torch.float16,
+            block_size=4,
+        ),
+        num_gpu_blocks=16,
+        device=torch.device("cuda"),
+    )
+
+    metadata = AttentionMetadata(
+        block_tables=torch.tensor([[0]], dtype=torch.int32, device="cuda"),
+        seq_lens=torch.tensor([4], dtype=torch.int32, device="cuda"),
+        max_seq_len=4,
+        num_prefill_tokens=4,
+        num_decode_tokens=0,
+        slot_mapping=torch.arange(4, dtype=torch.long, device="cuda"),
+        is_prefill=True,
+    )
+
+    query = torch.randn(4, 4, 16, dtype=torch.float16, device="cuda")
+    key = torch.randn(4, 2, 16, dtype=torch.float16, device="cuda")
+    value = torch.randn(4, 2, 16, dtype=torch.float16, device="cuda")
+
+    workspace0 = backend._fi_workspace
+    backend.forward(
+        query=query,
+        key=key,
+        value=value,
+        attention_metadata=metadata,
+    )
+    backend.forward(
+        query=query,
+        key=key,
+        value=value,
+        attention_metadata=metadata,
+    )
+    assert backend._fi_workspace is workspace0

--- a/tests/python/unit/test_flashinfer_utils.py
+++ b/tests/python/unit/test_flashinfer_utils.py
@@ -1,0 +1,88 @@
+import builtins
+import importlib
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+import moe_infinity.runtime.flashinfer_utils as flashinfer_utils
+
+
+def _import_flashinfer_available() -> bool:
+    try:
+        import flashinfer  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def _load_flashinfer_utils_with_blocked_import() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[3]
+        / "moe_infinity"
+        / "runtime"
+        / "flashinfer_utils.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_test_flashinfer_utils_missing", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+
+    original_import = builtins.__import__
+
+    def _guarded_import(name, *args, **kwargs):
+        if name == "flashinfer":
+            raise ImportError("blocked flashinfer import for test")
+        return original_import(name, *args, **kwargs)
+
+    builtins.__import__ = _guarded_import
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        builtins.__import__ = original_import
+
+    return module
+
+
+def test_has_flashinfer_flag_matches_import() -> None:
+    importable = _import_flashinfer_available()
+    importlib.reload(flashinfer_utils)
+    assert flashinfer_utils.HAS_FLASHINFER is importable
+
+
+def test_get_workspace_returns_correct_shape_and_dtype() -> None:
+    ws = flashinfer_utils.get_workspace(torch.device("cpu"))
+    assert ws.dtype == torch.uint8
+    assert ws.numel() == 128 * 1024 * 1024
+    assert ws.device.type == "cpu"
+
+
+def test_get_workspace_caches_per_device() -> None:
+    d = torch.device("cpu")
+    ws1 = flashinfer_utils.get_workspace(d)
+    ws2 = flashinfer_utils.get_workspace(d)
+    assert ws1 is ws2
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="requires CUDA to validate different-device workspace caching",
+)
+def test_get_workspace_different_devices() -> None:
+    ws_cpu = flashinfer_utils.get_workspace(torch.device("cpu"))
+    ws_cuda = flashinfer_utils.get_workspace(torch.device("cuda"))
+    assert ws_cpu is not ws_cuda
+    assert ws_cpu.device.type == "cpu"
+    assert ws_cuda.device.type == "cuda"
+
+
+def test_graceful_when_flashinfer_missing() -> None:
+    module = _load_flashinfer_utils_with_blocked_import()
+    assert getattr(module, "HAS_FLASHINFER") is False
+    ws = module.get_workspace(torch.device("cpu"))
+    assert ws.dtype == torch.uint8
+    assert ws.numel() == 128 * 1024 * 1024

--- a/tests/python/unit/test_kv_swap_recovery.py
+++ b/tests/python/unit/test_kv_swap_recovery.py
@@ -48,7 +48,7 @@ def _make_group(
 
 
 def test_swap_recovery_lifecycle() -> None:
-    scheduler = _make_scheduler(num_blocks=3)
+    scheduler = _make_scheduler(num_blocks=4)
     group1 = _make_group("req-1", seq_id=1, prompt_len=4)
     scheduler.add_request(group1)
 
@@ -57,12 +57,14 @@ def test_swap_recovery_lifecycle() -> None:
     scheduler.update_after_step(completed_seq_ids=[], new_decode_seq_ids=[1])
     assert group1.sequences[0].status is SequenceStatus.DECODE
 
-    group2 = _make_group("req-2", seq_id=2)
+    group2 = _make_group("req-2", seq_id=2, prompt_len=12)
     scheduler.add_request(group2)
 
     preempt_cycle = scheduler.schedule()
     assert 1 in preempt_cycle.preempted_seq_ids
     assert group1.sequences[0].status is SequenceStatus.SWAPPED
+
+    scheduler.update_after_step(completed_seq_ids=[2], new_decode_seq_ids=[])
 
     recovery_cycle = scheduler.schedule()
     assert group1.sequences[0].status is SequenceStatus.DECODE
@@ -104,8 +106,12 @@ def test_free_gpu_blocks_preserves_cpu_buffer() -> None:
     )
 
     assert 33 in swapped_cpu_buffers
+    blocks_before = kv_cache.get_block_table(33)
+    assert len(blocks_before) == 2
+
     kv_cache.free_gpu_blocks(seq_id=33)
 
     assert 33 in swapped_cpu_buffers
     assert 33 in sequence_tables
-    assert kv_cache.get_block_table(33)
+    assert kv_cache.get_block_table(33) == []
+    assert kv_cache.block_allocator.num_free_blocks == 2


### PR DESCRIPTION
## Summary

Integrates FlashInfer's `BatchPrefillWithPagedKVCacheWrapper` and `BatchDecodeWithPagedKVCacheWrapper` into both the runtime and serving attention paths, replacing PyTorch SDPA / custom paged attention kernels when FlashInfer is installed. Graceful fallback when FlashInfer is not available — zero behavior change.

Fixes #64

## Kernel-Level A/B Benchmark Results

Measured on **NVIDIA RTX A5000** (24GB), FlashInfer 0.2.5 (cu124), PyTorch 2.6, Docker container with `--gpus "device=2,3"`.

### Canonical Validation (`validate_flashinfer.py`)

| Test | Result |
|------|--------|
| FlashInfer import/version | PASS — v0.2.5, wrappers present |
| Paged KV tensor construction | PASS — shape=(2,2,16,8,64), fp16 |
| BatchPrefill correctness | PASS — allclose(atol=1e-2, rtol=1e-2) |
| BatchDecode correctness | PASS — allclose(atol=1e-2, rtol=1e-2) |
| **FlashInfer latency vs naive SDPA** | PASS — **0.0324ms vs 0.1583ms = 4.88x speedup** |
| FlashInfer + _store coexistence | BLOCKED (expected — vanilla PyTorch container) |

### Multi-Configuration Kernel Sweep (`ab_kernel_bench.py`)

| Config | FlashInfer (ms) | Naive SDPA (ms) | Speedup |
|--------|----------------:|----------------:|--------:|
| Small (b=2, h=8, d=64) | 0.0292 | 0.1552 | **5.32x** |
| Medium (b=4, h=16, d=128) | 0.0405 | 0.3123 | **7.71x** |
| Large (b=8, h=32, d=128) | 0.1127 | 0.6099 | **5.41x** |

**Summary**: FlashInfer paged attention delivers **5-8x kernel-level speedup** over naive PyTorch SDPA across representative batch/head/dim configurations, with correctness verified via allclose on both prefill and decode paths.

### Benchmark Infrastructure

The PR includes ready-to-run A/B comparison tooling:
- `benchmarks/serving/validate_flashinfer.py` — Kernel correctness + latency A/B (no model needed)
- `benchmarks/serving/ab_kernel_bench.py` — Multi-config kernel sweep
- `benchmarks/serving/baseline_performance.py` then `throughput.py` / `latency.py` / `memory.py` — End-to-end serving benchmarks with `--baseline-json` for delta comparison

## Changes

### FlashInfer Integration (7 layers, bottom-up)
- **Layer 0** — `moe_infinity/runtime/flashinfer_utils.py` (NEW): Centralized FlashInfer detection (`HAS_FLASHINFER`), workspace management (128MB uint8, cached per device), lazy import
- **Layer 1** — `moe_infinity/runtime/attention_backend.py`: `PagedAttentionBackend` gains FlashInfer NHD KV cache layout + prefill/decode wrapper lifecycle. All metadata tensors enforced as `int32`
- **Layer 1.5** — `moe_infinity/serving/batch.py`: `split_prefill_decode_batch()` splits mixed prefill/decode batches for separate FlashInfer wrapper dispatch
- **Layer 2** — `moe_infinity/serving/kv_cache.py`: `PagedKVCache._compute_attention()` wired to FlashInfer wrappers (was dead code)
- **Layer 2.5** — `moe_infinity/entrypoints/big_modeling.py`: `_native_model_forward()` now passes `attention_metadata` to model via `set_paged_context()` / `clear_paged_context()` lifecycle
- **Layer 3** — `moe_infinity/models/modeling_deepseek_v{2,3}/modeling_deepseek.py`: `PagedAttention.forward()` intercepts after Q/K/V projection to route through `_paged_backend` when context is set
- **Layer 4** — `moe_infinity/serving/model_runner.py`: `ModelRunner.execute()` manages paged context lifecycle around model forward (try/finally)

### Packaging & Docs
- `setup.py`: Added `extras_require={"flashinfer": ["flashinfer"]}`
- `README.md`: Added "Enable FlashInfer (Optional)" section with install commands for CUDA 12.1/12.4

### Bugfix: Scheduler preemption was broken
Discovered during integration testing — `free_gpu_blocks()` was a no-op stub, making the entire preemption mechanism non-functional:
- `free_gpu_blocks()`: Now actually frees blocks back to allocator (preserves `_num_tokens` for swap_in)
- `swap_in()`: Re-allocates fresh blocks before restoring CPU data
- Updated `test_kv_swap_recovery.py` for correct block management contract

## Test Results
```
295 passed, 8 skipped, 0 failed (16.53s)
```
- 9 new test files covering all layers + E2E
- 8 skips are FlashInfer+CUDA conditional (expected in CI without GPU)
- Zero regressions on existing tests
