### PR TITLE
feat(models): add GPT-OSS MoE support with packed expert offloading and MXFP4 handling

### DIFF
--- a/moe_infinity/common/constants.py
+++ b/moe_infinity/common/constants.py
@@ -2,6 +2,7 @@ from transformers import (
     DbrxForCausalLM,
     DeepseekV2ForCausalLM,
     DeepseekV3ForCausalLM,
+    GptOssForCausalLM,
     JambaForCausalLM,
     MixtralForCausalLM,
     NllbMoeForConditionalGeneration,
@@ -26,6 +27,7 @@ MODEL_MAPPING_NAMES = {
     "arctic": ArcticForCausalLM,
     "deepseek": DeepseekV2ForCausalLM,
     "deepseek_v3": DeepseekV3ForCausalLM,
+    "gptoss": GptOssForCausalLM,
     "qwen3": Qwen3MoeForCausalLM,
     "dbrx": DbrxForCausalLM,
     "olmoe": OlmoeForCausalLM,
@@ -40,6 +42,7 @@ MODEL_MAPPING_TYPES = {
     "arctic": 4,
     "deepseek": 5,
     "deepseek_v3": 5,
+    "gptoss": 4,
     "qwen3": 5,
     "dbrx": 4,
     "olmoe": 4,
@@ -48,7 +51,9 @@ MODEL_MAPPING_TYPES = {
 
 
 def parse_expert_type(config: PretrainedConfig) -> int:
-    architecture = config.architectures[0].lower()
+    architecture = (
+        config.architectures[0].lower() if config.architectures else ""
+    )
     arch = None
     for supp_arch in MODEL_MAPPING_NAMES:
         if supp_arch in architecture:

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -178,7 +178,12 @@ class MoE:
 
             is_flash_attn_available = True
 
-            if arch == "deepseek" or arch == "deepseek_v3" or arch == "nllb":
+            if (
+                arch == "deepseek"
+                or arch == "deepseek_v3"
+                or arch == "nllb"
+                or arch == "gptoss"
+            ):
                 is_flash_attn_available = False
         except ImportError:
             print(

--- a/moe_infinity/models/__init__.py
+++ b/moe_infinity/models/__init__.py
@@ -8,6 +8,7 @@ from .dbrx import SyncDbrxFFNBlock
 from .deepseek import DeepseekMoEBlock
 from .deepseek_v2_wrapper import SyncDeepseekV2MoEBlock
 from .deepseek_v3_wrapper import SyncDeepseekV3MoEBlock
+from .gpt_oss import SyncGptOssMLP
 from .grok import SyncGrokMoeBlock
 from .jamba import SyncJambaMoEBlock
 from .mixtral import SyncMixtralSparseMoeBlock

--- a/moe_infinity/models/gpt_oss.py
+++ b/moe_infinity/models/gpt_oss.py
@@ -55,10 +55,11 @@ class SyncGptOssMLP(nn.Module):
     def _expert_forward(
         self, hidden_states: torch.Tensor, expert_idx: int
     ) -> torch.Tensor:
-        gate_up_w = self.experts.gate_up_proj[expert_idx]
-        gate_up_b = self.experts.gate_up_proj_bias[expert_idx]
-        down_w = self.experts.down_proj[expert_idx]
-        down_b = self.experts.down_proj_bias[expert_idx]
+        device = hidden_states.device
+        gate_up_w = self.experts.gate_up_proj[expert_idx].to(device)
+        gate_up_b = self.experts.gate_up_proj_bias[expert_idx].to(device)
+        down_w = self.experts.down_proj[expert_idx].to(device)
+        down_b = self.experts.down_proj_bias[expert_idx].to(device)
 
         gate_up = F.linear(hidden_states, gate_up_w.t(), gate_up_b)
         gate, up = gate_up[..., ::2], gate_up[..., 1::2]

--- a/moe_infinity/models/gpt_oss.py
+++ b/moe_infinity/models/gpt_oss.py
@@ -1,0 +1,121 @@
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from moe_infinity.utils import ArcherConfig
+
+
+class SyncGptOssMLP(nn.Module):
+    archer_config: Optional[ArcherConfig] = None
+    layer_id: Optional[int] = None
+
+    def __init__(self, config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.num_experts = config.num_local_experts
+        self.top_k = config.num_experts_per_tok
+        self.alpha = 1.702
+        self.swiglu_limit = 7.0
+
+        self.router = nn.Linear(self.hidden_size, self.num_experts, bias=True)
+
+        self.gate_up_proj = nn.Parameter(
+            torch.empty(
+                self.num_experts, self.hidden_size, 2 * self.intermediate_size
+            )
+        )
+        self.gate_up_proj_bias = nn.Parameter(
+            torch.empty(self.num_experts, 2 * self.intermediate_size)
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty(
+                self.num_experts, self.intermediate_size, self.hidden_size
+            )
+        )
+        self.down_proj_bias = nn.Parameter(
+            torch.empty(self.num_experts, self.hidden_size)
+        )
+
+        self.expert_executor = None
+        self.archer_tracer = None
+        self.archer_engine = None
+        self.expert_tensor_ids: Optional[Dict[int, int]] = None
+
+    def _swiglu(self, gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor:
+        gate = gate.clamp(max=self.swiglu_limit)
+        up = up.clamp(-self.swiglu_limit, self.swiglu_limit)
+        return (up + 1) * (gate * torch.sigmoid(gate * self.alpha))
+
+    def _expert_forward(
+        self, hidden_states: torch.Tensor, expert_idx: int
+    ) -> torch.Tensor:
+        gate_up_w = self.gate_up_proj[expert_idx]
+        gate_up_b = self.gate_up_proj_bias[expert_idx]
+        down_w = self.down_proj[expert_idx]
+        down_b = self.down_proj_bias[expert_idx]
+
+        gate_up = F.linear(hidden_states, gate_up_w.t(), gate_up_b)
+        gate, up = gate_up[..., ::2], gate_up[..., 1::2]
+        activated = self._swiglu(gate, up)
+        return F.linear(activated, down_w.t(), down_b)
+
+    def forward(
+        self, hidden_states: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        num_tokens = batch_size * sequence_length
+        hidden_flat = hidden_states.view(-1, hidden_dim)
+
+        router_logits = self.router(hidden_flat)
+
+        routing_weights = F.softmax(router_logits, dim=-1, dtype=torch.float32)
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )
+        routing_weights = routing_weights / routing_weights.sum(
+            dim=-1, keepdim=True
+        )
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        router_mask = torch.zeros(
+            num_tokens,
+            self.num_experts,
+            dtype=torch.bool,
+            device=hidden_states.device,
+        )
+        router_mask.scatter_(1, selected_experts, True)
+
+        routing_weights_mask = torch.zeros(
+            num_tokens,
+            self.num_experts,
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        routing_weights_mask.scatter_(1, selected_experts, routing_weights)
+
+        if self.expert_executor is not None:
+            self.expert_executor.dispatch_local(
+                self.layer_id, hidden_flat, router_mask, routing_weights_mask
+            )
+            final_hidden = self.expert_executor.wait_dispatch_local()
+        else:
+            final_hidden = torch.zeros_like(hidden_flat)
+            for expert_idx in range(self.num_experts):
+                token_mask = router_mask[:, expert_idx]
+                if not token_mask.any():
+                    continue
+                expert_input = hidden_flat[token_mask]
+                expert_output = self._expert_forward(expert_input, expert_idx)
+                weight = routing_weights_mask[token_mask, expert_idx].unsqueeze(
+                    -1
+                )
+                final_hidden[token_mask] += weight * expert_output
+
+        final_hidden = final_hidden.view(
+            batch_size, sequence_length, hidden_dim
+        )
+        final_hidden = final_hidden.to(hidden_states.dtype)
+        return final_hidden, router_logits

--- a/moe_infinity/models/gpt_oss.py
+++ b/moe_infinity/models/gpt_oss.py
@@ -7,6 +7,25 @@ import torch.nn.functional as F
 from moe_infinity.utils import ArcherConfig
 
 
+class _PackedExperts(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        num_experts = config.num_local_experts
+        hidden = config.hidden_size
+        intermediate = config.intermediate_size
+
+        self.gate_up_proj = nn.Parameter(
+            torch.empty(num_experts, hidden, 2 * intermediate)
+        )
+        self.gate_up_proj_bias = nn.Parameter(
+            torch.empty(num_experts, 2 * intermediate)
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty(num_experts, intermediate, hidden)
+        )
+        self.down_proj_bias = nn.Parameter(torch.empty(num_experts, hidden))
+
+
 class SyncGptOssMLP(nn.Module):
     archer_config: Optional[ArcherConfig] = None
     layer_id: Optional[int] = None
@@ -21,23 +40,7 @@ class SyncGptOssMLP(nn.Module):
         self.swiglu_limit = 7.0
 
         self.router = nn.Linear(self.hidden_size, self.num_experts, bias=True)
-
-        self.gate_up_proj = nn.Parameter(
-            torch.empty(
-                self.num_experts, self.hidden_size, 2 * self.intermediate_size
-            )
-        )
-        self.gate_up_proj_bias = nn.Parameter(
-            torch.empty(self.num_experts, 2 * self.intermediate_size)
-        )
-        self.down_proj = nn.Parameter(
-            torch.empty(
-                self.num_experts, self.intermediate_size, self.hidden_size
-            )
-        )
-        self.down_proj_bias = nn.Parameter(
-            torch.empty(self.num_experts, self.hidden_size)
-        )
+        self.experts = _PackedExperts(config)
 
         self.expert_executor = None
         self.archer_tracer = None
@@ -52,10 +55,10 @@ class SyncGptOssMLP(nn.Module):
     def _expert_forward(
         self, hidden_states: torch.Tensor, expert_idx: int
     ) -> torch.Tensor:
-        gate_up_w = self.gate_up_proj[expert_idx]
-        gate_up_b = self.gate_up_proj_bias[expert_idx]
-        down_w = self.down_proj[expert_idx]
-        down_b = self.down_proj_bias[expert_idx]
+        gate_up_w = self.experts.gate_up_proj[expert_idx]
+        gate_up_b = self.experts.gate_up_proj_bias[expert_idx]
+        down_w = self.experts.down_proj[expert_idx]
+        down_b = self.experts.down_proj_bias[expert_idx]
 
         gate_up = F.linear(hidden_states, gate_up_w.t(), gate_up_b)
         gate, up = gate_up[..., ::2], gate_up[..., 1::2]

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -45,6 +45,7 @@ from moe_infinity.models import (
     SyncDbrxFFNBlock,
     SyncDeepseekV2MoEBlock,
     SyncDeepseekV3MoEBlock,
+    SyncGptOssMLP,
     SyncGrokMoeBlock,
     SyncJambaMoEBlock,
     SyncMixtralSparseMoeBlock,
@@ -668,6 +669,7 @@ class OffloadEngine(object):
                         or isinstance(module, SyncDeepseekV3MoEBlock)
                         or isinstance(module, Qwen3MoEBlock)
                         or isinstance(module, SyncDbrxFFNBlock)
+                        or isinstance(module, SyncGptOssMLP)
                         or isinstance(module, SyncOlmoeMoEBlock)
                         or isinstance(module, SyncJambaMoEBlock)
                     ):

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -499,6 +499,10 @@ class OffloadEngine(object):
 
                 self.dtype = parse_expert_dtype(self.config)
                 self.dtype_cls = self.config.torch_dtype
+                if self.dtype_cls is None:
+                    self.dtype_cls = getattr(
+                        self.config, "dtype", torch.bfloat16
+                    )
 
                 if self.config.model_type == "deepseek_v3":
                     self.dtype_cls = torch.float8_e4m3fn

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import tempfile
+import warnings
 from typing import Callable, Dict, Type, Union
 
 import torch
@@ -70,6 +71,7 @@ from moe_infinity.utils.async_transfer import (
     wait_transfer,
 )
 from moe_infinity.utils.device import get_default_device, get_device
+from moe_infinity.utils.mxfp4 import identify_mxfp4_pairs, is_mxfp4_quantized
 
 _prefetch_lib = None
 # Alias for compatibility
@@ -522,7 +524,20 @@ class OffloadEngine(object):
                             with safe_open(
                                 ckpt, framework="pt", device="cpu"
                             ) as f:
-                                for k in f.keys():
+                                weight_keys = list(f.keys())
+                                mxfp4_pairs = identify_mxfp4_pairs(weight_keys)
+                                is_mxfp4_ckpt = bool(mxfp4_pairs)
+                                if not is_mxfp4_ckpt:
+                                    try:
+                                        is_mxfp4_ckpt = is_mxfp4_quantized(
+                                            self.config
+                                        )
+                                    except Exception:
+                                        is_mxfp4_ckpt = False
+
+                                for k in weight_keys:
+                                    if is_mxfp4_ckpt and k.endswith("_scales"):
+                                        continue
                                     state_dict[k] = f.get_tensor(k)
                         else:
                             state_dict = torch.load(ckpt)
@@ -531,6 +546,21 @@ class OffloadEngine(object):
                         for k, v in state_dict.items():
                             try:
                                 state_dict[k] = v.to(self.dtype_cls).to("cpu")
+                            except (RuntimeError, TypeError) as e:
+                                if k.endswith("_blocks"):
+                                    warnings.warn(
+                                        f"Could not convert tensor {k} (dtype={v.dtype}) "
+                                        f"to {self.dtype_cls}: {e}. Keeping original dtype.",
+                                        UserWarning,
+                                        stacklevel=2,
+                                    )
+                                    state_dict[k] = v.to("cpu")
+                                    continue
+                                print(
+                                    f"Error converting {k} (device={v.device}) to {self.dtype_cls} on CPU: {e}",
+                                    flush=True,
+                                )
+                                raise
                             except Exception as e:
                                 print(
                                     f"Error converting {k} (device={v.device}) to {self.dtype_cls} on CPU: {e}",

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -725,11 +725,13 @@ class OffloadEngine(object):
                         module.archer_engine = self.archer_engine
                         module.archer_config = self.archer_config
                         self.expert_modules.append(module)
-                        module.expert_executor = self.expert_executor
-                        module.expert_prefetcher = self.expert_prefetcher
-                        module.expert_tracer = self.expert_tracer
-                        module.expert_predictor = self.expert_predictor
-                        module.expert_tensor_map = self.expert_tensor_map
+
+                        if not isinstance(module, SyncGptOssMLP):
+                            module.expert_executor = self.expert_executor
+                            module.expert_prefetcher = self.expert_prefetcher
+                            module.expert_tracer = self.expert_tracer
+                            module.expert_predictor = self.expert_predictor
+                            module.expert_tensor_map = self.expert_tensor_map
 
                         module.lib = self.prefetch_lib
 
@@ -956,7 +958,7 @@ class OffloadEngine(object):
                 key = key.split(".")[0]
                 output_device_index = 0
 
-            if "expert" in key:
+            if "expert" in key and self.config.model_type != "gpt_oss":
                 for expert_idx, expert_tensors in enumerate(tensors):
                     expert_key = (
                         f"{key}.expert_{expert_idx}"

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -578,6 +578,16 @@ class OffloadEngine(object):
                         gc.collect()
                         torch.cuda.empty_cache()
 
+                    if is_mxfp4_quantized(self.config):
+                        blocks_aliases = {}
+                        for key in list(self.name_id_map.keys()):
+                            if key.endswith("_blocks"):
+                                base_name = key[: -len("_blocks")]
+                                blocks_aliases[base_name] = self.name_id_map[
+                                    key
+                                ]
+                        self.name_id_map.update(blocks_aliases)
+
                     with open(name_id_map_file, "w") as f:
                         json.dump(self.name_id_map, f)
                     _write_model_signature(

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -466,6 +466,11 @@ class OffloadEngine(object):
             SyncDeepseekV3MoEBlock
         )
 
+        transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp = (
+            transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP
+        )
+        transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = SyncGptOssMLP
+
         def from_pretrained_decorator(
             orig_from_pretrained: Callable,
         ) -> Callable:
@@ -719,6 +724,10 @@ class OffloadEngine(object):
         PreTrainedModel.post_init = PreTrainedModel._old_post_init
 
         deactivate_empty_init()
+
+        transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = (
+            transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp
+        )
 
     def get_topology(self, model):
         name_lst = []
@@ -1249,3 +1258,6 @@ class OffloadEngine(object):
 
         transformers.models.deepseek_v2.modeling_deepseek_v2.DeepseekV2MoE = transformers.models.deepseek_v2.modeling_deepseek_v2._old_deepseek_v2_moe
         transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE = transformers.models.deepseek_v3.modeling_deepseek_v3._old_deepseek_v3_moe
+        transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = (
+            transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp
+        )

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -177,10 +177,13 @@ class PagedKVCache:
         self._swapped_out_sequences.discard(seq_id)
 
     def free_gpu_blocks(self, seq_id: int) -> None:
-        if seq_id not in self._sequence_tables:
+        block_table = self._sequence_tables.get(seq_id)
+        if block_table is None:
             return
 
-        return
+        if block_table._block_ids:
+            self.block_allocator.free(block_table._block_ids)
+            block_table._block_ids = []
 
     def get_block_table(self, seq_id: int) -> list[int]:
         block_table = self._require_sequence(seq_id)
@@ -202,13 +205,20 @@ class PagedKVCache:
         self._swapped_out_sequences.add(seq_id)
 
     def swap_in(self, seq_id: int) -> None:
-        _ = self._require_sequence(seq_id)
+        block_table = self._require_sequence(seq_id)
         if seq_id not in self._swapped_out_sequences:
             return
 
+        # Re-allocate blocks if they were freed during swap-out
+        if not block_table._block_ids and block_table._num_tokens > 0:
+            from math import ceil
+
+            needed = ceil(block_table._num_tokens / block_table.block_size)
+            block_table._block_ids = self.block_allocator.allocate(needed)
+
         cpu_buffer = self._swapped_cpu_buffers.pop(seq_id, None)
         if cpu_buffer is not None:
-            block_ids = self.get_block_table(seq_id)
+            block_ids = block_table.get_block_ids()
             if block_ids:
                 self._kv_cache[:, block_ids, ...] = cpu_buffer.to(
                     device=self._kv_cache.device,

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -49,16 +49,18 @@ def ensure_config_compat(config: PretrainedConfig) -> PretrainedConfig:
 
 def parse_expert_dtype(config: PretrainedConfig) -> int:
     dtype = config.torch_dtype
+    if dtype is None:
+        dtype = getattr(config, "dtype", None)
+    if dtype is None:
+        dtype = torch.bfloat16
     if dtype == torch.bfloat16:
-        dtype = 0
+        return 0
     elif dtype == torch.float32:
-        dtype = 1
+        return 1
     elif dtype == torch.float16:
-        dtype = 2
+        return 2
     else:
         assert False, "Unknown dtype %s" % dtype
-
-    return dtype
 
 
 def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -62,7 +62,7 @@ def parse_expert_dtype(config: PretrainedConfig) -> int:
 
 
 def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
-    arch = config.architectures[0].lower()
+    arch = (config.architectures or [""])[0].lower()
 
     if "nllb" in arch:
         num_encoder_layers = config.encoder_layers // config.encoder_sparse_step
@@ -84,6 +84,11 @@ def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
         num_decoder_layers = config.num_hidden_layers
         num_layers = config.num_hidden_layers
         num_experts = config.n_routed_experts
+    elif "gpt_oss" in arch or "gptoss" in arch:
+        num_encoder_layers = 0
+        num_decoder_layers = config.num_hidden_layers
+        num_layers = config.num_hidden_layers
+        num_experts = config.num_local_experts
     else:
         raise RuntimeError(f"Unsupported architecture {arch}")
 
@@ -93,8 +98,14 @@ def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
 def parse_expert_id(
     param_name: str, config: PretrainedConfig
 ) -> Tuple[Optional[int], Optional[int]]:
-    arch = config.architectures[0].lower()
+    arch = (config.architectures or [""])[0].lower()
     _, _, num_encoder_layers = parse_moe_param(config)
+    result = None
+    layer_type = ""
+    layer_id = 0
+    expert_id = 0
+    encoder_sparse_step = 1
+    decoder_sparse_step = 1
 
     if "nllb" in arch:
         # example "decoder.block.1.layer.2.mlp.experts.expert_100.wi.weight"
@@ -149,6 +160,14 @@ def parse_expert_id(
             # print(f"layer_id: {layer_id}, expert_id: {expert_id}")
             layer_id = int(layer_id)
             expert_id = int(expert_id)
+    elif "gpt_oss" in arch or "gptoss" in arch:
+        result = re.findall(
+            r"layers\.(\d+)\.mlp\.experts\.(gate_up_proj|down_proj)",
+            param_name,
+        )
+        if result:
+            layer_id = int(result[0][0])
+            return layer_id, None
 
     if result:
         if layer_type == "decoder":

--- a/moe_infinity/utils/mxfp4.py
+++ b/moe_infinity/utils/mxfp4.py
@@ -15,6 +15,13 @@ class _ConfigWithQuantization(Protocol):
     def quantization_config(self) -> Optional[_QuantizationConfigLike]: ...
 
 
+def _get_quant_field(quant_config, field: str):
+    """Get a field from quantization_config, handling both dict and object."""
+    if isinstance(quant_config, dict):
+        return quant_config.get(field)
+    return getattr(quant_config, field, None)
+
+
 def is_mxfp4_quantized(config: _ConfigWithQuantization) -> bool:
     try:
         quant_config = config.quantization_config
@@ -22,7 +29,7 @@ def is_mxfp4_quantized(config: _ConfigWithQuantization) -> bool:
         return False
     if quant_config is None:
         return False
-    return quant_config.quant_method == "mxfp4"
+    return _get_quant_field(quant_config, "quant_method") == "mxfp4"
 
 
 def get_mxfp4_modules_to_not_convert(
@@ -34,7 +41,7 @@ def get_mxfp4_modules_to_not_convert(
         return []
     if quant_config is None:
         return []
-    modules = quant_config.modules_to_not_convert
+    modules = _get_quant_field(quant_config, "modules_to_not_convert")
     if modules is None:
         return []
     if isinstance(modules, str):

--- a/moe_infinity/utils/mxfp4.py
+++ b/moe_infinity/utils/mxfp4.py
@@ -1,0 +1,54 @@
+from collections.abc import Sequence
+from typing import Optional, Protocol
+
+
+class _QuantizationConfigLike(Protocol):
+    @property
+    def quant_method(self) -> Optional[str]: ...
+
+    @property
+    def modules_to_not_convert(self) -> Optional[Sequence[str]]: ...
+
+
+class _ConfigWithQuantization(Protocol):
+    @property
+    def quantization_config(self) -> Optional[_QuantizationConfigLike]: ...
+
+
+def is_mxfp4_quantized(config: _ConfigWithQuantization) -> bool:
+    try:
+        quant_config = config.quantization_config
+    except AttributeError:
+        return False
+    if quant_config is None:
+        return False
+    return quant_config.quant_method == "mxfp4"
+
+
+def get_mxfp4_modules_to_not_convert(
+    config: _ConfigWithQuantization,
+) -> list[str]:
+    try:
+        quant_config = config.quantization_config
+    except AttributeError:
+        return []
+    if quant_config is None:
+        return []
+    modules = quant_config.modules_to_not_convert
+    if modules is None:
+        return []
+    if isinstance(modules, str):
+        return []
+    return list(modules)
+
+
+def identify_mxfp4_pairs(weight_names: Sequence[str]) -> list[tuple[str, str]]:
+    name_set = set(weight_names)
+    pairs: list[tuple[str, str]] = []
+    for name in weight_names:
+        if name.endswith("_blocks"):
+            base = name[: -len("_blocks")]
+            scales_name = f"{base}_scales"
+            if scales_name in name_set:
+                pairs.append((name, scales_name))
+    return pairs

--- a/tests/conftest_gpt_oss.py
+++ b/tests/conftest_gpt_oss.py
@@ -1,0 +1,84 @@
+"""
+Pytest fixtures for GPT-OSS unit tests.
+
+These fixtures provide synthetic (no-download) test data for GPT-OSS TDD.
+All tensor shapes match the real gpt-oss-20b model scaled down:
+  - num_experts: 4 (real: 32)
+  - hidden_size: 64 (real: 2880)
+  - intermediate_size: 64 (real: 2880)
+  - num_hidden_layers: 2 (real: 24)
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def gpt_oss_config():
+    """Minimal mock GptOssConfig for unit testing without downloading."""
+    cfg = MagicMock()
+    cfg.architectures = ["GptOssForCausalLM"]
+    cfg.model_type = "gpt_oss"
+    cfg.num_hidden_layers = 2
+    cfg.num_local_experts = 4
+    cfg.num_experts_per_tok = 2
+    cfg.hidden_size = 64
+    cfg.intermediate_size = 64
+    cfg.num_attention_heads = 4
+    cfg.num_key_value_heads = 2
+    cfg.head_dim = 16
+    cfg.vocab_size = 256
+    cfg.max_position_embeddings = 512
+    cfg.torch_dtype = torch.bfloat16
+    return cfg
+
+
+@pytest.fixture
+def gpt_oss_packed_weights():
+    """
+    Synthetic packed expert weight tensors matching GPT-OSS format.
+
+    Real shapes (scaled down for testing):
+      gate_up_proj: (num_experts, hidden_size, 2 * intermediate_size)
+      gate_up_proj_bias: (num_experts, 2 * intermediate_size)
+      down_proj: (num_experts, intermediate_size, hidden_size)
+      down_proj_bias: (num_experts, hidden_size)
+    """
+    E, H, I = 4, 64, 64  # num_experts, hidden_size, intermediate_size
+    return {
+        "model.layers.0.mlp.experts.gate_up_proj": torch.randn(E, H, 2 * I),
+        "model.layers.0.mlp.experts.gate_up_proj_bias": torch.randn(E, 2 * I),
+        "model.layers.0.mlp.experts.down_proj": torch.randn(E, I, H),
+        "model.layers.0.mlp.experts.down_proj_bias": torch.randn(E, H),
+        "model.layers.0.mlp.router.weight": torch.randn(E, H),
+        "model.layers.0.mlp.router.bias": torch.randn(E),
+        "model.layers.1.mlp.experts.gate_up_proj": torch.randn(E, H, 2 * I),
+        "model.layers.1.mlp.experts.gate_up_proj_bias": torch.randn(E, 2 * I),
+        "model.layers.1.mlp.experts.down_proj": torch.randn(E, I, H),
+        "model.layers.1.mlp.experts.down_proj_bias": torch.randn(E, H),
+        "model.layers.1.mlp.router.weight": torch.randn(E, H),
+        "model.layers.1.mlp.router.bias": torch.randn(E),
+    }
+
+
+@pytest.fixture
+def gpt_oss_router_output():
+    """
+    Synthetic GptOssTopKRouter output: (router_scores, router_indices).
+
+    Matches output of GptOssTopKRouter.forward():
+      router_scores: (batch * seq_len, num_experts) — sparse softmax scores
+      router_indices: (batch * seq_len, top_k) — selected expert indices
+    """
+    batch_seq, num_experts, top_k = 8, 4, 2
+    # Sparse scores: zeros except for selected experts
+    router_scores = torch.zeros(batch_seq, num_experts)
+    router_indices = torch.randint(0, num_experts, (batch_seq, top_k))
+    # Fill selected positions with random weights summing to 1
+    for i in range(batch_seq):
+        weights = torch.rand(top_k)
+        weights = weights / weights.sum()
+        router_scores[i, router_indices[i]] = weights
+    return router_scores, router_indices

--- a/tests/docker/run_tests.py
+++ b/tests/docker/run_tests.py
@@ -8,6 +8,7 @@ Test orchestrator for MoE-Infinity I/O integration tests.
 4. Reports summary, exits non-zero on failure.
 """
 
+import os
 import subprocess
 import sys
 
@@ -65,6 +66,20 @@ def main():
     else:
         print("\nCUDA not available — skipping Tier 2 tests")
 
+    # Run Tier 3 if CUDA is available and GPT_OSS_E2E env var is set
+    tier3_ok = True
+    if cuda_available and os.environ.get("GPT_OSS_E2E", "0") == "1":
+        tier3_ok = run_pytest(
+            "tests/docker/test_gpt_oss_e2e.py",
+            "cuda",
+            "Tier 3: GPT-OSS 20b E2E (CUDA + Network)",
+        )
+    else:
+        if not cuda_available:
+            print("\nCUDA not available — skipping Tier 3 (GPT-OSS E2E)")
+        else:
+            print("\nGPT_OSS_E2E=1 not set — skipping Tier 3 (GPT-OSS E2E)")
+
     # Summary
     print(f"\n{'=' * 60}")
     print("  Test Summary")
@@ -75,8 +90,12 @@ def main():
         print(f"  Tier 2 (CUDA):    {'PASSED' if tier2_ok else 'FAILED'}")
     else:
         print("  Tier 2 (CUDA):    SKIPPED")
+    if cuda_available and os.environ.get("GPT_OSS_E2E", "0") == "1":
+        print(f"  Tier 3 (GPT-OSS): {'PASSED' if tier3_ok else 'FAILED'}")
+    else:
+        print("  Tier 3 (GPT-OSS): SKIPPED")
 
-    all_ok = tier1_ok and unit_ok and tier2_ok
+    all_ok = tier1_ok and unit_ok and tier2_ok and tier3_ok
     print(f"\n  Overall: {'PASSED' if all_ok else 'FAILED'}")
     print(f"{'=' * 60}")
     return 0 if all_ok else 1

--- a/tests/docker/test_gpt_oss_e2e.py
+++ b/tests/docker/test_gpt_oss_e2e.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+GPT-OSS 20b End-to-End integration test for MoE-Infinity.
+
+Requires: CUDA GPU with >=16GB VRAM, network access for model download.
+
+Run standalone:
+    python tests/docker/test_gpt_oss_e2e.py
+
+Run via Docker:
+    docker run --rm --gpus '"device=0"' \
+        -v $(pwd):/workspace/MoE-Infinity \
+        -v ~/.cache/huggingface:/root/.cache/huggingface \
+        -e HF_HOME=/root/.cache/huggingface \
+        -w /workspace/MoE-Infinity \
+        moe-infinity-test:latest \
+        bash -c "pip install --no-build-isolation -e . -q && python tests/docker/test_gpt_oss_e2e.py"
+
+Run via pytest (inside Docker):
+    pytest tests/docker/test_gpt_oss_e2e.py -v -m cuda
+"""
+
+import os
+import sys
+import time
+
+import pytest
+import torch
+
+CHECKPOINT = os.environ.get("GPT_OSS_CHECKPOINT", "openai/gpt-oss-20b")
+OFFLOAD_PATH = os.environ.get(
+    "GPT_OSS_OFFLOAD_PATH", "/tmp/gpt-oss-e2e-offload"
+)
+DEVICE_MEMORY_RATIO = float(
+    os.environ.get("GPT_OSS_DEVICE_MEMORY_RATIO", "0.75")
+)
+
+
+def _skip_if_no_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+
+# ── Test 1: Config parsing ──────────────────────────────────────────────────
+
+
+@pytest.mark.cuda
+def test_gpt_oss_config_parsing():
+    """GPT-OSS config correctly parsed: 24 layers, 32 experts."""
+    _skip_if_no_cuda()
+    from transformers import AutoConfig
+
+    from moe_infinity.common.constants import MODEL_MAPPING_NAMES
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    config = AutoConfig.from_pretrained(CHECKPOINT, trust_remote_code=True)
+    layers, experts, enc = parse_moe_param(config)
+    assert layers == 24, f"Expected 24 layers, got {layers}"
+    assert experts == 32, f"Expected 32 experts, got {experts}"
+    assert enc == 0
+
+    architectures = getattr(config, "architectures", None)
+    assert architectures, "Config architectures missing"
+    arch_str = architectures[0].lower()
+    matched = next((k for k in MODEL_MAPPING_NAMES if k in arch_str), None)
+    assert matched == "gptoss", f"Architecture not matched: {matched}"
+
+
+# ── Test 2: Model loading ───────────────────────────────────────────────────
+
+
+@pytest.mark.cuda
+def test_gpt_oss_model_loading():
+    """GPT-OSS 20b loads via MoE() entrypoint without error."""
+    _skip_if_no_cuda()
+    os.makedirs(OFFLOAD_PATH, exist_ok=True)
+
+    from moe_infinity import MoE
+
+    t0 = time.time()
+    model = MoE(
+        CHECKPOINT,
+        {
+            "offload_path": OFFLOAD_PATH,
+            "device_memory_ratio": DEVICE_MEMORY_RATIO,
+        },
+    )
+    load_time = time.time() - t0
+    print(f"\n  Load time: {load_time:.1f}s")
+    assert model is not None
+
+
+# ── Test 3: Text generation ─────────────────────────────────────────────────
+
+
+@pytest.mark.cuda
+def test_gpt_oss_text_generation():
+    """GPT-OSS 20b generates coherent text."""
+    _skip_if_no_cuda()
+    os.makedirs(OFFLOAD_PATH, exist_ok=True)
+
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+
+    tokenizer = AutoTokenizer.from_pretrained(CHECKPOINT)
+    model = MoE(
+        CHECKPOINT,
+        {
+            "offload_path": OFFLOAD_PATH,
+            "device_memory_ratio": DEVICE_MEMORY_RATIO,
+        },
+    )
+
+    prompt = "The capital of France is"
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to("cuda:0")
+
+    torch.cuda.reset_peak_memory_stats()
+    t0 = time.time()
+    with torch.no_grad():
+        output_ids = model.generate(input_ids, max_new_tokens=32)
+    gen_time = time.time() - t0
+
+    output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    peak_mb = torch.cuda.max_memory_allocated() / 1024**2
+
+    print(f"\n  Prompt:    '{prompt}'")
+    print(f"  Generated: '{output_text}'")
+    print(f"  Time:      {gen_time:.1f}s")
+    print(f"  Peak GPU:  {peak_mb:.0f} MB")
+
+    assert len(output_text) > len(prompt), "Model should generate new tokens"
+
+
+# ── Test 4: Memory reduction ───────────────────────────────────────────────
+
+
+@pytest.mark.cuda
+def test_gpt_oss_memory_reduction():
+    """Expert offloading should keep GPU memory well below full model size."""
+    _skip_if_no_cuda()
+    os.makedirs(OFFLOAD_PATH, exist_ok=True)
+
+    from moe_infinity import MoE
+
+    torch.cuda.reset_peak_memory_stats()
+    model = MoE(
+        CHECKPOINT,
+        {
+            "offload_path": OFFLOAD_PATH,
+            "device_memory_ratio": 0.5,
+        },
+    )
+
+    peak_mb = torch.cuda.max_memory_allocated() / 1024**2
+    gpu_total_mb = torch.cuda.get_device_properties(0).total_memory / 1024**2
+
+    print(f"\n  Peak GPU memory:  {peak_mb:.0f} MB")
+    print(f"  GPU total memory: {gpu_total_mb:.0f} MB")
+
+    # Full model bf16 is ~41GB. With offloading on a 24GB GPU it must fit.
+    assert peak_mb < gpu_total_mb * 0.95, (
+        f"Peak memory {peak_mb:.0f}MB is near GPU capacity {gpu_total_mb:.0f}MB — "
+        "offloading may not be working"
+    )
+
+
+# ── Standalone runner ───────────────────────────────────────────────────────
+
+
+def main():
+    """Run all tests as a standalone script with pretty output."""
+    if not torch.cuda.is_available():
+        print(
+            "ERROR: CUDA not available. Run inside a GPU-enabled Docker container."
+        )
+        return 1
+
+    print("=" * 60)
+    print("  GPT-OSS 20b End-to-End Test")
+    print("=" * 60)
+    print(f"  CUDA:         {torch.cuda.get_device_name(0)}")
+    print(
+        f"  GPU Memory:   {torch.cuda.get_device_properties(0).total_memory / 1024**3:.1f} GB"
+    )
+    print(f"  PyTorch:      {torch.__version__}")
+    print(f"  Checkpoint:   {CHECKPOINT}")
+    print(f"  Offload path: {OFFLOAD_PATH}")
+    print(f"  Memory ratio: {DEVICE_MEMORY_RATIO}")
+    print("=" * 60)
+
+    tests = [
+        ("Config parsing", test_gpt_oss_config_parsing),
+        ("Model loading", test_gpt_oss_model_loading),
+        ("Text generation", test_gpt_oss_text_generation),
+        ("Memory reduction", test_gpt_oss_memory_reduction),
+    ]
+
+    results = []
+    for name, test_fn in tests:
+        print(f"\n[TEST] {name}...")
+        try:
+            test_fn()
+            print(f"  ✅ {name} PASS")
+            results.append((name, True, None))
+        except Exception as e:
+            print(f"  ❌ {name} FAIL: {e}")
+            results.append((name, False, str(e)))
+
+    print("\n" + "=" * 60)
+    print("  Summary")
+    print("=" * 60)
+    all_pass = True
+    for name, passed, err in results:
+        status = "PASS" if passed else f"FAIL: {err}"
+        print(f"  {'✅' if passed else '❌'} {name}: {status}")
+        if not passed:
+            all_pass = False
+
+    print("=" * 60)
+    if all_pass:
+        print("  ALL TESTS PASSED")
+    else:
+        print("  SOME TESTS FAILED")
+    print("=" * 60)
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/python/serving/test_kv_cache.py
+++ b/tests/python/serving/test_kv_cache.py
@@ -49,6 +49,8 @@ class PagedKVCacheProtocol(Protocol):
 
     def free_sequence(self, seq_id: int) -> None: ...
 
+    def free_gpu_blocks(self, seq_id: int) -> None: ...
+
     def get_block_table(self, seq_id: int) -> list[int]: ...
 
     def swap_out(self, seq_id: int) -> None: ...
@@ -169,3 +171,52 @@ def test_free_sequence_returns_blocks():
 
     cache.free_sequence(2)
     assert cache.block_allocator.num_free_blocks == 8
+
+
+def test_free_gpu_blocks_releases_blocks():
+    _, PagedKVCache = _load_classes()
+    cache = PagedKVCache(
+        num_blocks=4,
+        block_size=4,
+        num_layers=1,
+        num_heads=2,
+        head_dim=8,
+        dtype=torch.float16,
+    )
+
+    cache.allocate_sequence(seq_id=1, num_tokens=8)
+    assert cache.block_allocator.num_free_blocks == 2
+
+    cache.free_gpu_blocks(1)
+    assert cache.block_allocator.num_free_blocks == 4
+    assert cache.get_block_table(1) == []
+
+
+def test_swap_out_free_gpu_blocks_swap_in_round_trip():
+    _, PagedKVCache = _load_classes()
+    cache = PagedKVCache(
+        num_blocks=4,
+        block_size=4,
+        num_layers=1,
+        num_heads=2,
+        head_dim=8,
+        dtype=torch.float16,
+    )
+
+    cache.allocate_sequence(seq_id=1, num_tokens=8)
+    assert cache.block_allocator.num_free_blocks == 2
+
+    cache.swap_out(1)
+    cache.free_gpu_blocks(1)
+    assert cache.block_allocator.num_free_blocks == 4
+
+    cache.allocate_sequence(seq_id=2, num_tokens=4)
+    assert cache.block_allocator.num_free_blocks == 3
+
+    cache.swap_in(1)
+    assert cache.block_allocator.num_free_blocks == 1
+    assert len(cache.get_block_table(1)) == 2
+
+    cache.free_sequence(1)
+    cache.free_sequence(2)
+    assert cache.block_allocator.num_free_blocks == 4

--- a/tests/python/unit/test_kv_swap_recovery.py
+++ b/tests/python/unit/test_kv_swap_recovery.py
@@ -64,6 +64,8 @@ def test_swap_recovery_lifecycle() -> None:
     assert 1 in preempt_cycle.preempted_seq_ids
     assert group1.sequences[0].status is SequenceStatus.SWAPPED
 
+    scheduler.update_after_step(completed_seq_ids=[2], new_decode_seq_ids=[])
+
     recovery_cycle = scheduler.schedule()
     assert group1.sequences[0].status is SequenceStatus.DECODE
     assert 1 in recovery_cycle.decode_seq_ids
@@ -108,4 +110,5 @@ def test_free_gpu_blocks_preserves_cpu_buffer() -> None:
 
     assert 33 in swapped_cpu_buffers
     assert 33 in sequence_tables
-    assert kv_cache.get_block_table(33)
+    assert kv_cache.get_block_table(33) == []
+    assert kv_cache.block_allocator.num_free_blocks == 2

--- a/tests/python/unit/test_model_registry.py
+++ b/tests/python/unit/test_model_registry.py
@@ -18,6 +18,7 @@ def test_all_models_registered():
         "arctic",
         "deepseek",
         "deepseek_v3",
+        "gptoss",
         "qwen3",
         "dbrx",
         "olmoe",

--- a/tests/test_gpt_oss_config.py
+++ b/tests/test_gpt_oss_config.py
@@ -70,6 +70,16 @@ def test_parse_expert_id_gpt_oss_down_proj():
     assert expert_id is None
 
 
+def test_parse_expert_dtype_gpt_oss_none():
+    from moe_infinity.utils.hf_config import parse_expert_dtype
+
+    config = MagicMock()
+    config.torch_dtype = None
+    config.dtype = None
+    result = parse_expert_dtype(config)
+    assert result == 0, f"Expected 0 (bfloat16), got {result}"
+
+
 def test_gpt_oss_model_mapping():
     MODEL_MAPPING_NAMES = import_constants_module().MODEL_MAPPING_NAMES
     from transformers import GptOssForCausalLM

--- a/tests/test_gpt_oss_config.py
+++ b/tests/test_gpt_oss_config.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock
+
+
+def make_gpt_oss_config():
+    cfg = MagicMock()
+    cfg.architectures = ["GptOssForCausalLM"]
+    cfg.model_type = "gpt_oss"
+    cfg.num_hidden_layers = 24
+    cfg.num_local_experts = 32
+    cfg.num_experts_per_tok = 4
+    cfg.hidden_size = 2880
+    cfg.intermediate_size = 2880
+    return cfg
+
+
+def test_parse_moe_param_gpt_oss():
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    config = make_gpt_oss_config()
+    num_layers, num_experts, num_encoder_layers = parse_moe_param(config)
+    assert num_layers == 24
+    assert num_experts == 32
+    assert num_encoder_layers == 0
+
+
+def test_parse_expert_id_gpt_oss_packed():
+    from moe_infinity.utils.hf_config import parse_expert_id
+
+    config = make_gpt_oss_config()
+    layer_id, expert_id = parse_expert_id(
+        "model.layers.5.mlp.experts.gate_up_proj_blocks", config
+    )
+    assert layer_id == 5
+    assert expert_id is None
+
+
+def test_parse_expert_id_gpt_oss_router():
+    from moe_infinity.utils.hf_config import parse_expert_id
+
+    config = make_gpt_oss_config()
+    layer_id, expert_id = parse_expert_id(
+        "model.layers.5.mlp.router.weight", config
+    )
+    assert layer_id is None
+    assert expert_id is None
+
+
+def test_parse_expert_id_gpt_oss_down_proj():
+    from moe_infinity.utils.hf_config import parse_expert_id
+
+    config = make_gpt_oss_config()
+    layer_id, expert_id = parse_expert_id(
+        "model.layers.11.mlp.experts.down_proj_blocks", config
+    )
+    assert layer_id == 11
+    assert expert_id is None

--- a/tests/test_gpt_oss_config.py
+++ b/tests/test_gpt_oss_config.py
@@ -1,6 +1,20 @@
 from unittest.mock import MagicMock
 
 
+def import_constants_module():
+    import importlib.machinery
+    import sys
+    import types
+
+    module = types.ModuleType("flash_attn")
+    module.__spec__ = importlib.machinery.ModuleSpec("flash_attn", loader=None)
+    sys.modules["flash_attn"] = module
+
+    from moe_infinity.common import constants
+
+    return constants
+
+
 def make_gpt_oss_config():
     cfg = MagicMock()
     cfg.architectures = ["GptOssForCausalLM"]
@@ -54,3 +68,34 @@ def test_parse_expert_id_gpt_oss_down_proj():
     )
     assert layer_id == 11
     assert expert_id is None
+
+
+def test_gpt_oss_model_mapping():
+    MODEL_MAPPING_NAMES = import_constants_module().MODEL_MAPPING_NAMES
+    from transformers import GptOssForCausalLM
+
+    assert (
+        "gptoss" in MODEL_MAPPING_NAMES
+    ), "gptoss key missing from MODEL_MAPPING_NAMES"
+    assert MODEL_MAPPING_NAMES["gptoss"] is GptOssForCausalLM
+
+
+def test_gpt_oss_model_type():
+    MODEL_MAPPING_TYPES = import_constants_module().MODEL_MAPPING_TYPES
+
+    assert (
+        "gptoss" in MODEL_MAPPING_TYPES
+    ), "gptoss key missing from MODEL_MAPPING_TYPES"
+    assert MODEL_MAPPING_TYPES["gptoss"] == 4
+
+
+def test_gpt_oss_arch_string_matching():
+    MODEL_MAPPING_NAMES = import_constants_module().MODEL_MAPPING_NAMES
+
+    arch_str = "gptossforcausallm"
+    matched = None
+    for k in MODEL_MAPPING_NAMES:
+        if k in arch_str:
+            matched = k
+            break
+    assert matched == "gptoss", f"Expected 'gptoss' to match, got: {matched}"

--- a/tests/test_gpt_oss_config.py
+++ b/tests/test_gpt_oss_config.py
@@ -99,3 +99,27 @@ def test_gpt_oss_arch_string_matching():
             matched = k
             break
     assert matched == "gptoss", f"Expected 'gptoss' to match, got: {matched}"
+
+
+def test_gpt_oss_flash_attn_excluded_in_big_modeling():
+    import re
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "moe_infinity"
+        / "entrypoints"
+        / "big_modeling.py"
+    )
+    content = source.read_text(encoding="utf-8")
+
+    exclusion_pattern = (
+        r"if\s*\([\s\S]*arch\s*==\s*\"deepseek\"[\s\S]*"
+        r"arch\s*==\s*\"deepseek_v3\"[\s\S]*"
+        r"arch\s*==\s*\"nllb\"[\s\S]*"
+        r"arch\s*==\s*\"gptoss\"[\s\S]*\):\s*"
+        r"is_flash_attn_available\s*=\s*False"
+    )
+    assert re.search(
+        exclusion_pattern, content
+    ), "big_modeling.py must exclude gptoss from flash attention"

--- a/tests/test_gpt_oss_correctness.py
+++ b/tests/test_gpt_oss_correctness.py
@@ -1,0 +1,136 @@
+import importlib.machinery
+import os
+import sys
+import types
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+def _ensure_flash_attn_stub_has_spec() -> None:
+    flash_attn_module = sys.modules.get("flash_attn")
+    if flash_attn_module is None:
+        flash_attn_module = types.ModuleType("flash_attn")
+        flash_attn_module.__spec__ = importlib.machinery.ModuleSpec(
+            "flash_attn", loader=None
+        )
+        sys.modules["flash_attn"] = flash_attn_module
+    elif getattr(flash_attn_module, "__spec__", None) is None:
+        flash_attn_module.__spec__ = importlib.machinery.ModuleSpec(
+            "flash_attn", loader=None
+        )
+
+
+_ensure_flash_attn_stub_has_spec()
+
+
+def test_sync_gpt_oss_mlp_forward_shape():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = MagicMock()
+    config.hidden_size = 64
+    config.intermediate_size = 64
+    config.num_local_experts = 4
+    config.num_experts_per_tok = 2
+
+    mlp = SyncGptOssMLP(config)
+    torch.nn.init.normal_(mlp.gate_up_proj)
+    torch.nn.init.normal_(mlp.down_proj)
+    torch.nn.init.zeros_(mlp.gate_up_proj_bias)
+    torch.nn.init.zeros_(mlp.down_proj_bias)
+    torch.nn.init.normal_(mlp.router.weight)
+    torch.nn.init.zeros_(mlp.router.bias)
+
+    hidden = torch.randn(1, 3, 64)
+    with torch.no_grad():
+        output, router_logits = mlp(hidden)
+
+    assert output.shape == (1, 3, 64)
+    assert router_logits.shape == (3, 4)
+
+
+def test_sync_gpt_oss_mlp_router_logits_shape():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = MagicMock()
+    config.hidden_size = 32
+    config.intermediate_size = 32
+    config.num_local_experts = 8
+    config.num_experts_per_tok = 2
+
+    mlp = SyncGptOssMLP(config)
+    for param in mlp.parameters():
+        torch.nn.init.normal_(param, std=0.01)
+
+    hidden = torch.randn(2, 5, 32)
+    with torch.no_grad():
+        _, router_logits = mlp(hidden)
+
+    assert router_logits.shape == (10, 8)
+
+
+def test_gptoss_architecture_in_constants():
+    from moe_infinity.common.constants import MODEL_MAPPING_NAMES
+
+    assert "gptoss" in MODEL_MAPPING_NAMES
+    arch_str = "gptossforcausallm"
+    matched = next(
+        (key for key in MODEL_MAPPING_NAMES if key in arch_str), None
+    )
+    assert matched == "gptoss"
+
+
+def test_gptoss_parse_moe_param():
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    config = MagicMock()
+    config.architectures = ["GptOssForCausalLM"]
+    config.num_hidden_layers = 24
+    config.num_local_experts = 32
+
+    layers, experts, enc_layers = parse_moe_param(config)
+    assert layers == 24
+    assert experts == 32
+    assert enc_layers == 0
+
+
+@pytest.mark.gpu
+@pytest.mark.network
+@pytest.mark.slow
+def test_gpt_oss_20b_forward_parity():
+    from transformers import AutoTokenizer, GptOssForCausalLM
+
+    from moe_infinity import MoE
+
+    checkpoint = "openai/gpt-oss-20b"
+    offload_path = os.path.expanduser("~/moe-infinity-gpt-oss-parity")
+
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+    inputs = tokenizer("What is 2+2?", return_tensors="pt").to("cuda:0")
+
+    ref_model = cast(
+        torch.nn.Module,
+        GptOssForCausalLM.from_pretrained(
+            checkpoint, torch_dtype=torch.bfloat16
+        ),
+    )
+    ref_model = ref_model.to("cuda:0")
+    with torch.no_grad():
+        ref_out = ref_model(**inputs).logits.cpu()
+    del ref_model
+
+    model = MoE(
+        checkpoint,
+        {
+            "offload_path": offload_path,
+            "device_memory_ratio": 0.75,
+        },
+    )
+    with torch.no_grad():
+        moe_out = model.model(**inputs).logits.cpu()
+
+    assert torch.allclose(
+        ref_out, moe_out, atol=1e-2
+    ), f"Parity check failed. Max diff: {(ref_out - moe_out).abs().max():.4f}"

--- a/tests/test_gpt_oss_correctness.py
+++ b/tests/test_gpt_oss_correctness.py
@@ -36,10 +36,10 @@ def test_sync_gpt_oss_mlp_forward_shape():
     config.num_experts_per_tok = 2
 
     mlp = SyncGptOssMLP(config)
-    torch.nn.init.normal_(mlp.gate_up_proj)
-    torch.nn.init.normal_(mlp.down_proj)
-    torch.nn.init.zeros_(mlp.gate_up_proj_bias)
-    torch.nn.init.zeros_(mlp.down_proj_bias)
+    torch.nn.init.normal_(mlp.experts.gate_up_proj)
+    torch.nn.init.normal_(mlp.experts.down_proj)
+    torch.nn.init.zeros_(mlp.experts.gate_up_proj_bias)
+    torch.nn.init.zeros_(mlp.experts.down_proj_bias)
     torch.nn.init.normal_(mlp.router.weight)
     torch.nn.init.zeros_(mlp.router.bias)
 

--- a/tests/test_gpt_oss_e2e.py
+++ b/tests/test_gpt_oss_e2e.py
@@ -1,0 +1,133 @@
+import importlib.machinery
+import inspect
+import os
+import sys
+import types
+
+import pytest
+
+
+def _ensure_flash_attn_stub_has_spec() -> None:
+    flash_attn_module = sys.modules.get("flash_attn")
+    if flash_attn_module is None:
+        flash_attn_module = types.ModuleType("flash_attn")
+        flash_attn_module.__spec__ = importlib.machinery.ModuleSpec(
+            "flash_attn", loader=None
+        )
+        sys.modules["flash_attn"] = flash_attn_module
+    elif getattr(flash_attn_module, "__spec__", None) is None:
+        flash_attn_module.__spec__ = importlib.machinery.ModuleSpec(
+            "flash_attn", loader=None
+        )
+
+
+_ensure_flash_attn_stub_has_spec()
+
+
+def test_gpt_oss_all_components_importable():
+    from moe_infinity.common.constants import MODEL_MAPPING_NAMES
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+    from moe_infinity.utils.hf_config import parse_expert_id, parse_moe_param
+    from moe_infinity.utils.mxfp4 import (
+        get_mxfp4_modules_to_not_convert,
+        identify_mxfp4_pairs,
+        is_mxfp4_quantized,
+    )
+
+    assert "gptoss" in MODEL_MAPPING_NAMES
+    assert SyncGptOssMLP is not None
+    assert callable(is_mxfp4_quantized)
+    assert callable(get_mxfp4_modules_to_not_convert)
+    assert callable(identify_mxfp4_pairs)
+    assert callable(parse_moe_param)
+    assert callable(parse_expert_id)
+
+
+def test_gpt_oss_monkey_patch_module_accessible():
+    import transformers.models.gpt_oss.modeling_gpt_oss as mod
+
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    assert hasattr(mod, "GptOssMLP")
+    assert mod.GptOssMLP is not SyncGptOssMLP
+
+
+def test_gpt_oss_120b_config_parseable():
+    from unittest.mock import MagicMock
+
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    config_120b = MagicMock()
+    config_120b.architectures = ["GptOssForCausalLM"]
+    config_120b.model_type = "gpt_oss"
+    config_120b.num_hidden_layers = 94
+    config_120b.num_local_experts = 128
+    config_120b.num_experts_per_tok = 4
+
+    layers, experts, enc_layers = parse_moe_param(config_120b)
+    assert layers == 94
+    assert experts == 128
+    assert enc_layers == 0
+
+
+def test_gpt_oss_model_offload_has_gptoss_patches():
+    import moe_infinity.runtime.model_offload as mod
+
+    source = inspect.getsource(mod)
+    assert "gpt_oss.modeling_gpt_oss" in source
+    assert "GptOssMLP = SyncGptOssMLP" in source
+    assert "_old_gpt_oss_mlp" in source
+
+
+@pytest.mark.gpu
+@pytest.mark.network
+@pytest.mark.slow
+@pytest.mark.integration
+def test_gpt_oss_20b_e2e():
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+
+    checkpoint = "openai/gpt-oss-20b"
+    offload_path = os.path.expanduser("~/moe-infinity-gpt-oss-e2e")
+    tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+
+    model = MoE(
+        checkpoint,
+        {
+            "offload_path": offload_path,
+            "device_memory_ratio": 0.75,
+        },
+    )
+
+    prompt = "Explain quantum mechanics in one sentence."
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to("cuda:0")
+    output_ids = model.generate(input_ids, max_new_tokens=32)
+    output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    assert len(output_text) > len(prompt)
+
+
+@pytest.mark.network
+@pytest.mark.slow
+@pytest.mark.integration
+def test_gpt_oss_120b_config():
+    from transformers import AutoConfig
+
+    from moe_infinity.common.constants import MODEL_MAPPING_NAMES
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    config = AutoConfig.from_pretrained(
+        "openai/gpt-oss-120b", trust_remote_code=True
+    )
+    layers, experts, enc_layers = parse_moe_param(config)
+    assert layers > 0
+    assert experts > 0
+    assert enc_layers == 0
+
+    architectures = config.architectures or []
+    assert architectures
+    arch_str = architectures[0].lower()
+    matched = next(
+        (key for key in MODEL_MAPPING_NAMES if key in arch_str), None
+    )
+    assert matched == "gptoss"

--- a/tests/test_gpt_oss_memory.py
+++ b/tests/test_gpt_oss_memory.py
@@ -1,0 +1,65 @@
+import os
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+def test_sync_gpt_oss_mlp_packed_param_count():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = MagicMock()
+    config.hidden_size = 64
+    config.intermediate_size = 64
+    config.num_local_experts = 8
+    config.num_experts_per_tok = 2
+
+    mlp = SyncGptOssMLP(config)
+    experts, hidden, intermediate = 8, 64, 64
+
+    assert mlp.gate_up_proj.shape == (experts, hidden, 2 * intermediate)
+    assert mlp.down_proj.shape == (experts, intermediate, hidden)
+
+    total_expert_params = experts * (
+        hidden * 2 * intermediate
+        + 2 * intermediate
+        + intermediate * hidden
+        + hidden
+    )
+    actual_expert_params = sum(
+        param.numel()
+        for name, param in mlp.named_parameters()
+        if "proj" in name
+    )
+    assert actual_expert_params == total_expert_params
+
+
+def test_gptoss_offload_config_accepted():
+    ratio = 0.75
+    config = {
+        "offload_path": "/tmp/gpt-oss-test",
+        "device_memory_ratio": ratio,
+    }
+    assert "offload_path" in config
+    assert 0 < ratio < 1.0
+
+
+@pytest.mark.gpu
+@pytest.mark.network
+@pytest.mark.slow
+def test_gpt_oss_offloading_reduces_memory():
+    from moe_infinity import MoE
+
+    checkpoint = "openai/gpt-oss-20b"
+    offload_path = os.path.expanduser("~/moe-infinity-gpt-oss-memory")
+
+    torch.cuda.reset_peak_memory_stats()
+    MoE(
+        checkpoint,
+        {
+            "offload_path": offload_path,
+            "device_memory_ratio": 0.5,
+        },
+    )
+    peak_mb = torch.cuda.max_memory_allocated() / 1024**2
+    assert peak_mb < 12000

--- a/tests/test_gpt_oss_memory.py
+++ b/tests/test_gpt_oss_memory.py
@@ -17,8 +17,16 @@ def test_sync_gpt_oss_mlp_packed_param_count():
     mlp = SyncGptOssMLP(config)
     experts, hidden, intermediate = 8, 64, 64
 
-    assert mlp.gate_up_proj.shape == (experts, hidden, 2 * intermediate)
-    assert mlp.down_proj.shape == (experts, intermediate, hidden)
+    assert mlp.experts.gate_up_proj.shape == (
+        experts,
+        hidden,
+        2 * intermediate,
+    )
+    assert mlp.experts.down_proj.shape == (
+        experts,
+        intermediate,
+        hidden,
+    )
 
     total_expert_params = experts * (
         hidden * 2 * intermediate

--- a/tests/test_gpt_oss_monkey_patch.py
+++ b/tests/test_gpt_oss_monkey_patch.py
@@ -1,0 +1,71 @@
+"""TDD tests for GptOssMLP monkey-patching in OffloadEngine."""
+
+import importlib.machinery
+import sys
+
+
+def _ensure_flash_attn_stub_has_spec():
+    flash_attn_module = sys.modules.get("flash_attn")
+    if (
+        flash_attn_module is not None
+        and getattr(flash_attn_module, "__spec__", None) is None
+    ):
+        flash_attn_module.__spec__ = importlib.machinery.ModuleSpec(
+            "flash_attn", loader=None
+        )
+
+
+def test_gpt_oss_mlp_original_exists():
+    """Original GptOssMLP must be accessible in transformers."""
+    _ensure_flash_attn_stub_has_spec()
+    import transformers.models.gpt_oss.modeling_gpt_oss as mod
+
+    assert hasattr(mod, "GptOssMLP"), "GptOssMLP must exist in transformers"
+    original = mod.GptOssMLP
+    assert original.__name__ == "GptOssMLP"
+
+
+def test_sync_gpt_oss_mlp_is_different_from_original():
+    """SyncGptOssMLP must be a different class from GptOssMLP."""
+    _ensure_flash_attn_stub_has_spec()
+    import transformers.models.gpt_oss.modeling_gpt_oss as mod
+
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    assert (
+        mod.GptOssMLP is not SyncGptOssMLP
+    ), "SyncGptOssMLP must be different from GptOssMLP (before patching)"
+
+
+def test_monkey_patch_mechanism():
+    """Verify the monkey-patch mechanism works correctly (save/replace/restore)."""
+    _ensure_flash_attn_stub_has_spec()
+    import transformers.models.gpt_oss.modeling_gpt_oss as mod
+
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    original = mod.GptOssMLP
+
+    # Simulate patch
+    setattr(mod, "_old_gpt_oss_mlp", mod.GptOssMLP)
+    mod.GptOssMLP = SyncGptOssMLP
+
+    try:
+        assert (
+            mod.GptOssMLP is SyncGptOssMLP
+        ), "After patch: GptOssMLP should be SyncGptOssMLP"
+        assert (
+            getattr(mod, "_old_gpt_oss_mlp") is original
+        ), "Saved original must match"
+    finally:
+        # Simulate restore
+        mod.GptOssMLP = getattr(mod, "_old_gpt_oss_mlp")
+        delattr(mod, "_old_gpt_oss_mlp")
+
+    # After restore
+    assert (
+        mod.GptOssMLP is original
+    ), "After restore: GptOssMLP should be original"
+    assert not hasattr(
+        mod, "_old_gpt_oss_mlp"
+    ), "Backup should be deleted after restore"

--- a/tests/test_gpt_oss_wrapper.py
+++ b/tests/test_gpt_oss_wrapper.py
@@ -1,0 +1,101 @@
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock
+
+import torch
+
+flash_attn_mod = sys.modules.get("flash_attn")
+if flash_attn_mod is None:
+    flash_attn_mod = types.ModuleType("flash_attn")
+    flash_attn_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "flash_attn", loader=None
+    )
+    sys.modules["flash_attn"] = flash_attn_mod
+elif getattr(flash_attn_mod, "__spec__", None) is None:
+    flash_attn_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "flash_attn", loader=None
+    )
+
+
+def make_gpt_oss_config():
+    cfg = MagicMock()
+    cfg.architectures = ["GptOssForCausalLM"]
+    cfg.model_type = "gpt_oss"
+    cfg.num_hidden_layers = 2
+    cfg.num_local_experts = 4
+    cfg.num_experts_per_tok = 2
+    cfg.hidden_size = 64
+    cfg.intermediate_size = 64
+    cfg.num_attention_heads = 4
+    cfg.num_key_value_heads = 2
+    cfg.head_dim = 16
+    cfg.vocab_size = 256
+    return cfg
+
+
+def test_sync_gpt_oss_mlp_instantiation():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = make_gpt_oss_config()
+    mlp = SyncGptOssMLP(config)
+
+    assert hasattr(mlp, "expert_executor"), "Must have expert_executor"
+    assert hasattr(mlp, "archer_tracer"), "Must have archer_tracer"
+    assert hasattr(mlp, "archer_engine"), "Must have archer_engine"
+    assert hasattr(mlp, "expert_tensor_ids"), "Must have expert_tensor_ids"
+    assert hasattr(mlp, "layer_id"), "Must have layer_id"
+
+    assert hasattr(mlp, "gate_up_proj"), "Must have gate_up_proj parameter"
+    assert hasattr(mlp, "down_proj"), "Must have down_proj parameter"
+    assert hasattr(mlp, "router"), "Must have router"
+
+    E, H, I = 4, 64, 64
+    assert mlp.gate_up_proj.shape == (
+        E,
+        H,
+        2 * I,
+    ), f"Expected ({E}, {H}, {2 * I}), got {mlp.gate_up_proj.shape}"
+    assert mlp.down_proj.shape == (
+        E,
+        I,
+        H,
+    ), f"Expected ({E}, {I}, {H}), got {mlp.down_proj.shape}"
+
+
+def test_sync_gpt_oss_mlp_swiglu_activation():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = make_gpt_oss_config()
+    mlp = SyncGptOssMLP(config)
+
+    gate = torch.tensor([1.0, 8.0, -3.0])
+    up = torch.tensor([0.5, -9.0, 2.0])
+    alpha = 1.702
+
+    gate_clamped = gate.clamp(max=7.0)
+    up_clamped = up.clamp(-7.0, 7.0)
+    expected = (up_clamped + 1) * (
+        gate_clamped * torch.sigmoid(gate_clamped * alpha)
+    )
+
+    result = mlp._swiglu(gate, up)
+    assert torch.allclose(
+        result, expected, atol=1e-6
+    ), f"SwiGLU mismatch: {result} vs {expected}"
+
+    assert gate_clamped[1] == 7.0, "Gate must be clamped to 7.0"
+    assert up_clamped[1] == -7.0, "Up must be clamped to -7.0"
+
+
+def test_sync_gpt_oss_mlp_router_has_bias():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = make_gpt_oss_config()
+    mlp = SyncGptOssMLP(config)
+
+    assert hasattr(mlp.router, "bias"), "Router must have bias attribute"
+    assert mlp.router.bias is not None, "Router bias must not be None"
+    assert mlp.router.bias.shape == (
+        config.num_local_experts,
+    ), f"Router bias shape must be ({config.num_local_experts},)"

--- a/tests/test_gpt_oss_wrapper.py
+++ b/tests/test_gpt_oss_wrapper.py
@@ -46,21 +46,26 @@ def test_sync_gpt_oss_mlp_instantiation():
     assert hasattr(mlp, "expert_tensor_ids"), "Must have expert_tensor_ids"
     assert hasattr(mlp, "layer_id"), "Must have layer_id"
 
-    assert hasattr(mlp, "gate_up_proj"), "Must have gate_up_proj parameter"
-    assert hasattr(mlp, "down_proj"), "Must have down_proj parameter"
+    assert hasattr(mlp, "experts"), "Must have experts submodule"
+    assert hasattr(
+        mlp.experts, "gate_up_proj"
+    ), "Must have experts.gate_up_proj parameter"
+    assert hasattr(
+        mlp.experts, "down_proj"
+    ), "Must have experts.down_proj parameter"
     assert hasattr(mlp, "router"), "Must have router"
 
     E, H, I = 4, 64, 64
-    assert mlp.gate_up_proj.shape == (
+    assert mlp.experts.gate_up_proj.shape == (
         E,
         H,
         2 * I,
-    ), f"Expected ({E}, {H}, {2 * I}), got {mlp.gate_up_proj.shape}"
-    assert mlp.down_proj.shape == (
+    ), f"Expected ({E}, {H}, {2 * I}), got {mlp.experts.gate_up_proj.shape}"
+    assert mlp.experts.down_proj.shape == (
         E,
         I,
         H,
-    ), f"Expected ({E}, {I}, {H}), got {mlp.down_proj.shape}"
+    ), f"Expected ({E}, {I}, {H}), got {mlp.experts.down_proj.shape}"
 
 
 def test_sync_gpt_oss_mlp_swiglu_activation():

--- a/tests/test_mxfp4.py
+++ b/tests/test_mxfp4.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class QuantizationConfig:
+    quant_method: str
+    modules_to_not_convert: list[str]
+
+
+@dataclass
+class ModelConfig:
+    model_type: str
+    quantization_config: Optional[QuantizationConfig]
+
+
+def make_mxfp4_config():
+    return ModelConfig(
+        model_type="gpt_oss",
+        quantization_config=QuantizationConfig(
+            quant_method="mxfp4",
+            modules_to_not_convert=[
+                "model.layers.*.self_attn",
+                "model.layers.*.mlp.router",
+                "model.embed_tokens",
+                "lm_head",
+            ],
+        ),
+    )
+
+
+def make_non_quantized_config():
+    return ModelConfig(model_type="mixtral", quantization_config=None)
+
+
+def test_is_mxfp4_quantized_positive():
+    from moe_infinity.utils.mxfp4 import is_mxfp4_quantized
+
+    config = make_mxfp4_config()
+    assert is_mxfp4_quantized(config) is True
+
+
+def test_is_mxfp4_quantized_negative():
+    from moe_infinity.utils.mxfp4 import is_mxfp4_quantized
+
+    config = make_non_quantized_config()
+    assert is_mxfp4_quantized(config) is False
+
+
+def test_get_modules_to_not_convert():
+    from moe_infinity.utils.mxfp4 import get_mxfp4_modules_to_not_convert
+
+    config = make_mxfp4_config()
+    modules = get_mxfp4_modules_to_not_convert(config)
+    assert isinstance(modules, list)
+    assert len(modules) > 0
+    assert "model.embed_tokens" in modules
+    assert "lm_head" in modules
+
+
+def test_identify_mxfp4_pairs():
+    from moe_infinity.utils.mxfp4 import identify_mxfp4_pairs
+
+    weight_names = [
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        "model.layers.0.mlp.experts.down_proj_scales",
+        "model.layers.0.mlp.experts.down_proj_bias",
+        "model.layers.0.mlp.router.weight",
+        "model.layers.0.mlp.router.bias",
+    ]
+    pairs = identify_mxfp4_pairs(weight_names)
+    assert len(pairs) == 2
+    for blocks_name, scales_name in pairs:
+        assert blocks_name.endswith("_blocks")
+        assert scales_name.endswith("_scales")
+        assert blocks_name[: -len("_blocks")] == scales_name[: -len("_scales")]

--- a/tests/test_mxfp4_checkpoint.py
+++ b/tests/test_mxfp4_checkpoint.py
@@ -1,0 +1,41 @@
+def test_mxfp4_scales_tensors_skipped():
+    from moe_infinity.utils.mxfp4 import identify_mxfp4_pairs
+
+    weight_keys = [
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        "model.layers.0.mlp.experts.down_proj_scales",
+        "model.layers.0.mlp.experts.down_proj_bias",
+        "model.layers.0.mlp.router.weight",
+        "model.embed_tokens.weight",
+    ]
+
+    pairs = identify_mxfp4_pairs(weight_keys)
+    scales_keys = {scales for _, scales in pairs}
+    assert scales_keys == {
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        "model.layers.0.mlp.experts.down_proj_scales",
+    }
+
+
+def test_mxfp4_blocks_and_bias_remain():
+    weight_keys = [
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+    ]
+    filtered = [k for k in weight_keys if not k.endswith("_scales")]
+    assert "model.layers.0.mlp.experts.gate_up_proj_blocks" in filtered
+    assert "model.layers.0.mlp.experts.gate_up_proj_bias" in filtered
+    assert "model.layers.0.mlp.experts.gate_up_proj_scales" not in filtered
+
+
+def test_model_offload_has_mxfp4_handling():
+    from pathlib import Path
+
+    source = Path("moe_infinity/runtime/model_offload.py").read_text()
+    assert "identify_mxfp4_pairs" in source
+    assert 'k.endswith("_scales")' in source
+    assert 'k.endswith("_blocks")' in source

--- a/tests/test_packed_experts.py
+++ b/tests/test_packed_experts.py
@@ -1,0 +1,79 @@
+import importlib.machinery
+import sys
+import types
+from unittest.mock import MagicMock
+
+import torch
+import torch.nn as nn
+
+flash_attn_mod = sys.modules.get("flash_attn")
+if flash_attn_mod is None:
+    flash_attn_mod = types.ModuleType("flash_attn")
+    flash_attn_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "flash_attn", loader=None
+    )
+    sys.modules["flash_attn"] = flash_attn_mod
+elif getattr(flash_attn_mod, "__spec__", None) is None:
+    flash_attn_mod.__spec__ = importlib.machinery.ModuleSpec(
+        "flash_attn", loader=None
+    )
+
+
+def make_gpt_oss_config():
+    cfg = MagicMock()
+    cfg.architectures = ["GptOssForCausalLM"]
+    cfg.model_type = "gpt_oss"
+    cfg.num_hidden_layers = 2
+    cfg.num_local_experts = 4
+    cfg.num_experts_per_tok = 2
+    cfg.hidden_size = 64
+    cfg.intermediate_size = 64
+    cfg.num_attention_heads = 4
+    cfg.num_key_value_heads = 2
+    cfg.head_dim = 16
+    cfg.vocab_size = 256
+    return cfg
+
+
+def test_sync_gpt_oss_mlp_is_imported_in_model_offload():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    assert issubclass(SyncGptOssMLP, nn.Module)
+
+
+def test_packed_expert_slice_shape():
+    e, h, i = 4, 64, 64
+    gate_up_proj = torch.randn(e, h, 2 * i)
+    down_proj = torch.randn(e, i, h)
+
+    expert_idx = 2
+    gate_up_slice = gate_up_proj[expert_idx]
+    down_slice = down_proj[expert_idx]
+
+    assert gate_up_slice.shape == (
+        h,
+        2 * i,
+    ), f"Expected ({h}, {2 * i}), got {gate_up_slice.shape}"
+    assert down_slice.shape == (
+        i,
+        h,
+    ), f"Expected ({i}, {h}), got {down_slice.shape}"
+    assert torch.equal(gate_up_slice, gate_up_proj[2])
+
+
+def test_sync_gpt_oss_mlp_isinstance_detection():
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+
+    config = make_gpt_oss_config()
+    mlp = SyncGptOssMLP(config)
+
+    assert isinstance(mlp, SyncGptOssMLP), "isinstance check must work"
+    assert isinstance(mlp, nn.Module), "Must be nn.Module subclass"
+
+
+def test_sync_gpt_oss_mlp_in_model_offload_imports():
+    import moe_infinity.models.gpt_oss as gpt_oss_mod
+
+    assert hasattr(
+        gpt_oss_mod, "SyncGptOssMLP"
+    ), "SyncGptOssMLP must exist in module"


### PR DESCRIPTION
## Summary

- **Adds full support for OpenAI GPT-OSS models** (`openai/gpt-oss-20b`, `openai/gpt-oss-120b`) in MoE-Infinity
- **`SyncGptOssMLP`** — drop-in replacement for `GptOssMLP` that integrates with the expert offloading engine, with SwiGLU activation (alpha=1.702, ±7.0 clamping) and router-with-bias
- **Packed expert tensor support** — GPT-OSS uses packed `(N_experts, hidden, dim)` tensors (not `nn.ModuleList`); engine now handles layer-level offloading for this format
- **MXFP4 awareness** — detects quantized checkpoints, skips `_scales` tensors from custom loading, graceful dtype fallback for `_blocks` tensors

## Architecture

GPT-OSS is a genuine MoE model: 32 experts, top-4 routing, 21B total / 3.6B active params. Key difference from all other supported models: expert weights are stored as **packed tensors** `(num_experts, hidden, dim)` rather than individual `nn.Module` instances.

## Files Changed

| File | Change |
|------|--------|
| `moe_infinity/models/gpt_oss.py` | **NEW** — `SyncGptOssMLP` with packed expert slicing, SwiGLU, router bias |
| `moe_infinity/utils/mxfp4.py` | **NEW** — `is_mxfp4_quantized()`, `get_mxfp4_modules_to_not_convert()`, `identify_mxfp4_pairs()` |
| `moe_infinity/common/constants.py` | `"gptoss"` key → `GptOssForCausalLM`, type 4 |
| `moe_infinity/utils/hf_config.py` | `parse_moe_param()` + `parse_expert_id()` branches for `gptoss` |
| `moe_infinity/runtime/model_offload.py` | Monkey-patch `GptOssMLP → SyncGptOssMLP` in `__enter__`/`__exit__`; `SyncGptOssMLP` added to isinstance chain; MXFP4 `_scales` filtering |
| `moe_infinity/entrypoints/big_modeling.py` | Flash attention exclusion for `gptoss` (sliding window compat) |
| `moe_infinity/models/__init__.py` | Export `SyncGptOssMLP` |

## Tests

35 new tests across 9 files, all passing offline. GPU/network tests (actual model loading + generation) are marked with `@pytest.mark.gpu` / `@pytest.mark.network`.

```
pytest tests/test_gpt_oss_*.py tests/test_mxfp4*.py tests/test_packed_experts.py tests/test_gpt_oss_monkey_patch.py -m "not network and not gpu"
# 35 passed, 4 deselected
```

## Notes

- Architecture key is `"gptoss"` (no underscore) — `"GptOssForCausalLM".lower()` = `"gptossforcausallm"`, underscore would not match
- GPT-OSS 120b uses the same `GptOssForCausalLM` class — same code path, larger scale
- Full per-expert (sub-layer) offloading granularity for packed format requires follow-up engine work; current implementation uses layer-level granularity