### PR TITLE
feat(server): add production-readiness features to OpenAI-compatible API

### DIFF
--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -8,6 +8,7 @@ import math
 import os
 import time
 from contextlib import suppress
+from dataclasses import dataclass, field
 from threading import Event, Lock
 from types import SimpleNamespace
 from typing import Any, Literal, Optional, cast
@@ -34,9 +35,15 @@ except Exception:
             return False
 
     class Response:  # type: ignore[no-redef]
-        def __init__(self, status_code: int = 200, content: Any = None) -> None:
+        def __init__(
+            self,
+            status_code: int = 200,
+            content: Any = None,
+            media_type: Optional[str] = None,
+        ) -> None:
             self.status_code = status_code
             self.content = content
+            self.media_type = media_type
 
     class JSONResponse(Response):  # type: ignore[no-redef]
         pass
@@ -53,6 +60,12 @@ except Exception:
 
     class _FallbackFastAPI:
         def on_event(self, *_args: Any, **_kwargs: Any) -> Any:
+            def _decorator(func: Any) -> Any:
+                return func
+
+            return _decorator
+
+        def middleware(self, *_args: Any, **_kwargs: Any) -> Any:
             def _decorator(func: Any) -> Any:
                 return func
 
@@ -96,6 +109,9 @@ from .protocol import (
     CompletionResponseChoice,
     CompletionResponseStreamChoice,
     CompletionStreamResponse,
+    LogProbs,
+    ModelCard,
+    ModelList,
     UsageInfo,
     create_error_response,
     random_uuid,
@@ -131,11 +147,122 @@ _cp_middleware: Optional[Any] = None
 _eviction_sync: Optional[Any] = None
 _cp_reorder_latencies: collections.deque[float] = collections.deque(maxlen=100)
 
+_api_keys: set[str] = set()
+_rate_limit_rpm: int = 0
+_rate_limit_buckets: dict[str, list[float]] = {}
+_rate_limit_lock = Lock()
+_max_waiting_requests: int = 0
+_max_n: int = 16
+
+
+@dataclass
+class _SequenceResultState:
+    seq_id: int
+    token_texts: list[str] = field(default_factory=list)
+    text_offsets: list[int] = field(default_factory=list)
+    token_logprobs: list[Optional[float]] = field(default_factory=list)
+    top_logprobs: list[Optional[dict[int, float]]] = field(default_factory=list)
+    usage: dict[str, int] = field(default_factory=dict)
+    finish_reason: Optional[str] = None
+    cumulative_logprob: float = 0.0
+    token_count: int = 0
+    current_text_offset: int = 0
+
+
+@dataclass
+class _FinalSequenceResult:
+    seq_id: int
+    text: str
+    usage: dict[str, int]
+    finish_reason: Optional[str]
+    logprobs: Optional[LogProbs]
+    cumulative_logprob: float
+    token_count: int
+
 
 def _resolve_contextpilot_enabled(cli_enabled: bool) -> bool:
     if os.environ.get("CONTEXTPILOT_ENABLED", "1") == "0":
         return False
     return bool(cli_enabled)
+
+
+def _configure_auth(api_key_csv: Optional[str], rate_limit: int) -> None:
+    global _api_keys
+    global _rate_limit_rpm
+    global _rate_limit_buckets
+
+    configured_keys = {
+        key.strip() for key in (api_key_csv or "").split(",") if key.strip()
+    }
+    _api_keys = configured_keys
+    _rate_limit_rpm = max(0, int(rate_limit))
+    with _rate_limit_lock:
+        _rate_limit_buckets = {}
+
+
+def _check_auth(request: Any) -> Any:
+    if not _api_keys:
+        return None
+
+    if request.url.path in {"/health", "/metrics", "/v1/models"}:
+        return None
+
+    auth_header = str(request.headers.get("Authorization", ""))
+    scheme, _, token = auth_header.partition(" ")
+    if scheme != "Bearer" or not token or token not in _api_keys:
+        return create_error_response(
+            status_code=401,
+            message="Invalid or missing API key.",
+            error_type="authentication_error",
+            code="invalid_api_key",
+        )
+
+    if _rate_limit_rpm <= 0:
+        return None
+
+    now = time.time()
+    window_start = now - 60.0
+    with _rate_limit_lock:
+        bucket = _rate_limit_buckets.setdefault(token, [])
+        bucket[:] = [timestamp for timestamp in bucket if timestamp >= window_start]
+        if len(bucket) >= _rate_limit_rpm:
+            return create_error_response(
+                status_code=429,
+                message="Rate limit exceeded. Please retry later.",
+                error_type="rate_limit_error",
+                code="rate_limit_exceeded",
+            )
+        bucket.append(now)
+
+    return None
+
+
+def _check_backpressure(runtime_engine: object) -> Any:
+    if _max_waiting_requests <= 0:
+        return None
+
+    scheduler = getattr(runtime_engine, "scheduler", None)
+    num_waiting = getattr(scheduler, "num_waiting", 0)
+    if int(num_waiting) < _max_waiting_requests:
+        return None
+
+    return create_error_response(
+        status_code=503,
+        message="Server is at capacity. Please retry later.",
+        error_type="server_error",
+        code="queue_full",
+    )
+
+
+_configure_auth(os.environ.get("MOE_API_KEYS"), 0)
+
+
+@app.middleware("http")
+async def auth_middleware(request: Request, call_next: Any) -> Response:
+    auth_result = _check_auth(request)
+    if auth_result is not None:
+        return auth_result
+    return await call_next(request)
 
 
 def _is_contextpilot_active() -> bool:
@@ -450,13 +577,167 @@ def _build_sampling_params(
     top_p: Optional[float],
     max_tokens: Optional[int],
     stop: Any,
+    logprobs: Optional[int | bool] = None,
 ) -> SamplingParams:
     return SamplingParams(
         temperature=float(temperature) if temperature is not None else 1.0,
         top_p=float(top_p) if top_p is not None else 1.0,
+        logprobs=int(logprobs) if logprobs else 0,
         max_tokens=cast(int, max_tokens),
         stop=_extract_stop_sequences(stop),
     )
+
+
+def _validate_parallel_sampling(
+    *,
+    n: Optional[int],
+    best_of: Optional[int] = None,
+) -> Optional[Any]:
+    requested_n = int(n or 1)
+    requested_best_of = int(best_of or requested_n)
+
+    if requested_n <= 0:
+        return create_error_response(
+            status_code=400,
+            message="n must be greater than 0",
+            error_type="invalid_request_error",
+            code="invalid_request_error",
+            param="n",
+        )
+    if requested_n > _max_n:
+        return create_error_response(
+            status_code=400,
+            message=f"n must be less than or equal to {_max_n}",
+            error_type="invalid_request_error",
+            code="invalid_request_error",
+            param="n",
+        )
+    if requested_best_of <= 0:
+        return create_error_response(
+            status_code=400,
+            message="best_of must be greater than 0",
+            error_type="invalid_request_error",
+            code="invalid_request_error",
+            param="best_of",
+        )
+    if requested_best_of > _max_n:
+        return create_error_response(
+            status_code=400,
+            message=f"best_of must be less than or equal to {_max_n}",
+            error_type="invalid_request_error",
+            code="invalid_request_error",
+            param="best_of",
+        )
+    if requested_best_of < requested_n:
+        return create_error_response(
+            status_code=400,
+            message="best_of must be greater than or equal to n",
+            error_type="invalid_request_error",
+            code="invalid_request_error",
+            param="best_of",
+        )
+    return None
+
+
+def _finalize_sequence_result(
+    state: _SequenceResultState,
+    *,
+    include_logprobs: bool,
+) -> _FinalSequenceResult:
+    logprobs: Optional[LogProbs] = None
+    if include_logprobs:
+        logprobs = LogProbs(
+            text_offset=state.text_offsets,
+            token_logprobs=state.token_logprobs,
+            tokens=state.token_texts,
+            top_logprobs=state.top_logprobs,
+        )
+
+    return _FinalSequenceResult(
+        seq_id=state.seq_id,
+        text="".join(state.token_texts),
+        usage=dict(state.usage),
+        finish_reason=state.finish_reason,
+        logprobs=logprobs,
+        cumulative_logprob=state.cumulative_logprob,
+        token_count=state.token_count,
+    )
+
+
+def _select_best_results(
+    results: list[_FinalSequenceResult],
+    *,
+    n: int,
+    best_of: int,
+    use_logprobs: bool,
+) -> list[_FinalSequenceResult]:
+    if len(results) <= n and best_of <= n:
+        return sorted(results, key=lambda result: result.seq_id)
+
+    if use_logprobs:
+        ranked = sorted(
+            results,
+            key=lambda result: (-result.cumulative_logprob, result.seq_id),
+        )
+    else:
+        ranked = sorted(
+            results,
+            key=lambda result: (-result.token_count, result.seq_id),
+        )
+
+    selected = ranked[:n]
+    return sorted(selected, key=lambda result: result.seq_id)
+
+
+def _apply_response_format_validation(
+    result: _FinalSequenceResult,
+    response_format: Any,
+) -> _FinalSequenceResult:
+    if response_format is None:
+        return result
+
+    format_type = str(getattr(response_format, "type", "text"))
+    if format_type != "json_object":
+        return result
+
+    try:
+        json.loads(result.text)
+    except Exception:
+        result.finish_reason = "error"
+
+    return result
+
+
+def _format_prometheus_metrics(stats: dict[str, object]) -> str:
+    lines = []
+    lines.append("# HELP moe_requests_completed Total completed requests")
+    lines.append("# TYPE moe_requests_completed counter")
+    lines.append(f"moe_requests_completed {stats.get('completed_requests', 0)}")
+    lines.append("# HELP moe_requests_cancelled Total cancelled requests")
+    lines.append("# TYPE moe_requests_cancelled counter")
+    lines.append(f"moe_requests_cancelled {stats.get('cancelled_requests', 0)}")
+    lines.append("# HELP moe_queue_depth Current pending requests")
+    lines.append("# TYPE moe_queue_depth gauge")
+    lines.append(f"moe_queue_depth {stats.get('pending_requests', 0)}")
+    lines.append("# HELP moe_tokens_generated_total Total tokens generated")
+    lines.append("# TYPE moe_tokens_generated_total counter")
+    lines.append(
+        f"moe_tokens_generated_total {stats.get('total_generated_tokens', 0)}"
+    )
+    lines.append("# HELP moe_kv_cache_free_blocks Free KV cache blocks")
+    lines.append("# TYPE moe_kv_cache_free_blocks gauge")
+    lines.append(
+        f"moe_kv_cache_free_blocks {stats.get('kv_cache_free_blocks', 0)}"
+    )
+    lines.append("# HELP moe_kv_cache_total_blocks Total KV cache blocks")
+    lines.append("# TYPE moe_kv_cache_total_blocks gauge")
+    lines.append(
+        f"moe_kv_cache_total_blocks {stats.get('kv_cache_num_blocks', 0)}"
+    )
+    lines.append("# HELP moe_engine_steps_total Total engine steps")
+    lines.append("# TYPE moe_engine_steps_total counter")
+    lines.append(f"moe_engine_steps_total {stats.get('num_steps', 0)}")
+    return "\n".join(lines) + "\n"
 
 
 def _tokenize_text(prompt: str) -> list[int]:
@@ -514,33 +795,49 @@ async def _wait_non_stream_result(
     prompt_token_ids: list[int],
     sampling_params: SamplingParams,
     raw_request: Request,
-) -> tuple[str, dict[str, int], Optional[str]]:
+    expected_sequences: int = 1,
+) -> list[_FinalSequenceResult]:
     runtime_engine, _ = _ensure_runtime_ready()
     done_event = Event()
-    token_texts: list[str] = []
-    usage: dict[str, int] = {
-        "prompt_tokens": len(prompt_token_ids),
-        "completion_tokens": 0,
-        "total_tokens": len(prompt_token_ids),
-    }
-    finish_reason: Optional[str] = None
+    finished_seq_ids: set[int] = set()
+    results_by_seq_id: dict[int, _SequenceResultState] = {}
 
     def on_token(output: RequestOutput) -> None:
-        nonlocal usage, finish_reason
-        token_texts.append(
-            _decode_token_text(output.token_id, output.token_text)
+        state = results_by_seq_id.setdefault(
+            output.seq_id,
+            _SequenceResultState(
+                seq_id=output.seq_id,
+                usage={
+                    "prompt_tokens": len(prompt_token_ids),
+                    "completion_tokens": 0,
+                    "total_tokens": len(prompt_token_ids),
+                },
+            ),
         )
+        token_text = _decode_token_text(output.token_id, output.token_text)
+        state.token_texts.append(token_text)
+        state.token_count += 1
+        if sampling_params.logprobs > 0:
+            state.text_offsets.append(state.current_text_offset)
+            state.token_logprobs.append(output.token_logprob)
+            state.top_logprobs.append(output.top_logprobs)
+            state.current_text_offset += len(token_text)
+        if output.token_logprob is not None:
+            state.cumulative_logprob += output.token_logprob
         if output.usage is not None:
-            usage = output.usage
+            state.usage = output.usage
         if output.finished:
-            finish_reason = output.finish_reason or "stop"
-            done_event.set()
+            state.finish_reason = output.finish_reason or "stop"
+            finished_seq_ids.add(output.seq_id)
+            if len(finished_seq_ids) >= expected_sequences:
+                done_event.set()
 
     runtime_engine.add_request(
         request_id=request_id,
         prompt_token_ids=prompt_token_ids,
         sampling_params=sampling_params,
         on_token=on_token,
+        n=expected_sequences,
     )
 
     while not done_event.is_set():
@@ -549,7 +846,13 @@ async def _wait_non_stream_result(
             raise HTTPException(status_code=499, detail="client disconnected")
         await asyncio.sleep(0.01)
 
-    return "".join(token_texts), usage, finish_reason
+    return [
+        _finalize_sequence_result(
+            state,
+            include_logprobs=sampling_params.logprobs > 0,
+        )
+        for seq_id, state in sorted(results_by_seq_id.items())
+    ]
 
 
 def _next_stream_event(generator: Any) -> Optional[str]:
@@ -557,6 +860,18 @@ def _next_stream_event(generator: Any) -> Optional[str]:
         return next(generator)
     except StopIteration:
         return None
+
+
+def _model_to_json(model: object, *, exclude_none: bool = False) -> str:
+    model_dump_json_fn = getattr(model, "model_dump_json", None)
+    if callable(model_dump_json_fn):
+        return str(model_dump_json_fn(exclude_none=exclude_none))
+
+    json_fn = getattr(model, "json", None)
+    if callable(json_fn):
+        return str(json_fn(exclude_none=exclude_none))
+
+    raise TypeError("response model does not support JSON serialization")
 
 
 def _make_completion_stream_chunk(
@@ -585,7 +900,7 @@ def _make_completion_stream_chunk(
             )
         ],
     )
-    return f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
+    return f"data: {_model_to_json(chunk, exclude_none=True)}\n\n"
 
 
 async def _completion_event_generator(
@@ -835,11 +1150,31 @@ async def shutdown_event() -> None:
 
 
 @app.get("/health")
-async def health() -> Response:
+async def health():
     status_dict = _health_state.get_status_dict()
     is_healthy = _health_state.is_healthy()
     status_code = 200 if is_healthy else 503
     return JSONResponse(content=status_dict, status_code=status_code)
+
+
+@app.get("/admin/stats")
+async def admin_stats():
+    if engine is None:
+        return create_error_response(
+            status_code=503,
+            message="Service is starting. Please retry shortly.",
+            error_type="server_error",
+            code="service_starting",
+        )
+
+    return JSONResponse(content=engine.get_stats())
+
+
+@app.get("/metrics")
+async def metrics():
+    stats = engine.get_stats() if engine is not None else {}
+    body = _format_prometheus_metrics(stats)
+    return Response(content=body, media_type="text/plain; charset=utf-8")
 
 
 @app.post("/contextpilot/toggle")
@@ -981,6 +1316,9 @@ async def completion(request: CompletionRequest, raw_request: Request):
         )
 
     runtime_engine, runtime_stream_manager = _ensure_runtime_ready()
+    backpressure_response = _check_backpressure(runtime_engine)
+    if backpressure_response is not None:
+        return backpressure_response
     created_time = int(time.monotonic())
     model_name = request.model or model_name_global or "unknown"
 
@@ -1000,6 +1338,16 @@ async def completion(request: CompletionRequest, raw_request: Request):
             param=exc.param,
         )
 
+    parallel_validation = _validate_parallel_sampling(
+        n=request.n,
+        best_of=request.best_of,
+    )
+    if parallel_validation is not None:
+        return parallel_validation
+
+    requested_n = int(request.n or 1)
+    requested_best_of = int(request.best_of or requested_n)
+
     try:
         prompt_is_tokens, prompts = parse_prompt_format(request.prompt)
     except ValueError as exc:
@@ -1015,9 +1363,17 @@ async def completion(request: CompletionRequest, raw_request: Request):
         top_p=request.top_p,
         max_tokens=request.max_tokens,
         stop=request.stop,
+        logprobs=request.logprobs,
     )
 
     if request.stream:
+        if requested_n != 1 or requested_best_of != 1:
+            return create_error_response(
+                status_code=400,
+                message="streaming completions only support n=1 and best_of=1",
+                error_type="invalid_request_error",
+                code="invalid_request_error",
+            )
         if len(prompts) != 1:
             return create_error_response(
                 status_code=400,
@@ -1071,6 +1427,7 @@ async def completion(request: CompletionRequest, raw_request: Request):
             prompt_token_ids=prompt_token_ids,
             sampling_params=sampling_params,
             on_token=on_stream_token,
+            n=1,
         )
 
         return StreamingResponse(
@@ -1112,29 +1469,39 @@ async def completion(request: CompletionRequest, raw_request: Request):
                 code="context_length_exceeded",
             )
 
-        (
-            output_text,
-            usage,
-            result_finish_reason,
-        ) = await _wait_non_stream_result(
+        sequence_results = await _wait_non_stream_result(
             request_id=request_id,
             prompt_token_ids=prompt_token_ids,
             sampling_params=sampling_params,
             raw_request=raw_request,
+            expected_sequences=requested_best_of,
         )
 
-        choices.append(
-            CompletionResponseChoice(
-                index=index,
-                text=output_text,
-                logprobs=None,
-                finish_reason=cast(
-                    Literal["stop", "length"], result_finish_reason or "stop"
-                ),
-            )
+        selected_results = _select_best_results(
+            sequence_results,
+            n=requested_n,
+            best_of=requested_best_of,
+            use_logprobs=sampling_params.logprobs > 0,
         )
-        usage_prompt_tokens += usage.get("prompt_tokens", 0)
-        usage_completion_tokens += usage.get("completion_tokens", 0)
+        selected_results = [
+            _apply_response_format_validation(result, request.response_format)
+            for result in selected_results
+        ]
+
+        for result in selected_results:
+            choices.append(
+                CompletionResponseChoice(
+                    index=len(choices),
+                    text=result.text,
+                    logprobs=result.logprobs,
+                    finish_reason=cast(
+                        Literal["stop", "length", "error"],
+                        result.finish_reason or "stop",
+                    ),
+                )
+            )
+            usage_completion_tokens += result.usage.get("completion_tokens", 0)
+        usage_prompt_tokens += len(prompt_token_ids)
 
     return CompletionResponse(
         id=f"cmpl-{random_uuid()}",
@@ -1160,6 +1527,9 @@ async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
         )
 
     runtime_engine, runtime_stream_manager = _ensure_runtime_ready()
+    backpressure_response = _check_backpressure(runtime_engine)
+    if backpressure_response is not None:
+        return backpressure_response
     created_time = int(time.monotonic())
     model_name = request.model or model_name_global or "unknown"
     request_id = random_uuid()
@@ -1180,11 +1550,18 @@ async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
             param=exc.param,
         )
 
+    parallel_validation = _validate_parallel_sampling(n=request.n)
+    if parallel_validation is not None:
+        return parallel_validation
+
+    requested_n = int(request.n or 1)
+
     sampling_params = _build_sampling_params(
         temperature=request.temperature,
         top_p=request.top_p,
         max_tokens=request.max_tokens,
         stop=request.stop,
+        logprobs=request.top_logprobs if request.logprobs else request.logprobs,
     )
     processed_messages = _process_chat_messages_with_contextpilot(
         request.messages,
@@ -1212,6 +1589,13 @@ async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
         )
 
     if request.stream:
+        if requested_n != 1:
+            return create_error_response(
+                status_code=400,
+                message="streaming chat completions only support n=1",
+                error_type="invalid_request_error",
+                code="invalid_request_error",
+            )
         stream = runtime_stream_manager.create_stream(
             request_id=request_id,
             model=model_name,
@@ -1232,6 +1616,7 @@ async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
             prompt_token_ids=prompt_token_ids,
             sampling_params=sampling_params,
             on_token=on_stream_token,
+            n=1,
         )
         return StreamingResponse(
             _chat_event_generator(
@@ -1242,11 +1627,20 @@ async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
             media_type="text/event-stream",
         )
 
-    output_text, usage, chat_finish_reason = await _wait_non_stream_result(
+    sequence_results = await _wait_non_stream_result(
         request_id=request_id,
         prompt_token_ids=prompt_token_ids,
         sampling_params=sampling_params,
         raw_request=raw_request,
+        expected_sequences=requested_n,
+    )
+    sequence_results = [
+        _apply_response_format_validation(result, request.response_format)
+        for result in sequence_results
+    ]
+
+    usage_completion_tokens = sum(
+        result.usage.get("completion_tokens", 0) for result in sequence_results
     )
 
     return ChatCompletionResponse(
@@ -1255,19 +1649,37 @@ async def chat_completion(request: ChatCompletionRequest, raw_request: Request):
         model=model_name,
         choices=[
             ChatCompletionResponseChoice(
-                index=0,
-                message=ChatMessage(role="assistant", content=output_text),
+                index=index,
+                message=ChatMessage(role="assistant", content=result.text),
+                logprobs=result.logprobs,
                 finish_reason=cast(
-                    Literal["stop", "length"], chat_finish_reason or "stop"
+                    Literal["stop", "length", "error"],
+                    result.finish_reason or "stop",
                 ),
             )
+            for index, result in enumerate(sequence_results)
         ],
         usage=UsageInfo(
-            prompt_tokens=usage.get("prompt_tokens", len(prompt_token_ids)),
-            completion_tokens=usage.get("completion_tokens", 0),
-            total_tokens=usage.get("total_tokens", len(prompt_token_ids)),
+            prompt_tokens=len(prompt_token_ids),
+            completion_tokens=usage_completion_tokens,
+            total_tokens=len(prompt_token_ids) + usage_completion_tokens,
         ),
     )
+
+
+@app.get("/v1/models")
+async def list_models():
+    if engine is None:
+        return create_error_response(
+            status_code=503,
+            message="Service is starting. Please retry shortly.",
+            error_type="server_error",
+            code="service_starting",
+        )
+
+    model_name = model_name_global or "unknown"
+    card = ModelCard(id=model_name)
+    return ModelList(data=[card])
 
 
 def _resolve_int_attr(config: object, *names: str) -> Optional[int]:
@@ -1379,6 +1791,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--device-memory-ratio", type=float, default=0.75)
     parser.add_argument("--kv-cache-ratio", type=float, default=0.25)
     parser.add_argument("--max-batch-size", type=int, default=32)
+    parser.add_argument("--api-key", type=str, default=None)
+    parser.add_argument("--rate-limit", type=int, default=0)
+    parser.add_argument("--max-waiting-requests", type=int, default=0)
+    parser.add_argument("--max-n", type=int, default=16)
     parser.add_argument("--enable-prefix-caching", action="store_true")
     parser.add_argument(
         "--startup-timeout",
@@ -1414,6 +1830,9 @@ def parse_args() -> argparse.Namespace:
 
 if __name__ == "__main__":
     args = parse_args()
+    _max_waiting_requests = max(0, int(args.max_waiting_requests))
+    _max_n = max(1, int(args.max_n))
+    _configure_auth(args.api_key or os.environ.get("MOE_API_KEYS"), args.rate_limit)
     with _contextpilot_state_lock:
         _contextpilot_enabled = _resolve_contextpilot_enabled(
             args.enable_contextpilot

--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -224,7 +224,9 @@ def _check_auth(request: Any) -> Any:
     window_start = now - 60.0
     with _rate_limit_lock:
         bucket = _rate_limit_buckets.setdefault(token, [])
-        bucket[:] = [timestamp for timestamp in bucket if timestamp >= window_start]
+        bucket[:] = [
+            timestamp for timestamp in bucket if timestamp >= window_start
+        ]
         if len(bucket) >= _rate_limit_rpm:
             return create_error_response(
                 status_code=429,
@@ -1832,7 +1834,9 @@ if __name__ == "__main__":
     args = parse_args()
     _max_waiting_requests = max(0, int(args.max_waiting_requests))
     _max_n = max(1, int(args.max_n))
-    _configure_auth(args.api_key or os.environ.get("MOE_API_KEYS"), args.rate_limit)
+    _configure_auth(
+        args.api_key or os.environ.get("MOE_API_KEYS"), args.rate_limit
+    )
     with _contextpilot_state_lock:
         _contextpilot_enabled = _resolve_contextpilot_enabled(
             args.enable_contextpilot

--- a/moe_infinity/entrypoints/openai/protocol.py
+++ b/moe_infinity/entrypoints/openai/protocol.py
@@ -127,6 +127,10 @@ class UsageInfo(BaseModel):
     completion_tokens: Optional[int] = 0
 
 
+class ResponseFormat(BaseModel):
+    type: str = "text"
+
+
 class ChatCompletionRequest(BaseModel):
     model: str
     messages: Union[str, List[Dict[str, str]]]
@@ -136,6 +140,9 @@ class ChatCompletionRequest(BaseModel):
     max_tokens: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = Field(default_factory=list)
     stream: Optional[bool] = False
+    logprobs: Optional[bool] = False
+    top_logprobs: Optional[int] = None
+    response_format: Optional[ResponseFormat] = None
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None
@@ -171,6 +178,7 @@ class CompletionRequest(BaseModel):
     presence_penalty: Optional[float] = 0.0
     frequency_penalty: Optional[float] = 0.0
     best_of: Optional[int] = None
+    response_format: Optional[ResponseFormat] = None
     logit_bias: Optional[Dict[str, float]] = None
     user: Optional[str] = None
 
@@ -202,7 +210,7 @@ class CompletionResponseChoice(BaseModel):
     index: int
     text: str
     logprobs: Optional[LogProbs] = None
-    finish_reason: Optional[Literal["stop", "length"]] = None
+    finish_reason: Optional[Literal["stop", "length", "error"]] = None
 
 
 class CompletionResponse(BaseModel):
@@ -218,7 +226,7 @@ class CompletionResponseStreamChoice(BaseModel):
     index: int
     text: str
     logprobs: Optional[LogProbs] = None
-    finish_reason: Optional[Literal["stop", "length"]] = None
+    finish_reason: Optional[Literal["stop", "length", "error"]] = None
 
 
 class CompletionStreamResponse(BaseModel):
@@ -238,7 +246,8 @@ class ChatMessage(BaseModel):
 class ChatCompletionResponseChoice(BaseModel):
     index: int
     message: ChatMessage
-    finish_reason: Optional[Literal["stop", "length"]] = None
+    logprobs: Optional[LogProbs] = None
+    finish_reason: Optional[Literal["stop", "length", "error"]] = None
 
 
 class ChatCompletionResponse(BaseModel):
@@ -258,7 +267,7 @@ class DeltaMessage(BaseModel):
 class ChatCompletionResponseStreamChoice(BaseModel):
     index: int
     delta: DeltaMessage
-    finish_reason: Optional[Literal["stop", "length"]] = None
+    finish_reason: Optional[Literal["stop", "length", "error"]] = None
 
 
 class ChatCompletionStreamResponse(BaseModel):

--- a/moe_infinity/serving/engine.py
+++ b/moe_infinity/serving/engine.py
@@ -38,10 +38,13 @@ def set_eviction_sync(adapter: Optional[EvictionSyncAdapter]) -> None:
 @dataclass
 class RequestOutput:
     request_id: str
+    seq_id: int
     token_id: int
     token_text: Optional[str]
     finished: bool
     finish_reason: Optional[str] = None
+    token_logprob: Optional[float] = None
+    top_logprobs: Optional[dict[int, float]] = None
     usage: Optional[dict[str, int]] = None
 
 
@@ -124,7 +127,7 @@ class ContinuousBatchingEngine:
         self._sequences: dict[int, SequenceData] = {}
         self._sequence_to_request_id: dict[int, str] = {}
         self._request_to_seq_ids: dict[str, list[int]] = {}
-        self._request_outputs: dict[str, list[int]] = {}
+        self._request_outputs: dict[str, dict[int, list[int]]] = {}
         self._callbacks: dict[str, list[Callable[[RequestOutput], None]]] = {}
         self._completed_request_ids: set[str] = set()
         self._cancelled_request_ids: set[str] = set()
@@ -137,24 +140,34 @@ class ContinuousBatchingEngine:
         prompt_token_ids: list[int],
         sampling_params: SamplingParams,
         on_token: Optional[Callable[[RequestOutput], None]] = None,
+        n: int = 1,
     ) -> None:
         if request_id in self._request_to_seq_ids:
             raise ValueError(f"request_id '{request_id}' already exists")
+        if n <= 0:
+            raise ValueError("n must be greater than 0")
 
-        seq_id = self._next_seq_id
-        self._next_seq_id += 1
+        sequences: list[SequenceData] = []
+        seq_ids: list[int] = []
+        output_map: dict[int, list[int]] = {}
+        for _ in range(n):
+            seq_id = self._next_seq_id
+            self._next_seq_id += 1
+            seq_ids.append(seq_id)
+            sequence = SequenceData(
+                seq_id=seq_id,
+                prompt_token_ids=list(prompt_token_ids),
+                sampling_params=sampling_params,
+            )
+            sequences.append(sequence)
+            self._sequences[seq_id] = sequence
+            self._sequence_to_request_id[seq_id] = request_id
+            output_map[seq_id] = []
 
-        sequence = SequenceData(
-            seq_id=seq_id,
-            prompt_token_ids=list(prompt_token_ids),
-            sampling_params=sampling_params,
-        )
-        group = SequenceGroup(request_id=request_id, sequences=[sequence])
+        group = SequenceGroup(request_id=request_id, sequences=sequences)
 
-        self._sequences[seq_id] = sequence
-        self._sequence_to_request_id[seq_id] = request_id
-        self._request_to_seq_ids[request_id] = [seq_id]
-        self._request_outputs[request_id] = []
+        self._request_to_seq_ids[request_id] = seq_ids
+        self._request_outputs[request_id] = output_map
         if on_token is not None:
             self._callbacks.setdefault(request_id, []).append(on_token)
 
@@ -180,39 +193,52 @@ class ContinuousBatchingEngine:
 
         logits = self._execute_batch(batch)
         last_token_logits = self._extract_last_token_logits(logits, batch)
-        next_token_ids = self.sampler.sample(
+        sampler_output = self.sampler.sample(
             last_token_logits,
             batch.sampling_params,
         )
+        next_token_ids = sampler_output.token_ids
 
         outputs: list[RequestOutput] = []
         completed_seq_ids: list[int] = []
         new_decode_seq_ids: list[int] = []
+        touched_request_ids: set[str] = set()
 
         for index, seq_id in enumerate(batch.seq_ids):
             sequence = self._sequences[seq_id]
             request_id = self._sequence_to_request_id[seq_id]
+            touched_request_ids.add(request_id)
             token_id = int(next_token_ids[index].item())
 
             sequence.append_output_token(token_id)
-            self._request_outputs[request_id].append(token_id)
+            self._request_outputs[request_id][seq_id].append(token_id)
             self._total_generated_tokens += 1
 
             finish_reason = self._get_finish_reason(sequence, token_id)
             finished = finish_reason is not None
             if finished:
                 completed_seq_ids.append(seq_id)
-                self._completed_request_ids.add(request_id)
             else:
                 new_decode_seq_ids.append(seq_id)
 
             outputs.append(
                 RequestOutput(
                     request_id=request_id,
+                    seq_id=seq_id,
                     token_id=token_id,
                     token_text=self._decode_token(token_id),
                     finished=finished,
                     finish_reason=finish_reason,
+                    token_logprob=(
+                        sampler_output.token_logprobs[index]
+                        if sampler_output.token_logprobs is not None
+                        else None
+                    ),
+                    top_logprobs=(
+                        sampler_output.top_logprobs[index]
+                        if sampler_output.top_logprobs is not None
+                        else None
+                    ),
                     usage=(self._build_usage(sequence) if finished else None),
                 )
             )
@@ -223,17 +249,25 @@ class ContinuousBatchingEngine:
         )
         self._num_steps += 1
 
+        finished_request_ids = {
+            request_id
+            for request_id in touched_request_ids
+            if self._is_request_finished(request_id)
+        }
+        self._completed_request_ids.update(finished_request_ids)
+
         for output in outputs:
             for callback in self._callbacks.get(output.request_id, []):
                 callback(output)
-            if output.finished:
-                if _eviction_sync is not None:
-                    _eviction_sync.on_request_finished(output.request_id)
-                _ = self._callbacks.pop(output.request_id, None)
+
+        for request_id in finished_request_ids:
+            if _eviction_sync is not None:
+                _eviction_sync.on_request_finished(request_id)
+            _ = self._callbacks.pop(request_id, None)
 
         return outputs
 
-    def run_until_done(self) -> dict[str, list[int]]:
+    def run_until_done(self) -> dict[str, list[int] | list[list[int]]]:
         while self.has_pending_requests():
             outputs = self.step()
             if outputs:
@@ -245,9 +279,18 @@ class ContinuousBatchingEngine:
             )
 
         return {
-            request_id: list(output_token_ids)
-            for request_id, output_token_ids in self._request_outputs.items()
+            request_id: self._format_request_outputs(request_id)
+            for request_id in self._request_outputs
         }
+
+    def get_request_n_outputs(self, request_id: str) -> list[list[int]]:
+        if request_id not in self._request_outputs:
+            raise KeyError(f"unknown request_id '{request_id}'")
+
+        return [
+            list(self._request_outputs[request_id][seq_id])
+            for seq_id in self._request_to_seq_ids.get(request_id, [])
+        ]
 
     def abort_request(self, request_id: str) -> None:
         seq_ids = list(self._request_to_seq_ids.get(request_id, []))
@@ -431,6 +474,25 @@ class ContinuousBatchingEngine:
                 pending_request_ids.append(request_id)
 
         return pending_request_ids
+
+    def _is_request_finished(self, request_id: str) -> bool:
+        seq_ids = self._request_to_seq_ids.get(request_id, [])
+        if not seq_ids:
+            return False
+
+        return all(
+            self._sequences[seq_id].status is SequenceStatus.FINISHED
+            for seq_id in seq_ids
+            if seq_id in self._sequences
+        )
+
+    def _format_request_outputs(
+        self, request_id: str
+    ) -> list[int] | list[list[int]]:
+        outputs = self.get_request_n_outputs(request_id)
+        if len(outputs) == 1:
+            return outputs[0]
+        return outputs
 
     def _decode_token(self, token_id: int) -> Optional[str]:
         return self._decode_tokens([token_id])

--- a/moe_infinity/serving/sampler.py
+++ b/moe_infinity/serving/sampler.py
@@ -40,7 +40,9 @@ class Sampler:
             dtype=torch.long,
             device=logits.device,
         )
-        requested_logprobs = any(params.logprobs > 0 for params in sampling_params)
+        requested_logprobs = any(
+            params.logprobs > 0 for params in sampling_params
+        )
         token_logprobs: list[float | None] | None = None
         top_logprobs: list[dict[int, float] | None] | None = None
         if requested_logprobs:
@@ -63,7 +65,9 @@ class Sampler:
                 filtered = self._apply_top_p(filtered, params.top_p)
 
                 probs = torch.softmax(filtered, dim=-1)
-                sampled[idx] = torch.multinomial(probs, num_samples=1).squeeze(0)
+                sampled[idx] = torch.multinomial(probs, num_samples=1).squeeze(
+                    0
+                )
 
             if not requested_logprobs or params.logprobs <= 0:
                 continue

--- a/moe_infinity/serving/sampler.py
+++ b/moe_infinity/serving/sampler.py
@@ -11,6 +11,14 @@ class _SamplingParamsLike(Protocol):
     temperature: float
     top_k: int
     top_p: float
+    logprobs: int
+
+
+@dataclass
+class SamplerOutput:
+    token_ids: torch.Tensor
+    token_logprobs: list[float | None] | None = None
+    top_logprobs: list[dict[int, float] | None] | None = None
 
 
 @dataclass
@@ -19,7 +27,7 @@ class Sampler:
         self,
         logits: torch.Tensor,
         sampling_params: Sequence[_SamplingParamsLike],
-    ) -> torch.Tensor:
+    ) -> SamplerOutput:
         if logits.dim() != 2:
             raise ValueError("logits must have shape [num_seqs, vocab_size]")
         if logits.size(0) != len(sampling_params):
@@ -32,25 +40,52 @@ class Sampler:
             dtype=torch.long,
             device=logits.device,
         )
+        requested_logprobs = any(params.logprobs > 0 for params in sampling_params)
+        token_logprobs: list[float | None] | None = None
+        top_logprobs: list[dict[int, float] | None] | None = None
+        if requested_logprobs:
+            token_logprobs = [None for _ in range(logits.size(0))]
+            top_logprobs = [None for _ in range(logits.size(0))]
 
         for idx, params in enumerate(sampling_params):
             row = logits[idx]
             temperature = params.temperature
+            filtered = row
 
             if temperature == 0:
                 sampled[idx] = torch.argmax(row).to(dtype=torch.long)
-                continue
-            if temperature < 0:
+            elif temperature < 0:
                 raise ValueError("temperature must be non-negative")
 
-            filtered = row / temperature
-            filtered = self._apply_top_k(filtered, params.top_k)
-            filtered = self._apply_top_p(filtered, params.top_p)
+            else:
+                filtered = row / temperature
+                filtered = self._apply_top_k(filtered, params.top_k)
+                filtered = self._apply_top_p(filtered, params.top_p)
 
-            probs = torch.softmax(filtered, dim=-1)
-            sampled[idx] = torch.multinomial(probs, num_samples=1).squeeze(0)
+                probs = torch.softmax(filtered, dim=-1)
+                sampled[idx] = torch.multinomial(probs, num_samples=1).squeeze(0)
 
-        return sampled
+            if not requested_logprobs or params.logprobs <= 0:
+                continue
+
+            logprobs = torch.log_softmax(filtered, dim=-1)
+            sampled_token_id = int(sampled[idx].item())
+            if token_logprobs is not None:
+                token_logprobs[idx] = float(logprobs[sampled_token_id].item())
+
+            if top_logprobs is not None:
+                k = min(int(params.logprobs), logprobs.numel())
+                top_values, top_indices = torch.topk(logprobs, k=k)
+                top_logprobs[idx] = {
+                    int(token_id.item()): float(token_logprob.item())
+                    for token_id, token_logprob in zip(top_indices, top_values)
+                }
+
+        return SamplerOutput(
+            token_ids=sampled,
+            token_logprobs=token_logprobs,
+            top_logprobs=top_logprobs,
+        )
 
     @staticmethod
     def _apply_top_k(logits: torch.Tensor, top_k: int) -> torch.Tensor:
@@ -85,4 +120,4 @@ class Sampler:
         return filtered
 
 
-__all__ = ["Sampler"]
+__all__ = ["Sampler", "SamplerOutput"]

--- a/moe_infinity/serving/scheduler.py
+++ b/moe_infinity/serving/scheduler.py
@@ -237,6 +237,10 @@ class Scheduler:
     def has_work(self) -> bool:
         return bool(self._waiting or self._running)
 
+    @property
+    def num_waiting(self) -> int:
+        return len(self._waiting)
+
     def get_running_seq_ids(self) -> list[int]:
         running_seq_ids: list[int] = []
         for group in self._running:

--- a/moe_infinity/serving/sequence.py
+++ b/moe_infinity/serving/sequence.py
@@ -20,6 +20,7 @@ class SamplingParams:
     temperature: float = 1.0
     top_k: int = -1
     top_p: float = 1.0
+    logprobs: int = 0
     max_tokens: int = 256
     stop: list[str] = field(default_factory=list)
     repetition_penalty: float = 1.0

--- a/tests/python/contextpilot/test_runtime_toggle.py
+++ b/tests/python/contextpilot/test_runtime_toggle.py
@@ -132,12 +132,22 @@ def test_completion_uses_contextpilot_before_tokenization(
 
     async def _fake_wait_non_stream_result(
         **_: Any,
-    ) -> tuple[str, dict[str, int], str]:
-        return (
-            "ok",
-            {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
-            "stop",
-        )
+    ) -> list[Any]:
+        return [
+            server_module._FinalSequenceResult(
+                seq_id=0,
+                text="ok",
+                usage={
+                    "prompt_tokens": 2,
+                    "completion_tokens": 1,
+                    "total_tokens": 3,
+                },
+                finish_reason="stop",
+                logprobs=None,
+                cumulative_logprob=0.0,
+                token_count=1,
+            )
+        ]
 
     def _fake_tokenize(prompt: str) -> list[int]:
         captured["tokenized_prompt"] = prompt
@@ -189,12 +199,22 @@ def test_chat_middleware_failure_falls_back_to_original_messages(
 
     async def _fake_wait_non_stream_result(
         **_: Any,
-    ) -> tuple[str, dict[str, int], str]:
-        return (
-            "ok",
-            {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
-            "stop",
-        )
+    ) -> list[Any]:
+        return [
+            server_module._FinalSequenceResult(
+                seq_id=0,
+                text="ok",
+                usage={
+                    "prompt_tokens": 2,
+                    "completion_tokens": 1,
+                    "total_tokens": 3,
+                },
+                finish_reason="stop",
+                logprobs=None,
+                cumulative_logprob=0.0,
+                token_count=1,
+            )
+        ]
 
     def _fake_chat_prompt_to_token_ids(request: Any) -> list[int]:
         captured["messages"] = request.messages

--- a/tests/python/integration/test_stability_e2e.py
+++ b/tests/python/integration/test_stability_e2e.py
@@ -54,6 +54,9 @@ class _Output:
     def __init__(self) -> None:
         self.token_id = 1
         self.token_text = "ok"
+        self.seq_id = 0
+        self.token_logprob = None
+        self.top_logprobs = None
         self.finished = True
         self.finish_reason = "stop"
         self.usage = {

--- a/tests/python/serving/test_api_routes.py
+++ b/tests/python/serving/test_api_routes.py
@@ -274,11 +274,15 @@ def test_rate_limit_rejects_excess(
     _configure_auth_state(monkeypatch, api_keys="test-key-1", rate_limit=2)
     headers = {"Authorization": "Bearer test-key-1"}
 
-    first = client.post("/v1/completions", json=_completion_payload(), headers=headers)
+    first = client.post(
+        "/v1/completions", json=_completion_payload(), headers=headers
+    )
     second = client.post(
         "/v1/completions", json=_completion_payload(), headers=headers
     )
-    third = client.post("/v1/completions", json=_completion_payload(), headers=headers)
+    third = client.post(
+        "/v1/completions", json=_completion_payload(), headers=headers
+    )
 
     assert first.status_code != 429
     assert second.status_code != 429

--- a/tests/python/serving/test_api_routes.py
+++ b/tests/python/serving/test_api_routes.py
@@ -1,0 +1,533 @@
+# pyright: reportAny=false, reportCallIssue=false, reportExplicitAny=false, reportMissingParameterType=false, reportMissingTypeArgument=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownVariableType=false
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+
+    import moe_infinity.entrypoints.openai.api_server_v2 as srv
+except TypeError:
+    pytest.skip(
+        "Pydantic v1 incompatible with Python 3.12+", allow_module_level=True
+    )
+
+
+def _make_mock_stats() -> dict[str, Any]:
+    return {
+        "pending_requests": 2,
+        "completed_requests": 10,
+        "cancelled_requests": 1,
+        "num_steps": 100,
+        "total_generated_tokens": 500,
+        "kv_cache_num_blocks": 32,
+        "kv_cache_free_blocks": 20,
+        "sequence_status_counts": {
+            "waiting": 1,
+            "prefill": 0,
+            "decode": 1,
+            "finished": 10,
+            "swapped": 0,
+            "cancelled": 1,
+        },
+        "memory": {
+            "device": "cpu",
+            "total_gpu_memory_bytes": 0,
+            "expert_cache_bytes": 0,
+            "kv_cache_bytes": 0,
+        },
+    }
+
+
+def _completion_payload() -> dict[str, Any]:
+    return {
+        "model": "test-model",
+        "prompt": "hello",
+        "max_tokens": 4,
+    }
+
+
+def _configure_auth_state(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    api_keys: str | None,
+    rate_limit: int = 0,
+) -> None:
+    if api_keys is None:
+        monkeypatch.delenv("MOE_API_KEYS", raising=False)
+        configured_keys = ""
+    else:
+        monkeypatch.setenv("MOE_API_KEYS", api_keys)
+        configured_keys = api_keys
+
+    srv._configure_auth(configured_keys, rate_limit)
+
+
+@dataclass
+class _MockOutput:
+    seq_id: int = 0
+    token_id: int = 1
+    token_text: str = "ok"
+    finished: bool = True
+    finish_reason: str = "stop"
+    token_logprob: float | None = None
+    top_logprobs: dict[int, float] | None = None
+    usage: dict[str, int] = field(
+        default_factory=lambda: {
+            "prompt_tokens": 3,
+            "completion_tokens": 1,
+            "total_tokens": 4,
+        }
+    )
+
+
+@pytest.fixture
+def client() -> Any:
+    original_engine = srv.engine
+    original_model_name = srv.model_name_global
+    original_tokenizer = srv.tokenizer
+    original_health_state = srv._health_state
+    original_stream_manager = srv.stream_manager
+    original_api_keys = set(getattr(srv, "_api_keys", set()))
+    original_rate_limit_rpm = getattr(srv, "_rate_limit_rpm", 0)
+    original_rate_limit_buckets = {
+        key: list(value)
+        for key, value in getattr(srv, "_rate_limit_buckets", {}).items()
+    }
+    original_max_waiting_requests = getattr(srv, "_max_waiting_requests", 0)
+    original_max_n = getattr(srv, "_max_n", 16)
+
+    mock_engine = MagicMock()
+    mock_engine.get_stats.return_value = _make_mock_stats()
+    mock_engine.scheduler = SimpleNamespace(num_waiting=0)
+    mock_engine.has_pending_requests.return_value = False
+    mock_engine.step.return_value = []
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        if callable(on_token):
+            _ = on_token(_MockOutput())
+
+    mock_engine.add_request.side_effect = _add_request
+    mock_engine.abort_request.return_value = None
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.encode.return_value = [1, 2, 3]
+    mock_tokenizer.decode.return_value = "ok"
+    mock_tokenizer.apply_chat_template.return_value = "user: hello\nassistant:"
+
+    srv.engine = mock_engine
+    srv.stream_manager = object()
+    srv.model_name_global = "test-model"
+    srv.tokenizer = mock_tokenizer
+    srv._health_state.set_healthy()
+
+    try:
+        with TestClient(srv.app) as test_client:
+            yield test_client
+    finally:
+        srv.engine = original_engine
+        srv.stream_manager = original_stream_manager
+        srv.model_name_global = original_model_name
+        srv.tokenizer = original_tokenizer
+        srv._health_state = original_health_state
+        srv._api_keys = original_api_keys
+        srv._rate_limit_rpm = original_rate_limit_rpm
+        srv._rate_limit_buckets = original_rate_limit_buckets
+        srv._max_waiting_requests = original_max_waiting_requests
+        srv._max_n = original_max_n
+
+
+def test_list_models(client: TestClient) -> None:
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "list"
+    assert payload["data"][0]["id"] == "test-model"
+    assert payload["data"][0]["object"] == "model"
+
+
+def test_list_models_engine_not_ready(client: TestClient) -> None:
+    srv.engine = None
+
+    response = client.get("/v1/models")
+
+    assert response.status_code == 503
+
+
+def test_admin_stats(client: TestClient) -> None:
+    response = client.get("/admin/stats")
+
+    assert response.status_code == 200
+    payload = response.json()
+    for key in _make_mock_stats():
+        assert key in payload
+
+
+def test_admin_stats_engine_not_ready(client: TestClient) -> None:
+    srv.engine = None
+
+    response = client.get("/admin/stats")
+
+    assert response.status_code == 503
+
+
+def test_metrics_endpoint(client: TestClient) -> None:
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    body = response.text
+    assert "moe_requests_completed" in body
+    assert "moe_queue_depth" in body
+    assert "moe_kv_cache_free_blocks" in body
+    assert "moe_tokens_generated_total" in body
+
+
+def test_metrics_engine_not_ready(client: TestClient) -> None:
+    srv.engine = None
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+    assert "moe_requests_completed 0" in response.text
+    assert "moe_queue_depth 0" in response.text
+
+
+def test_auth_rejects_missing_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys="test-key-1")
+
+    response = client.post("/v1/completions", json=_completion_payload())
+
+    assert response.status_code == 401
+
+
+def test_auth_accepts_valid_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys="test-key-1")
+
+    response = client.post(
+        "/v1/completions",
+        json=_completion_payload(),
+        headers={"Authorization": "Bearer test-key-1"},
+    )
+
+    assert response.status_code != 401
+
+
+def test_auth_rejects_invalid_key(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys="test-key-1")
+
+    response = client.post(
+        "/v1/completions",
+        json=_completion_payload(),
+        headers={"Authorization": "Bearer wrong-key"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_auth_exempts_health(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys="test-key-1")
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+
+
+def test_auth_exempts_metrics(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys="test-key-1")
+
+    response = client.get("/metrics")
+
+    assert response.status_code == 200
+
+
+def test_auth_disabled_when_no_keys(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys=None)
+
+    response = client.post("/v1/completions", json=_completion_payload())
+
+    assert response.status_code != 401
+
+
+def test_rate_limit_rejects_excess(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _configure_auth_state(monkeypatch, api_keys="test-key-1", rate_limit=2)
+    headers = {"Authorization": "Bearer test-key-1"}
+
+    first = client.post("/v1/completions", json=_completion_payload(), headers=headers)
+    second = client.post(
+        "/v1/completions", json=_completion_payload(), headers=headers
+    )
+    third = client.post("/v1/completions", json=_completion_payload(), headers=headers)
+
+    assert first.status_code != 429
+    assert second.status_code != 429
+    assert third.status_code == 429
+
+
+def test_backpressure_rejects_when_full(client: TestClient) -> None:
+    srv._max_waiting_requests = 2
+    assert srv.engine is not None
+    setattr(srv.engine, "scheduler", SimpleNamespace(num_waiting=2))
+
+    response = client.post("/v1/completions", json=_completion_payload())
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "queue_full"
+
+
+def test_backpressure_allows_when_below_limit(client: TestClient) -> None:
+    srv._max_waiting_requests = 10
+    assert srv.engine is not None
+    setattr(srv.engine, "scheduler", SimpleNamespace(num_waiting=2))
+
+    response = client.post("/v1/completions", json=_completion_payload())
+
+    assert response.status_code != 503
+
+
+def test_completion_logprobs_response(client: TestClient) -> None:
+    assert srv.engine is not None
+    mock_engine = cast(Any, srv.engine)
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        if callable(on_token):
+            _ = on_token(
+                _MockOutput(
+                    token_id=7,
+                    token_text="ok",
+                    token_logprob=-0.1,
+                    top_logprobs={7: -0.1, 3: -1.2},
+                )
+            )
+
+    mock_engine.add_request.side_effect = _add_request
+
+    response = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hello",
+            "max_tokens": 4,
+            "logprobs": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["choices"][0]["logprobs"]["token_logprobs"] == [-0.1]
+    assert payload["choices"][0]["logprobs"]["top_logprobs"][0] == {
+        "7": -0.1,
+        "3": -1.2,
+    }
+
+
+def test_chat_completion_logprobs_response(client: TestClient) -> None:
+    assert srv.engine is not None
+    mock_engine = cast(Any, srv.engine)
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        if callable(on_token):
+            _ = on_token(
+                _MockOutput(
+                    token_id=9,
+                    token_text="ok",
+                    token_logprob=-0.25,
+                    top_logprobs={9: -0.25, 4: -0.75},
+                )
+            )
+
+    mock_engine.add_request.side_effect = _add_request
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 4,
+            "logprobs": True,
+            "top_logprobs": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["choices"][0]["logprobs"]["token_logprobs"] == [-0.25]
+    assert payload["choices"][0]["logprobs"]["top_logprobs"][0] == {
+        "9": -0.25,
+        "4": -0.75,
+    }
+
+
+def test_completion_n_multiple_choices(client: TestClient) -> None:
+    assert srv.engine is not None
+    mock_engine = cast(Any, srv.engine)
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        num_sequences = int(kwargs.get("n", 1))
+        if callable(on_token):
+            for seq_id in range(num_sequences):
+                _ = on_token(
+                    _MockOutput(
+                        seq_id=seq_id,
+                        token_id=seq_id + 1,
+                        token_text=f"choice-{seq_id}",
+                        finished=True,
+                    )
+                )
+
+    mock_engine.add_request.side_effect = _add_request
+
+    response = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hello",
+            "max_tokens": 4,
+            "n": 2,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["choices"]) == 2
+    assert [choice["index"] for choice in payload["choices"]] == [0, 1]
+
+
+def test_completion_n_exceeds_max(client: TestClient) -> None:
+    srv._max_n = 2
+
+    response = client.post(
+        "/v1/completions",
+        json={
+            "model": "test-model",
+            "prompt": "hello",
+            "max_tokens": 4,
+            "n": 5,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request_error"
+
+
+def test_json_mode_valid_json(client: TestClient) -> None:
+    assert srv.engine is not None
+    mock_engine = cast(Any, srv.engine)
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        if callable(on_token):
+            _ = on_token(
+                _MockOutput(
+                    seq_id=0,
+                    token_id=1,
+                    token_text='{"ok": true}',
+                    finished=True,
+                    finish_reason="stop",
+                )
+            )
+
+    mock_engine.add_request.side_effect = _add_request
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 4,
+            "response_format": {"type": "json_object"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "stop"
+
+
+def test_json_mode_invalid_json(client: TestClient) -> None:
+    assert srv.engine is not None
+    mock_engine = cast(Any, srv.engine)
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        if callable(on_token):
+            _ = on_token(
+                _MockOutput(
+                    seq_id=0,
+                    token_id=1,
+                    token_text="hello world",
+                    finished=True,
+                    finish_reason="stop",
+                )
+            )
+
+    mock_engine.add_request.side_effect = _add_request
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 4,
+            "response_format": {"type": "json_object"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "error"
+
+
+def test_text_mode_ignores_json_validation(client: TestClient) -> None:
+    assert srv.engine is not None
+    mock_engine = cast(Any, srv.engine)
+
+    def _add_request(**kwargs: Any) -> None:
+        on_token = kwargs.get("on_token")
+        if callable(on_token):
+            _ = on_token(
+                _MockOutput(
+                    seq_id=0,
+                    token_id=1,
+                    token_text="hello world",
+                    finished=True,
+                    finish_reason="stop",
+                )
+            )
+
+    mock_engine.add_request.side_effect = _add_request
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 4,
+            "response_format": {"type": "text"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["choices"][0]["finish_reason"] == "stop"

--- a/tests/python/serving/test_engine.py
+++ b/tests/python/serving/test_engine.py
@@ -360,7 +360,8 @@ def test_engine_n_finished_when_all_complete() -> None:
     first_step_outputs = engine.step()
 
     assert any(
-        output.request_id == "req-n" and output.finished for output in first_step_outputs
+        output.request_id == "req-n" and output.finished
+        for output in first_step_outputs
     )
     assert engine.has_pending_requests() is True
     assert "req-n" not in engine._completed_request_ids

--- a/tests/python/serving/test_engine.py
+++ b/tests/python/serving/test_engine.py
@@ -308,3 +308,59 @@ def test_engine_has_pending_requests() -> None:
     _ = engine.run_until_done()
 
     assert engine.has_pending_requests() is False
+
+
+def test_engine_n_creates_multiple_sequences() -> None:
+    engine = _make_engine(tokenizer=MockTokenizer())
+
+    engine.add_request(
+        request_id="req-n",
+        prompt_token_ids=[10],
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=2),
+        n=3,
+    )
+
+    assert len(engine._request_to_seq_ids["req-n"]) == 3
+
+    outputs = engine.run_until_done()
+
+    assert outputs == {
+        "req-n": [
+            [11, 12],
+            [11, 12],
+            [11, 12],
+        ]
+    }
+    assert engine.get_request_n_outputs("req-n") == [
+        [11, 12],
+        [11, 12],
+        [11, 12],
+    ]
+
+
+def test_engine_n_finished_when_all_complete() -> None:
+    engine = _make_engine()
+
+    engine.add_request(
+        request_id="req-n",
+        prompt_token_ids=[10],
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=3),
+        n=2,
+    )
+
+    original_get_finish_reason = engine._get_finish_reason
+
+    def _get_finish_reason(sequence, token_id):
+        if sequence.seq_id == 0 and len(sequence.output_token_ids) == 1:
+            return "stop"
+        return original_get_finish_reason(sequence, token_id)
+
+    engine._get_finish_reason = _get_finish_reason
+
+    first_step_outputs = engine.step()
+
+    assert any(
+        output.request_id == "req-n" and output.finished for output in first_step_outputs
+    )
+    assert engine.has_pending_requests() is True
+    assert "req-n" not in engine._completed_request_ids

--- a/tests/python/serving/test_sampler.py
+++ b/tests/python/serving/test_sampler.py
@@ -58,8 +58,7 @@ def test_top_k_restricts_to_k() -> None:
     params = SamplingParams(temperature=1.0, top_k=2)
 
     sampled = [
-        sampler.sample(logits, [params]).token_ids[0].item()
-        for _ in range(100)
+        sampler.sample(logits, [params]).token_ids[0].item() for _ in range(100)
     ]
 
     assert set(sampled).issubset({0, 1})
@@ -111,8 +110,7 @@ def test_nucleus_sampling() -> None:
     params = SamplingParams(temperature=1.0, top_p=0.7)
 
     sampled = [
-        sampler.sample(logits, [params]).token_ids[0].item()
-        for _ in range(100)
+        sampler.sample(logits, [params]).token_ids[0].item() for _ in range(100)
     ]
 
     assert set(sampled).issubset({0, 1})

--- a/tests/python/serving/test_sampler.py
+++ b/tests/python/serving/test_sampler.py
@@ -38,7 +38,7 @@ def _sample_many(
 ) -> torch.Tensor:
     counts = torch.zeros(logits.size(-1), dtype=torch.long)
     for _ in range(trials):
-        token = sampler.sample(logits, [params])[0].item()
+        token = sampler.sample(logits, [params]).token_ids[0].item()
         counts[token] += 1
     return counts
 
@@ -49,7 +49,7 @@ def test_greedy_sampling() -> None:
 
     sampled = sampler.sample(logits, [SamplingParams(temperature=0.0)])
 
-    assert sampled.tolist() == [1]
+    assert sampled.token_ids.tolist() == [1]
 
 
 def test_top_k_restricts_to_k() -> None:
@@ -57,7 +57,10 @@ def test_top_k_restricts_to_k() -> None:
     logits = torch.tensor([[9.0, 8.0, 1.0, 0.0]])
     params = SamplingParams(temperature=1.0, top_k=2)
 
-    sampled = [sampler.sample(logits, [params])[0].item() for _ in range(100)]
+    sampled = [
+        sampler.sample(logits, [params]).token_ids[0].item()
+        for _ in range(100)
+    ]
 
     assert set(sampled).issubset({0, 1})
 
@@ -98,8 +101,8 @@ def test_batch_different_params() -> None:
 
     sampled = sampler.sample(logits, params)
 
-    assert sampled[0].item() == 1
-    assert sampled[1].item() in {0, 1}
+    assert sampled.token_ids[0].item() == 1
+    assert sampled.token_ids[1].item() in {0, 1}
 
 
 def test_nucleus_sampling() -> None:
@@ -107,6 +110,59 @@ def test_nucleus_sampling() -> None:
     logits = torch.tensor([[3.0, 2.0, 1.0, 0.0]])
     params = SamplingParams(temperature=1.0, top_p=0.7)
 
-    sampled = [sampler.sample(logits, [params])[0].item() for _ in range(100)]
+    sampled = [
+        sampler.sample(logits, [params]).token_ids[0].item()
+        for _ in range(100)
+    ]
 
     assert set(sampled).issubset({0, 1})
+
+
+def test_sample_returns_sampler_output() -> None:
+    sampler = Sampler()
+    logits = torch.tensor([[1.0, 5.0, 3.0]])
+
+    result = sampler.sample(logits, [SamplingParams(temperature=0.0)])
+
+    assert hasattr(result, "token_ids")
+    assert result.token_ids.tolist() == [1]
+
+
+def test_logprobs_returned_when_requested() -> None:
+    sampler = Sampler()
+    logits = torch.tensor([[1.0, 5.0, 3.0]])
+    params = SamplingParams(temperature=0.0, logprobs=2)
+
+    result = sampler.sample(logits, [params])
+
+    assert result.token_logprobs is not None
+    assert len(result.token_logprobs) == 1
+    assert result.top_logprobs is not None
+    assert len(result.top_logprobs[0]) == 2
+
+
+def test_logprobs_disabled_returns_none() -> None:
+    sampler = Sampler()
+    logits = torch.tensor([[1.0, 5.0, 3.0]])
+    params = SamplingParams(temperature=0.0, logprobs=0)
+
+    result = sampler.sample(logits, [params])
+
+    assert result.token_logprobs is None
+    assert result.top_logprobs is None
+
+
+def test_logprobs_values_are_valid() -> None:
+    sampler = Sampler()
+    logits = torch.tensor([[1.0, 5.0, 3.0]])
+    params = SamplingParams(temperature=0.0, logprobs=3)
+
+    result = sampler.sample(logits, [params])
+
+    assert result.token_logprobs is not None
+    assert result.top_logprobs is not None
+    for lp in result.token_logprobs:
+        assert lp <= 0.0
+    for top_lp_dict in result.top_logprobs:
+        for value in top_lp_dict.values():
+            assert value <= 0.0

--- a/tests/python/unit/test_v2_lifespan.py
+++ b/tests/python/unit/test_v2_lifespan.py
@@ -45,6 +45,9 @@ class _Output:
     def __init__(self) -> None:
         self.token_id = 1
         self.token_text = "ok"
+        self.seq_id = 0
+        self.token_logprob = None
+        self.top_logprobs = None
         self.usage = {
             "prompt_tokens": 1,
             "completion_tokens": 1,

--- a/tests/python/unit/test_v2_validation_integration.py
+++ b/tests/python/unit/test_v2_validation_integration.py
@@ -44,6 +44,9 @@ class _Output:
     def __init__(self) -> None:
         self.token_id = 1
         self.token_text = "ok"
+        self.seq_id = 0
+        self.token_logprob = None
+        self.top_logprobs = None
         self.finished = True
         self.finish_reason = "stop"
         self.usage = {


### PR DESCRIPTION
Add 8 features to make the serving layer production-ready:

1. GET /v1/models — returns ModelList with served model card
2. GET /metrics — Prometheus text format (counters + gauges)
3. API key auth + rate limiting — Bearer token via --api-key/MOE_API_KEYS, sliding-window rate limiter via --rate-limit
4. Backpressure — --max-waiting-requests returns 503 queue_full
5. Logprobs — SamplerOutput with per-token logprobs, threaded through engine → RequestOutput → API response
6. n>1 + best_of — multi-sequence generation with cumulative logprob scoring, capped by --max-n
7. JSON mode — response_format={type: json_object} with post-hoc validation
8. GET /admin/stats — engine stats as JSON

All features developed TDD-style with 533 lines of new tests. No new dependencies added.

## Description
Briefly describe your changes.

## Motivation
Explain why this change is needed and what problem it solves.
If it fixes an issue, link it (e.g., `close #123`).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
