### PR TITLE
feat(kernel): fused attention/FFN/QKV kernels and Marlin GEMM

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+# Vendored third-party kernel (Marlin, Apache-2.0, IST-DASLab) is excluded from
+# style/spelling hooks so we keep it byte-for-byte upstream.
+exclude: ^moe_infinity/kernel/marlin/
+
 repos:
 -   repo: meta
     hooks:

--- a/moe_infinity/kernel/__init__.py
+++ b/moe_infinity/kernel/__init__.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import os
+
 import torch
 
 from .paged_attention_ops import paged_attention_fwd
 from .sglang_adapter import sglang_topk_softmax as topk_softmax
+
+# Environment variable gate for fused kernels (set to "1" to disable)
+_FUSED_KERNELS_DISABLED = (
+    os.environ.get("MOE_DISABLE_FUSED_KERNELS", "0") == "1"
+)
 
 
 def launch_fused_softmax_topk_nobias(
@@ -17,8 +24,73 @@ def launch_fused_softmax_topk_nobias(
     return _impl(hidden_states, weight, top_k, normalize_topk)
 
 
+def fused_qkv_proj(
+    hidden_states: torch.Tensor,
+    weight_qkv: torch.Tensor,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused QKV projection. Falls back to 3 matmuls if fused kernels disabled."""
+    if _FUSED_KERNELS_DISABLED:
+        q_dim = num_q_heads * head_dim
+        kv_dim = num_kv_heads * head_dim
+        prefix_shape = hidden_states.shape[:-1]
+        h = hidden_states.reshape(-1, hidden_states.shape[-1])
+        out = h @ weight_qkv
+        q = out[:, :q_dim].reshape(*prefix_shape, num_q_heads, head_dim)
+        k = out[:, q_dim : q_dim + kv_dim].reshape(
+            *prefix_shape, num_kv_heads, head_dim
+        )
+        v = out[:, q_dim + kv_dim :].reshape(
+            *prefix_shape, num_kv_heads, head_dim
+        )
+        return q, k, v
+    from .fused_qkv import fused_qkv_proj as _impl
+
+    return _impl(hidden_states, weight_qkv, num_q_heads, num_kv_heads, head_dim)
+
+
+def fused_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+) -> torch.Tensor:
+    """Fused Gate+Up+SiLU+Down FFN. Falls back to eager if disabled."""
+    if _FUSED_KERNELS_DISABLED:
+        import torch.nn.functional as F
+
+        intermediate = F.silu(x @ gate_weight.T) * (x @ up_weight.T)
+        return intermediate @ down_weight.T
+    from .fused_ffn import fused_ffn as _impl
+
+    return _impl(x, gate_weight, up_weight, down_weight)
+
+
+def fused_decode_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Fused decode attention with paged KV. Falls back to FlashInfer/SDPA if disabled."""
+    if _FUSED_KERNELS_DISABLED:
+        return paged_attention_fwd(
+            query, key_cache, value_cache, block_tables, seq_lens, scale
+        )
+    from .fused_decode_attn import fused_decode_attention as _impl
+
+    return _impl(query, key_cache, value_cache, block_tables, seq_lens, scale)
+
+
 __all__ = [
     "topk_softmax",
     "launch_fused_softmax_topk_nobias",
     "paged_attention_fwd",
+    "fused_qkv_proj",
+    "fused_ffn",
+    "fused_decode_attention",
 ]

--- a/moe_infinity/kernel/_loader.py
+++ b/moe_infinity/kernel/_loader.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import importlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+
+
+def _import_triton_symbol(
+    module_names: tuple[str, ...], symbol_name: str
+) -> Any | None:
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+            return getattr(module, symbol_name)
+        except Exception:
+            continue
+    return None
+
+
+ASTSource = _import_triton_symbol(
+    ("triton.compiler.compiler", "triton.compiler"), "ASTSource"
+)
+CompiledKernel = _import_triton_symbol(
+    ("triton.compiler.compiler", "triton.compiler"),
+    "CompiledKernel",
+)
+if CompiledKernel is None:  # pragma: no cover - Triton not installed
+    CompiledKernel = Any
+make_backend = _import_triton_symbol(
+    ("triton.compiler.compiler", "triton.compiler"),
+    "make_backend",
+)
+GPUTarget = _import_triton_symbol(
+    ("triton.backends.compiler", "triton.compiler.compiler"),
+    "GPUTarget",
+)
+
+_KERNEL_CACHE: dict[tuple[str, str], Optional[CompiledKernel]] = {}
+_KERNEL_DIR = Path(__file__).resolve().parent
+_COMPILED_DIR = _KERNEL_DIR / "_compiled"
+_RUNTIME_DIR = _COMPILED_DIR / ".runtime"
+
+
+def _current_arch() -> str | None:
+    if not torch.cuda.is_available():
+        return None
+    major, minor = torch.cuda.get_device_capability()
+    return f"{major}{minor}"
+
+
+def _make_target(arch: str) -> Any | None:
+    if GPUTarget is None:
+        return None
+    return GPUTarget("cuda", int(arch), 32)
+
+
+def _runtime_binary_ext(arch: str) -> str:
+    if make_backend is None:
+        return "so"
+    target = _make_target(arch)
+    if target is None:
+        return "so"
+    try:
+        return str(make_backend(target).binary_ext)
+    except Exception:
+        return "so"
+
+
+def _artifact_paths(kernel_name: str, arch: str) -> tuple[Path, Path, Path]:
+    stem = f"{kernel_name}_{arch}"
+    return (
+        _COMPILED_DIR / f"{stem}.so",
+        _COMPILED_DIR / f"{stem}.json",
+        _COMPILED_DIR / f"{stem}.manifest",
+    )
+
+
+def _load_manifest(manifest_path: Path) -> dict[str, Any] | None:
+    if manifest_path.exists():
+        return json.loads(manifest_path.read_text())
+    return None
+
+
+def _build_ast_source(manifest: dict[str, Any]) -> Any | None:
+    if ASTSource is None:
+        return None
+    module = importlib.import_module(manifest["module"])
+    kernel_fn = getattr(module, manifest["function"])
+    signature = dict(manifest.get("signature", {}))
+    constants = dict(manifest.get("constants", {}))
+    return ASTSource(kernel_fn, signature=signature, constexprs=constants)
+
+
+def _prepare_runtime_artifacts(
+    kernel_name: str,
+    arch: str,
+    so_path: Path,
+    metadata_path: Path,
+) -> dict[str, str]:
+    _RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
+    binary_ext = _runtime_binary_ext(arch)
+    stem = f"{kernel_name}_{arch}"
+    runtime_binary_path = _RUNTIME_DIR / f"{stem}.{binary_ext}"
+    runtime_metadata_path = _RUNTIME_DIR / f"{stem}.json"
+
+    if binary_ext == "so":
+        runtime_binary_path = so_path
+    elif not runtime_binary_path.exists():
+        shutil.copyfile(so_path, runtime_binary_path)
+
+    if (
+        runtime_metadata_path != metadata_path
+        and not runtime_metadata_path.exists()
+    ):
+        shutil.copyfile(metadata_path, runtime_metadata_path)
+
+    return {
+        runtime_metadata_path.name: str(runtime_metadata_path),
+        runtime_binary_path.name: str(runtime_binary_path),
+    }
+
+
+def load_compiled_kernel(kernel_name: str) -> Optional[CompiledKernel]:
+    arch = _current_arch()
+    if arch is None:
+        return None
+
+    cache_key = (kernel_name, arch)
+    if cache_key in _KERNEL_CACHE:
+        return _KERNEL_CACHE[cache_key]
+
+    so_path, metadata_path, manifest_path = _artifact_paths(kernel_name, arch)
+    if not so_path.exists() or not metadata_path.exists():
+        _KERNEL_CACHE[cache_key] = None
+        return None
+
+    manifest = _load_manifest(manifest_path)
+    if manifest is None:
+        _KERNEL_CACHE[cache_key] = None
+        return None
+
+    try:
+        metadata = json.loads(metadata_path.read_text())
+        source = _build_ast_source(manifest)
+        if source is None or CompiledKernel is Any:
+            kernel = None
+        else:
+            metadata_group = _prepare_runtime_artifacts(
+                kernel_name,
+                arch,
+                so_path,
+                metadata_path,
+            )
+            kernel = CompiledKernel(
+                source, metadata_group, metadata.get("hash", kernel_name)
+            )
+    except Exception:
+        kernel = None
+
+    _KERNEL_CACHE[cache_key] = kernel
+    return kernel
+
+
+__all__ = ["load_compiled_kernel"]

--- a/moe_infinity/kernel/deterministic_matmul.py
+++ b/moe_infinity/kernel/deterministic_matmul.py
@@ -1,0 +1,74 @@
+# ruff: noqa: I001
+
+import torch
+import os
+
+
+_STATE = None
+
+
+def _capture_state():
+    global _STATE
+    if _STATE is not None:
+        return
+    _STATE = {
+        "deterministic_algorithms": torch.are_deterministic_algorithms_enabled(),
+        "cublas_workspace_config": os.environ.get("CUBLAS_WORKSPACE_CONFIG"),
+        "nccl_algo": os.environ.get("NCCL_ALGO"),
+    }
+
+
+def enable_deterministic_mode():
+    _capture_state()
+    torch.use_deterministic_algorithms(True)
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":16:8"
+    os.environ["NCCL_ALGO"] = "Tree"
+
+
+def disable_deterministic_mode():
+    global _STATE
+    if _STATE is None:
+        torch.use_deterministic_algorithms(False)
+        os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+        os.environ.pop("NCCL_ALGO", None)
+        return
+
+    torch.use_deterministic_algorithms(_STATE["deterministic_algorithms"])
+
+    if _STATE["cublas_workspace_config"] is None:
+        os.environ.pop("CUBLAS_WORKSPACE_CONFIG", None)
+    else:
+        os.environ["CUBLAS_WORKSPACE_CONFIG"] = _STATE[
+            "cublas_workspace_config"
+        ]
+
+    if _STATE["nccl_algo"] is None:
+        os.environ.pop("NCCL_ALGO", None)
+    else:
+        os.environ["NCCL_ALGO"] = _STATE["nccl_algo"]
+
+    _STATE = None
+
+
+def deterministic_linear(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> torch.Tensor:
+    allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+    try:
+        torch.backends.cuda.matmul.allow_tf32 = False
+        if input.dim() <= 1:
+            output = input.matmul(weight.t())
+        else:
+            output = torch.stack(
+                [sample.matmul(weight.t()) for sample in input.unbind(dim=0)],
+                dim=0,
+            )
+        if bias is not None:
+            output = output + bias
+        return output
+    finally:
+        torch.backends.cuda.matmul.allow_tf32 = allow_tf32
+
+
+if os.environ.get("MOE_DETERMINISTIC") == "1":
+    enable_deterministic_mode()

--- a/moe_infinity/kernel/fused_decode_attn.py
+++ b/moe_infinity/kernel/fused_decode_attn.py
@@ -1,0 +1,268 @@
+"""Decode-phase fused paged attention Triton kernel.
+
+Specialized for decode where each sequence contributes exactly one new query
+token attending over its paged KV cache.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_KV": 32}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_KV": 64}, num_stages=2, num_warps=4),
+        triton.Config({"BLOCK_KV": 128}, num_stages=2, num_warps=8),
+    ],
+    key=["head_dim", "block_size", "max_blocks_per_seq"],
+)
+@triton.jit
+def _fused_decode_attention_kernel(
+    query_ptr,  # [batch, 1, num_heads, head_dim]
+    key_ptr,  # [num_blocks, block_size, num_kv_heads, head_dim]
+    value_ptr,  # [num_blocks, block_size, num_kv_heads, head_dim]
+    block_tables_ptr,  # [batch, max_blocks_per_seq]
+    seq_lens_ptr,  # [batch]
+    out_ptr,  # [batch, num_heads, head_dim]
+    scale,
+    head_dim,
+    block_size,
+    max_blocks_per_seq,
+    q_stride_b,
+    q_stride_t,
+    q_stride_h,
+    q_stride_d,
+    k_stride_block,
+    k_stride_token,
+    k_stride_head,
+    k_stride_d,
+    v_stride_block,
+    v_stride_token,
+    v_stride_head,
+    v_stride_d,
+    bt_stride_b,
+    bt_stride_block,
+    out_stride_b,
+    out_stride_h,
+    out_stride_d,
+    QUERY_GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_KV: tl.constexpr,
+):
+    batch_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    offs_d = tl.arange(0, HEAD_DIM)
+    out_ptrs = (
+        out_ptr
+        + batch_idx * out_stride_b
+        + head_idx * out_stride_h
+        + offs_d * out_stride_d
+    )
+
+    seq_len = tl.load(seq_lens_ptr + batch_idx).to(tl.int32)
+    if seq_len <= 0:
+        tl.store(
+            out_ptrs,
+            tl.zeros((HEAD_DIM,), dtype=tl.bfloat16),
+            mask=offs_d < head_dim,
+        )
+        return
+
+    kv_head_idx = head_idx // QUERY_GROUP_SIZE
+    q_ptrs = (
+        query_ptr
+        + batch_idx * q_stride_b
+        + 0 * q_stride_t
+        + head_idx * q_stride_h
+        + offs_d * q_stride_d
+    )
+    q = tl.load(q_ptrs, mask=offs_d < head_dim, other=0.0).to(tl.float32)
+
+    acc = tl.zeros((HEAD_DIM,), dtype=tl.float32)
+    m_i = tl.full((), float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros((), dtype=tl.float32)
+
+    for token_start in range(0, tl.cdiv(seq_len, BLOCK_KV)):
+        offs_t = token_start * BLOCK_KV + tl.arange(0, BLOCK_KV)
+        token_mask = offs_t < seq_len
+
+        logical_block_idx = offs_t // block_size
+        token_in_block = offs_t % block_size
+        block_table_ptrs = (
+            block_tables_ptr
+            + batch_idx * bt_stride_b
+            + logical_block_idx * bt_stride_block
+        )
+        physical_block_idx = tl.load(block_table_ptrs, mask=token_mask, other=0)
+
+        k_ptrs = (
+            key_ptr
+            + physical_block_idx[:, None] * k_stride_block
+            + token_in_block[:, None] * k_stride_token
+            + kv_head_idx * k_stride_head
+            + offs_d[None, :] * k_stride_d
+        )
+        kv_mask = token_mask[:, None] & (offs_d[None, :] < head_dim)
+        k = tl.load(k_ptrs, mask=kv_mask, other=0.0).to(tl.float32)
+        logits = tl.sum(k * q[None, :], axis=1) * scale
+        logits = tl.where(token_mask, logits, float("-inf"))
+
+        m_ij = tl.max(logits, axis=0)
+        m_new = tl.maximum(m_i, m_ij)
+        alpha = tl.exp(m_i - m_new)
+        p = tl.exp(logits - m_new)
+        p = tl.where(token_mask, p, 0.0)
+
+        v_ptrs = (
+            value_ptr
+            + physical_block_idx[:, None] * v_stride_block
+            + token_in_block[:, None] * v_stride_token
+            + kv_head_idx * v_stride_head
+            + offs_d[None, :] * v_stride_d
+        )
+        v = tl.load(v_ptrs, mask=kv_mask, other=0.0).to(tl.float32)
+
+        acc = acc * alpha + tl.sum(v * p[:, None], axis=0)
+        l_i = l_i * alpha + tl.sum(p, axis=0)
+        m_i = m_new
+
+    out = tl.where(l_i > 0, acc / l_i, 0.0)
+    tl.store(out_ptrs, out.to(tl.bfloat16), mask=offs_d < head_dim)
+
+
+def fused_decode_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Launch decode-only single-query paged attention.
+
+    Args:
+        query: ``[batch, 1, num_heads, head_dim]`` bf16
+        key_cache: ``[num_blocks, block_size, num_kv_heads, head_dim]`` bf16
+        value_cache: ``[num_blocks, block_size, num_kv_heads, head_dim]`` bf16
+        block_tables: ``[batch, max_blocks_per_seq]`` int32
+        seq_lens: ``[batch]`` int32
+        scale: attention scaling factor
+
+    Returns:
+        ``[batch, num_heads, head_dim]`` bf16
+    """
+    if query.ndim != 4:
+        raise ValueError(
+            "query must have shape [batch, 1, num_heads, head_dim]"
+        )
+    if query.shape[1] != 1:
+        raise ValueError("decode attention expects exactly one query token")
+    if key_cache.ndim != 4 or value_cache.ndim != 4:
+        raise ValueError(
+            "key_cache and value_cache must have shape [num_blocks, block_size, num_kv_heads, head_dim]"
+        )
+    if key_cache.shape != value_cache.shape:
+        raise ValueError("key_cache and value_cache must have identical shapes")
+    if block_tables.ndim != 2:
+        raise ValueError(
+            "block_tables must have shape [batch, max_blocks_per_seq]"
+        )
+    if seq_lens.ndim != 1:
+        raise ValueError("seq_lens must have shape [batch]")
+
+    if not (
+        query.is_cuda
+        and key_cache.is_cuda
+        and value_cache.is_cuda
+        and block_tables.is_cuda
+        and seq_lens.is_cuda
+    ):
+        raise ValueError("fused_decode_attention requires CUDA tensors")
+
+    if query.dtype != torch.bfloat16:
+        raise ValueError(f"query must be bf16, got {query.dtype}")
+    if key_cache.dtype != torch.bfloat16 or value_cache.dtype != torch.bfloat16:
+        raise ValueError("key_cache and value_cache must be bf16")
+    if block_tables.dtype != torch.int32:
+        raise ValueError("block_tables must be int32")
+    if seq_lens.dtype != torch.int32:
+        raise ValueError("seq_lens must be int32")
+
+    batch, _, num_heads, head_dim = query.shape
+    num_blocks, block_size, num_kv_heads, kv_head_dim = key_cache.shape
+    if kv_head_dim != head_dim:
+        raise ValueError("query and KV cache head_dim must match")
+    if block_tables.shape[0] != batch:
+        raise ValueError("block_tables batch dimension must match query")
+    if seq_lens.shape[0] != batch:
+        raise ValueError("seq_lens batch dimension must match query")
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("num_heads must be divisible by num_kv_heads")
+    if head_dim not in (64, 128):
+        raise ValueError(f"head_dim must be 64 or 128, got {head_dim}")
+    if num_blocks <= 0:
+        raise ValueError("key_cache must contain at least one block")
+    if block_tables.shape[1] <= 0:
+        raise ValueError("block_tables must contain at least one block slot")
+    max_supported_seq_len = block_tables.shape[1] * block_size
+    if int(seq_lens.max().item()) > max_supported_seq_len:
+        raise ValueError(
+            "seq_lens exceed block_tables capacity for the provided block_size"
+        )
+
+    query = query.contiguous()
+    key_cache = key_cache.contiguous()
+    value_cache = value_cache.contiguous()
+    block_tables = block_tables.contiguous()
+    seq_lens = seq_lens.contiguous()
+
+    output = torch.empty(
+        (batch, num_heads, head_dim), dtype=query.dtype, device=query.device
+    )
+    if output.numel() == 0:
+        return output
+
+    query_group_size = num_heads // num_kv_heads
+    max_blocks_per_seq = block_tables.shape[1]
+    grid = (batch, num_heads)
+
+    _fused_decode_attention_kernel[grid](
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        output,
+        float(scale),
+        head_dim,
+        block_size,
+        max_blocks_per_seq,
+        query.stride(0),
+        query.stride(1),
+        query.stride(2),
+        query.stride(3),
+        key_cache.stride(0),
+        key_cache.stride(1),
+        key_cache.stride(2),
+        key_cache.stride(3),
+        value_cache.stride(0),
+        value_cache.stride(1),
+        value_cache.stride(2),
+        value_cache.stride(3),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        QUERY_GROUP_SIZE=query_group_size,
+        HEAD_DIM=head_dim,
+    )
+
+    return output
+
+
+__all__ = ["fused_decode_attention"]

--- a/moe_infinity/kernel/fused_ffn.py
+++ b/moe_infinity/kernel/fused_ffn.py
@@ -1,0 +1,273 @@
+"""Fused Gate+Up+SiLU FFN Triton kernel.
+
+Computes the gated intermediate ``silu(x @ gate_weight.T) * (x @ up_weight.T)``
+in a single Triton pass so ``x`` is read once per tile, then finishes the FFN
+with a second matmul against ``down_weight.T``.
+"""
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _silu(x):
+    """Compute the SiLU activation in Triton."""
+    return x * tl.sigmoid(x)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 32},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 64, "BLOCK_K": 64},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 128, "BLOCK_K": 32},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 32, "BLOCK_N": 128, "BLOCK_K": 64},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 32},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 64},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64},
+            num_stages=3,
+            num_warps=4,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 64},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32},
+            num_stages=3,
+            num_warps=8,
+        ),
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64},
+            num_stages=3,
+            num_warps=8,
+        ),
+    ],
+    key=["M", "N", "K"],
+)
+@triton.jit
+def _fused_gate_up_silu_kernel(
+    x_ptr,  # [M, K] bf16  — input activations
+    gate_weight_ptr,  # [N, K] bf16  — gate projection weights
+    up_weight_ptr,  # [N, K] bf16  — up projection weights
+    intermediate_ptr,  # [M, N] bf16 — fused intermediate activations
+    M,
+    N,
+    K,
+    stride_x_m,
+    stride_x_k,
+    stride_gate_n,
+    stride_gate_k,
+    stride_up_n,
+    stride_up_k,
+    stride_intermediate_m,
+    stride_intermediate_n,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Fuse gate/up GEMMs with SiLU and elementwise multiply."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    gate_acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    up_acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_block in range(0, tl.cdiv(K, BLOCK_K)):
+        k_start = k_block * BLOCK_K
+        k_offsets = k_start + offs_k
+
+        x_ptrs = (
+            x_ptr
+            + offs_m[:, None] * stride_x_m
+            + k_offsets[None, :] * stride_x_k
+        )
+        gate_ptrs = (
+            gate_weight_ptr
+            + offs_n[:, None] * stride_gate_n
+            + k_offsets[None, :] * stride_gate_k
+        )
+        up_ptrs = (
+            up_weight_ptr
+            + offs_n[:, None] * stride_up_n
+            + k_offsets[None, :] * stride_up_k
+        )
+
+        x_mask = (offs_m[:, None] < M) & (k_offsets[None, :] < K)
+        weight_mask = (offs_n[:, None] < N) & (k_offsets[None, :] < K)
+
+        x_tile = tl.load(x_ptrs, mask=x_mask, other=0.0)
+        gate_tile = tl.load(gate_ptrs, mask=weight_mask, other=0.0)
+        up_tile = tl.load(up_ptrs, mask=weight_mask, other=0.0)
+
+        gate_acc += tl.dot(
+            x_tile.to(tl.bfloat16),
+            tl.trans(gate_tile.to(tl.bfloat16)),
+            allow_tf32=False,
+        )
+        up_acc += tl.dot(
+            x_tile.to(tl.bfloat16),
+            tl.trans(up_tile.to(tl.bfloat16)),
+            allow_tf32=False,
+        )
+
+    fused = _silu(gate_acc) * up_acc
+
+    intermediate_ptrs = (
+        intermediate_ptr
+        + offs_m[:, None] * stride_intermediate_m
+        + offs_n[None, :] * stride_intermediate_n
+    )
+    intermediate_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    tl.store(intermediate_ptrs, fused.to(tl.bfloat16), mask=intermediate_mask)
+
+
+def reference_ffn(
+    x: torch.Tensor,
+    gate_w: torch.Tensor,
+    up_w: torch.Tensor,
+    down_w: torch.Tensor,
+) -> torch.Tensor:
+    """Reference FFN implementation for correctness checks."""
+    return (F.silu(x @ gate_w.T) * (x @ up_w.T)) @ down_w.T
+
+
+def fused_ffn(
+    x: torch.Tensor,
+    gate_weight: torch.Tensor,
+    up_weight: torch.Tensor,
+    down_weight: torch.Tensor,
+) -> torch.Tensor:
+    """Run a two-pass fused FFN.
+
+    Pass 1 computes ``silu(x @ gate_weight.T) * (x @ up_weight.T)`` in Triton
+    without materialising the gate and up projections separately. Pass 2 applies
+    the down projection with a standard matmul.
+
+    Args:
+        x: Input activations ``[M, K]`` in bf16.
+        gate_weight: Gate projection weights ``[I, K]`` in bf16.
+        up_weight: Up projection weights ``[I, K]`` in bf16.
+        down_weight: Down projection weights ``[K_out, I]`` in bf16.
+
+    Returns:
+        Output activations ``[M, K_out]``.
+    """
+    if x.dim() != 2:
+        raise ValueError(f"x must be 2D [M, K], got shape {tuple(x.shape)}")
+    if gate_weight.dim() != 2 or up_weight.dim() != 2 or down_weight.dim() != 2:
+        raise ValueError("gate_weight, up_weight, and down_weight must be 2D")
+
+    x = x.contiguous()
+    gate_weight = gate_weight.contiguous()
+    up_weight = up_weight.contiguous()
+    down_weight = down_weight.contiguous()
+
+    if x.dtype != torch.bfloat16:
+        raise TypeError(f"x must be bf16, got {x.dtype}")
+    if gate_weight.dtype != torch.bfloat16:
+        raise TypeError(f"gate_weight must be bf16, got {gate_weight.dtype}")
+    if up_weight.dtype != torch.bfloat16:
+        raise TypeError(f"up_weight must be bf16, got {up_weight.dtype}")
+    if down_weight.dtype != torch.bfloat16:
+        raise TypeError(f"down_weight must be bf16, got {down_weight.dtype}")
+    if not x.is_cuda:
+        raise ValueError("x must be a CUDA tensor")
+    if (
+        not gate_weight.is_cuda
+        or not up_weight.is_cuda
+        or not down_weight.is_cuda
+    ):
+        raise ValueError("all weights must be CUDA tensors")
+    if (
+        gate_weight.device != x.device
+        or up_weight.device != x.device
+        or down_weight.device != x.device
+    ):
+        raise ValueError("x and all weights must be on the same CUDA device")
+
+    M, K = x.shape
+    I, gate_k = gate_weight.shape
+    up_i, up_k = up_weight.shape
+    _, down_i = down_weight.shape
+
+    if gate_k != K or up_k != K:
+        raise ValueError(
+            f"projection K mismatch: x has K={K}, gate has K={gate_k}, up has K={up_k}"
+        )
+    if up_i != I:
+        raise ValueError(
+            f"intermediate size mismatch: gate has I={I}, up has I={up_i}"
+        )
+    if down_i != I:
+        raise ValueError(
+            f"down projection mismatch: intermediate I={I}, down expects I={down_i}"
+        )
+
+    intermediate = torch.empty((M, I), dtype=torch.bfloat16, device=x.device)
+
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(I, META["BLOCK_N"]),
+    )
+
+    _fused_gate_up_silu_kernel[grid](
+        x,
+        gate_weight,
+        up_weight,
+        intermediate,
+        M,
+        I,
+        K,
+        x.stride(0),
+        x.stride(1),
+        gate_weight.stride(0),
+        gate_weight.stride(1),
+        up_weight.stride(0),
+        up_weight.stride(1),
+        intermediate.stride(0),
+        intermediate.stride(1),
+    )
+
+    return torch.matmul(intermediate, down_weight.t())

--- a/moe_infinity/kernel/fused_qkv.py
+++ b/moe_infinity/kernel/fused_qkv.py
@@ -1,0 +1,232 @@
+"""Fused QKV projection Triton kernel.
+
+Computes Q, K, V = X @ [W_q | W_k | W_v] in a single GEMM pass."""
+
+# ruff: noqa: I001
+
+import triton
+import triton.language as tl
+import torch
+
+
+_AUTOTUNE_CONFIGS = [
+    triton.Config(
+        {"BLOCK_M": block_m, "BLOCK_N": block_n, "BLOCK_K": block_k},
+        num_stages=3 if block_k == 32 else 4,
+        num_warps=4 if block_m * block_n <= 8192 else 8,
+    )
+    for block_m in (32, 64, 128)
+    for block_n in (64, 128, 256)
+    for block_k in (32, 64)
+]
+
+
+@triton.autotune(
+    configs=_AUTOTUNE_CONFIGS,
+    key=["M", "N", "K"],
+)
+@triton.jit
+def _fused_qkv_kernel(
+    hidden_ptr,
+    weight_ptr,
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    M,
+    N,
+    K,
+    Q_DIM,
+    KV_DIM,
+    stride_hidden_m,
+    stride_hidden_k,
+    stride_weight_k,
+    stride_weight_n,
+    stride_q_m,
+    stride_q_n,
+    stride_k_m,
+    stride_k_n,
+    stride_v_m,
+    stride_v_n,
+    OUTPUT_IS_BF16: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_start in range(0, tl.cdiv(K, BLOCK_K)):
+        k_block = k_start * BLOCK_K + offs_k
+        hidden_ptrs = (
+            hidden_ptr
+            + offs_m[:, None] * stride_hidden_m
+            + k_block[None, :] * stride_hidden_k
+        )
+        weight_ptrs = (
+            weight_ptr
+            + k_block[:, None] * stride_weight_k
+            + offs_n[None, :] * stride_weight_n
+        )
+
+        hidden_mask = (offs_m[:, None] < M) & (k_block[None, :] < K)
+        weight_mask = (k_block[:, None] < K) & (offs_n[None, :] < N)
+
+        hidden = tl.load(hidden_ptrs, mask=hidden_mask, other=0.0)
+        weight = tl.load(weight_ptrs, mask=weight_mask, other=0.0)
+        acc += tl.dot(hidden, weight, allow_tf32=False)
+
+    if OUTPUT_IS_BF16:
+        out = acc.to(tl.bfloat16)
+    else:
+        out = acc.to(tl.float16)
+
+    q_mask = (offs_m[:, None] < M) & (offs_n[None, :] < Q_DIM)
+    q_ptrs = q_ptr + offs_m[:, None] * stride_q_m + offs_n[None, :] * stride_q_n
+    tl.store(q_ptrs, out, mask=q_mask)
+
+    k_offsets = offs_n - Q_DIM
+    k_mask = (
+        (offs_m[:, None] < M)
+        & (offs_n[None, :] >= Q_DIM)
+        & (offs_n[None, :] < Q_DIM + KV_DIM)
+    )
+    k_ptrs = (
+        k_ptr + offs_m[:, None] * stride_k_m + k_offsets[None, :] * stride_k_n
+    )
+    tl.store(k_ptrs, out, mask=k_mask)
+
+    v_offsets = offs_n - Q_DIM - KV_DIM
+    v_mask = (
+        (offs_m[:, None] < M)
+        & (offs_n[None, :] >= Q_DIM + KV_DIM)
+        & (offs_n[None, :] < N)
+    )
+    v_ptrs = (
+        v_ptr + offs_m[:, None] * stride_v_m + v_offsets[None, :] * stride_v_n
+    )
+    tl.store(v_ptrs, out, mask=v_mask)
+
+
+def fused_qkv_proj(
+    hidden_states: torch.Tensor,
+    weight_qkv: torch.Tensor,
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Project hidden states into Q, K, V with one Triton GEMM pass.
+
+    Args:
+        hidden_states: Input activations with shape ``[*, hidden_dim]``.
+        weight_qkv: Concatenated projection weights with shape
+            ``[hidden_dim, (num_q_heads + 2 * num_kv_heads) * head_dim]``.
+        num_q_heads: Number of query heads.
+        num_kv_heads: Number of key/value heads.
+        head_dim: Per-head hidden size.
+
+    Returns:
+        Tuple of ``(q, k, v)`` with shapes
+        ``[*, num_q_heads, head_dim]``,
+        ``[*, num_kv_heads, head_dim]``,
+        ``[*, num_kv_heads, head_dim]``.
+    """
+    if hidden_states.dim() < 2:
+        raise ValueError(
+            f"hidden_states must be at least 2D, got shape {tuple(hidden_states.shape)}"
+        )
+    if hidden_states.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(
+            f"hidden_states must be fp16 or bf16, got {hidden_states.dtype}"
+        )
+    if weight_qkv.dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError(
+            f"weight_qkv must be fp16 or bf16, got {weight_qkv.dtype}"
+        )
+    if hidden_states.dtype != weight_qkv.dtype:
+        raise TypeError(
+            "hidden_states and weight_qkv must share the same dtype, got "
+            f"{hidden_states.dtype} and {weight_qkv.dtype}"
+        )
+    if not hidden_states.is_cuda or not weight_qkv.is_cuda:
+        raise ValueError("hidden_states and weight_qkv must be CUDA tensors")
+
+    orig_shape = hidden_states.shape
+    hidden_states_2d = hidden_states.reshape(
+        -1, hidden_states.shape[-1]
+    ).contiguous()
+    weight_qkv = weight_qkv.contiguous()
+
+    M, K = hidden_states_2d.shape
+    q_dim = num_q_heads * head_dim
+    kv_dim = num_kv_heads * head_dim
+    total_dim = q_dim + 2 * kv_dim
+
+    if weight_qkv.dim() != 2:
+        raise ValueError(
+            f"weight_qkv must be 2D, got shape {tuple(weight_qkv.shape)}"
+        )
+    if weight_qkv.shape[0] != K:
+        raise ValueError(
+            f"hidden dimension mismatch: hidden_states={K}, weight_qkv={weight_qkv.shape[0]}"
+        )
+    if weight_qkv.shape[1] != total_dim:
+        raise ValueError(
+            "output dimension mismatch: expected "
+            f"{total_dim}, got {weight_qkv.shape[1]}"
+        )
+
+    q = torch.empty(
+        (M, q_dim), dtype=hidden_states_2d.dtype, device=hidden_states_2d.device
+    )
+    k = torch.empty(
+        (M, kv_dim),
+        dtype=hidden_states_2d.dtype,
+        device=hidden_states_2d.device,
+    )
+    v = torch.empty(
+        (M, kv_dim),
+        dtype=hidden_states_2d.dtype,
+        device=hidden_states_2d.device,
+    )
+
+    grid = lambda meta: (  # noqa: E731
+        triton.cdiv(M, meta["BLOCK_M"]),
+        triton.cdiv(total_dim, meta["BLOCK_N"]),
+    )
+
+    _fused_qkv_kernel[grid](
+        hidden_states_2d,
+        weight_qkv,
+        q,
+        k,
+        v,
+        M,
+        total_dim,
+        K,
+        q_dim,
+        kv_dim,
+        hidden_states_2d.stride(0),
+        hidden_states_2d.stride(1),
+        weight_qkv.stride(0),
+        weight_qkv.stride(1),
+        q.stride(0),
+        q.stride(1),
+        k.stride(0),
+        k.stride(1),
+        v.stride(0),
+        v.stride(1),
+        OUTPUT_IS_BF16=(hidden_states_2d.dtype == torch.bfloat16),
+    )
+
+    prefix_shape = orig_shape[:-1]
+    return (
+        q.reshape(*prefix_shape, num_q_heads, head_dim),
+        k.reshape(*prefix_shape, num_kv_heads, head_dim),
+        v.reshape(*prefix_shape, num_kv_heads, head_dim),
+    )

--- a/moe_infinity/kernel/marlin/LICENSE
+++ b/moe_infinity/kernel/marlin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/moe_infinity/kernel/marlin/marlin_cuda.cpp
+++ b/moe_infinity/kernel/marlin/marlin_cuda.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <torch/all.h>
+#include <torch/python.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime.h>
+
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 16
+);
+
+const int ERR_PROB_SHAPE = 1;
+const int ERR_KERN_SHAPE = 2;
+
+void mul(
+  const torch::Tensor& A,
+  const torch::Tensor& B,
+        torch::Tensor& C,
+  const torch::Tensor& s,
+        torch::Tensor& workspace,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 8
+) {
+  int prob_m = A.size(0);
+  int prob_n = C.size(1);
+  int prob_k = A.size(1);
+  int groupsize = (s.size(0) == 1) ? -1 : prob_k / s.size(0);
+  if (groupsize != -1 && groupsize * s.size(0) != prob_k)
+    AT_ERROR("k=", prob_k, " not compatible with ", s.size(0), " groups.");
+  if (workspace.numel() < prob_n / 128 * max_par)
+    AT_ERROR("workspace must be of size at least ", prob_n / 128 * max_par, ".");
+  int dev = A.get_device();
+  int err = marlin_cuda(
+    A.data_ptr(),
+    B.data_ptr(),
+    C.data_ptr(),
+    s.data_ptr(),
+    prob_m, prob_n, prob_k,
+    workspace.data_ptr(),
+    groupsize,
+    dev,
+    at::cuda::getCurrentCUDAStream(dev),
+    thread_k,
+    thread_n,
+    sms,
+    max_par
+  );
+  if (err == ERR_PROB_SHAPE) {
+    AT_ERROR(
+      "Problem (m=", prob_m, ", n=", prob_n, ", k=", prob_k, ")",
+      " not compatible with thread_k=", thread_k, ", thread_n=", thread_n, "."
+    );
+  } else if (err == ERR_KERN_SHAPE) {
+    AT_ERROR(
+      "No kernel implementation for thread_k=", thread_k, ", thread_n=", thread_n, ", groupsize=", groupsize, "."
+    );
+  }
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("mul", &mul, "Marlin FP16xINT4 matmul.");
+}

--- a/moe_infinity/kernel/marlin/marlin_cuda_kernel.cu
+++ b/moe_infinity/kernel/marlin/marlin_cuda_kernel.cu
@@ -1,0 +1,822 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef MARLIN_CUDA_KERNEL_CUH
+#define MARLIN_CUDA_KERNEL_CUH
+
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <iostream>
+
+
+constexpr int ceildiv(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+// Instances of `Vec` are used to organize groups of >>registers<<, as needed for instance as inputs to tensor core
+// operations. Consequently, all corresponding index accesses must be compile-time constants, which is why we
+// extensively use `#pragma unroll` throughout the kernel code to guarantee this.
+template <typename T, int n>
+struct Vec {
+  T elems[n];
+  __device__ T& operator[](int i) {
+    return elems[i];
+  }
+};
+
+using I4 = Vec<int, 4>;
+
+// Matrix fragments for tensor core instructions; their precise layout is documented here: 
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+using FragA = Vec<half2, 4>;
+using FragB = Vec<half2, 2>;
+using FragC = Vec<float, 4>;
+using FragS = Vec<half2, 1>; // quantization scales
+
+// Predicated asynchronous global->shared copy; used for inputs A where we apply predication to handle batchsizes that
+// are not multiples of 16.
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .pred p;\n"
+    "   setp.ne.b32 p, %0, 0;\n"
+    "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+    "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Asynchronous global->shared copy with a cache hint indicating that the values may be evicted immediately; used for
+// quantized weights B, which are only accessed precisely once and should thus not pollute the L2 cache which we need
+// for inputs A and outputs C. 
+__device__ inline void cp_async4_stream(void* smem_ptr, const void* glob_ptr) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .b64 p;\n"
+    "   createpolicy.fractional.L2::evict_first.b64 p, 1.0;"
+    "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
+    "}\n" :: "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Async copy fence.
+__device__ inline void cp_async_fence() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+// Wait until at most `n` async copy stages are still pending.
+template <int n>
+__device__ inline void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
+}
+
+// m16n8k16 tensor core mma instruction with fp16 inputs and fp32 output/accumulation.
+__device__ inline void mma(const FragA& a_frag, const FragB& frag_b, FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  asm volatile(
+    "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+    : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+    :  "r"(a[0]),  "r"(a[1]),  "r"(a[2]),  "r"(a[3]),  "r"(b[0]),  "r"(b[1]),
+       "f"(c[0]),  "f"(c[1]),  "f"(c[2]),  "f"(c[3])
+  );
+}
+
+// Instruction for loading a full 16x16 matrix fragment of operand A from shared memory, directly in tensor core layout.
+__device__ inline void ldsm4(FragA& frag_a, const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+    : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) : "r"(smem)
+  );
+}
+
+// Lookup-table based 3-input logical operation; explicitly used for dequantization as the compiler does not seem to
+// automatically recognize it in all cases. 
+template <int lut>
+__device__ inline int lop3(int a, int b, int c) {
+  int res;
+  asm volatile(
+    "lop3.b32 %0, %1, %2, %3, %4;\n"
+    : "=r"(res) : "r"(a), "r"(b), "r"(c), "n"(lut)
+  );
+  return res;
+}
+
+// Efficiently dequantize an int32 value into a full B-fragment of 4 fp16 values.
+// We mostly follow the strategy in the link below, with some small changes:
+// https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+__device__ inline FragB dequant(int q) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point directly into `SUB` and `ADD`.
+  const int SUB = 0x64086408;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd480d480;
+  FragB frag_b;
+  frag_b[0] = __hsub2(
+    *reinterpret_cast<half2*>(&lo),
+    *reinterpret_cast<const half2*>(&SUB)
+  );
+  frag_b[1] = __hfma2(
+    *reinterpret_cast<half2*>(&hi),
+    *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD)
+  );
+  return frag_b;
+}
+
+// Multiply dequantized values by the corresponding quantization scale; used only for grouped quantization.
+__device__ inline void scale(FragB& frag_b, FragS& frag_s, int i) {
+  half2 s = __half2half2(reinterpret_cast<__half*>(&frag_s)[i]);
+  frag_b[0] = __hmul2(frag_b[0], s);
+  frag_b[1] = __hmul2(frag_b[1], s);
+}
+
+// Wait until barrier reaches `count`, then lock for current threadblock.
+__device__ inline void barrier_acquire(int* lock, int count) {
+  if (threadIdx.x == 0) {
+    int state = -1;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible globally.
+      asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    while (state != count);
+  }
+  __syncthreads();
+}
+
+// Release barrier and increment visitation count.
+__device__ inline void barrier_release(int* lock, bool reset = false) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    if (reset) {
+      lock[0] = 0;
+      return;
+    }
+    int val = 1;
+    // Make sure that all writes since acquiring this barrier are visible globally, while releasing the barrier. 
+    asm volatile ("fence.acq_rel.gpu;\n");
+    asm volatile ("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val)); 
+  }
+}
+
+
+template <
+  const int threads, // number of threads in a threadblock
+  const int thread_m_blocks, // number of 16x16 blocks in the m dimension (batchsize) of the threadblock 
+  const int thread_n_blocks, // same for n dimension (output) 
+  const int thread_k_blocks, // same for k dimension (reduction)
+  const int stages, // number of stages for the async global->shared fetch pipeline
+  const int group_blocks = -1 // number of consecutive 16x16 blocks with a separate quantization scale
+>
+__global__ void Marlin(
+  const int4* __restrict__ A, // fp16 input matrix of shape mxk 
+  const int4* __restrict__ B, // 4bit quantized weight matrix of shape kxn 
+        int4* __restrict__ C, // fp16 output buffer of shape mxn
+  const int4* __restrict__ s, // fp16 quantization scales of shape (k/groupsize)xn 
+  int  prob_m, // batch dimension m
+  int  prob_n, // output dimension n
+  int  prob_k, // reduction dimension k
+  int* locks // extra global storage for barrier synchronization 
+) {
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the same size, which might involve multiple 
+  // column "slices" (of width 16 * `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM example: 
+  //   0 1 3 
+  //   0 2 3
+  //   1 2 4
+  // While this kind of partitioning makes things somewhat more complicated, it ensures good utilization of all SMs
+  // for many kinds of shape and GPU configurations, while requiring as few slow global cross-threadblock reductions as 
+  // possible.
+  
+  // For larger GEMMs we run multiple batchsize 64 versions in parallel for a better partitioning with less reductions
+  int parallel = 1;
+  if (prob_m > 16 * thread_m_blocks) {
+    parallel = prob_m / (16 * thread_m_blocks);
+    prob_m = 16 * thread_m_blocks;
+  }
+
+  int k_tiles = prob_k / 16 / thread_k_blocks;
+  int n_tiles = prob_n / 16 / thread_n_blocks;
+  int iters = ceildiv(k_tiles * n_tiles * parallel, gridDim.x);
+  // Ensure that the number of tiles in each stripe is a multiple of the groupsize; this avoids an annoying special case
+  // where a stripe starts in the middle of group.
+  if (group_blocks != -1)
+    iters = (group_blocks / thread_k_blocks) * ceildiv(iters, (group_blocks / thread_k_blocks));
+
+  int slice_row = (iters * blockIdx.x) % k_tiles;
+  int slice_col_par = (iters * blockIdx.x) / k_tiles;
+  int slice_col = slice_col_par;
+  int slice_iters; // number of threadblock tiles in the current slice
+  int slice_count = 0; // total number of active threadblocks in the current slice
+  int slice_idx; // index of threadblock in current slice; numbered bottom to top
+
+  // We can easily implement parallel problem execution by just remapping indices and advancing global pointers
+  if (slice_col_par >= n_tiles) {
+    A += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_k / 8;
+    C += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_n / 8;
+    locks += (slice_col_par / n_tiles) * n_tiles;
+    slice_col = slice_col_par % n_tiles;
+  }
+
+  // Compute all information about the current slice which is required for synchronization.
+  auto init_slice = [&] () {
+    slice_iters = iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
+    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel)
+      slice_iters = 0;
+    if (slice_iters == 0)
+      return;
+    if (slice_row + slice_iters > k_tiles) 
+      slice_iters = k_tiles - slice_row;
+    slice_count = 1;
+    slice_idx = 0;
+    int col_first = iters * ceildiv(k_tiles * slice_col_par, iters);
+    if (col_first <= k_tiles * (slice_col_par + 1)) {
+      int col_off = col_first - k_tiles * slice_col_par;
+      slice_count = ceildiv(k_tiles - col_off, iters);
+      if (col_off > 0)
+        slice_count++;
+      int delta_first = iters * blockIdx.x - col_first;
+      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
+        slice_idx = slice_count - 1;
+      else {
+        slice_idx = slice_count - 1 - delta_first / iters;
+        if (col_off > 0)
+          slice_idx--;
+      }
+    }
+    if (slice_col == n_tiles) {
+      A += 16 * thread_m_blocks * prob_k / 8;
+      C += 16 * thread_m_blocks * prob_n / 8;
+      locks += n_tiles;
+      slice_col = 0;
+    }
+  };
+  init_slice();
+
+  int a_gl_stride = prob_k / 8; // stride of the A matrix in global memory
+  // We typically use `constexpr` to indicate that this value is a compile-time constant
+  constexpr int a_sh_stride = 16 * thread_k_blocks / 8; // stride of an A matrix tile in shared memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / 8; // delta between subsequent A tiles in global memory
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o); // between subsequent accesses within a tile
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o); // between shared memory writes
+  constexpr int a_sh_rd_delta_o = 2 * ((threads / 32) / (thread_n_blocks / 4)); // between shared memory tile reads
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16; // within a shared memory tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks); // overall size of a tile
+  constexpr int a_sh_wr_iters = ceildiv(a_sh_stage, a_sh_wr_delta); // number of shared write iterations for a tile
+
+  int b_gl_stride = 16 * prob_n / 32;
+  constexpr int b_sh_stride = 32 * thread_n_blocks / 4;
+  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks;
+  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride);
+  constexpr int b_sh_wr_delta = threads;
+  constexpr int b_sh_rd_delta = threads;
+  constexpr int b_sh_stage = b_sh_stride * thread_k_blocks;
+  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
+
+  int s_gl_stride = prob_n / 8;
+  constexpr int s_sh_stride = 16 * thread_n_blocks / 8;
+  constexpr int s_sh_stage = s_sh_stride;
+  int s_gl_rd_delta = s_gl_stride;
+
+  // Global A read index of current thread.
+  int a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  a_gl_rd += a_gl_rd_delta_o * slice_row;
+  // Shared write index of current thread.
+  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  // Shared read index.
+  int a_sh_rd = a_sh_stride * ((threadIdx.x % 32) % 16) + (threadIdx.x % 32) / 16;
+  a_sh_rd += 2 * ((threadIdx.x / 32) / (thread_n_blocks / 4));
+
+  int b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+  b_gl_rd += b_sh_stride * slice_col;
+  b_gl_rd += b_gl_rd_delta_o * slice_row;
+  int b_sh_wr = threadIdx.x;
+  int b_sh_rd = threadIdx.x;
+
+  int s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
+  int s_sh_wr = threadIdx.x;
+  int s_sh_rd;
+  // We use a different scale layout for grouped and column-wise quantization as we scale a `half2` tile in column-major
+  // layout in the former and in row-major in the latter case.
+  if (group_blocks != -1)
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 4;
+  else
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) % 4;
+  
+  // Precompute which thread should not read memory in which iterations; this is needed if there are more threads than
+  // required for a certain tilesize or when the batchsize is not a multiple of 16.
+  bool a_sh_wr_pred[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stride;
+
+  // To ensure that writing and reading A tiles to/from shared memory, the latter in fragment format, is fully bank
+  // conflict free, we need to use a rather fancy XOR-based layout. The key here is that neither reads nor writes of 
+  // the 16-byte `int4` blocks of 8 consecutive threads involve the same shared memory banks. Further, it seems (based
+  // on NSight-Compute) that each warp must also write a consecutive memory segment?
+  auto transform_a = [&] (int i) {
+    int row = i / a_gl_rd_delta_o;
+    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ row;
+  };
+  // Since the computation of this remapping is non-trivial and, due to our main loop unrolls, all shared memory 
+  // accesses are static, we simply precompute both transformed reads and writes.
+  int a_sh_wr_trans[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
+  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++) {
+    #pragma unroll
+    for (int j = 0; j < thread_m_blocks; j++)
+      a_sh_rd_trans[i][j] = transform_a(a_sh_rd_delta_o * i + a_sh_rd_delta_i * j + a_sh_rd); 
+  }
+
+  // Since B-accesses have non-constant stride they have to be computed at runtime; we break dependicies between
+  // subsequent accesses with a tile by maintining multiple pointers (we have enough registers), a tiny optimization.
+  const int4* B_ptr[b_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++)
+    B_ptr[i] = B + b_gl_rd_delta_i * i + b_gl_rd;
+
+  extern __shared__ int4 sh[];
+  // Shared memory storage for global fetch pipelines. 
+  int4* sh_a = sh;
+  int4* sh_b = sh_a + (stages * a_sh_stage);
+  int4* sh_s = sh_b + (stages * b_sh_stage);
+  // Register storage for double buffer of shared memory reads. 
+  FragA frag_a[2][thread_m_blocks];
+  I4 frag_b_quant[2];
+  FragC frag_c[thread_m_blocks][4][2];
+  FragS frag_s[2][4];
+
+  // Zero accumulators.
+  auto zero_accums = [&] () {
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
+      reinterpret_cast<float*>(frag_c)[i] = 0;
+  };
+
+  // Asynchronously fetch the next A, B and s tile from global to the next shared memory pipeline location.
+  auto fetch_to_shared = [&] (int pipe, int a_off, bool pred = true) {
+    if (pred) {
+      int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < a_sh_wr_iters; i++) {
+        cp_async4_pred(
+          &sh_a_stage[a_sh_wr_trans[i]],
+          &A[a_gl_rd_delta_i * i + a_gl_rd + a_gl_rd_delta_o * a_off],
+          a_sh_wr_pred[i]
+        );
+      }
+      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < b_sh_wr_iters; i++) {
+        cp_async4_stream(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr], B_ptr[i]);
+        B_ptr[i] += b_gl_rd_delta_o;
+      }
+      // Only fetch scales if this tile starts a new group
+      if (group_blocks != -1 && pipe % (group_blocks / thread_k_blocks) == 0) {
+        int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
+        s_gl_rd += s_gl_rd_delta;
+      }
+    }
+    // Insert a fence even when we are winding down the pipeline to ensure that waiting is also correct at this point.
+    cp_async_fence();
+  };
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&] () {
+    // We only have `stages - 2` active fetches since we are double buffering and can only issue the next fetch when
+    // it is guaranteed that the previous shared memory load is fully complete (as it may otherwise be overwritten).
+    cp_async_wait<stages - 2>();
+    __syncthreads();
+  };
+
+  // Load the next sub-tile from the current location in the shared memory pipe into the current register buffer.
+  auto fetch_to_registers = [&] (int k, int pipe) {
+    // It may seem inefficient that we reload the groups for every sub-tile; however, this does not seem to be a
+    // significant bottleneck, while some theoretically better attempts have lead to bad instruction ordering by the
+    // compiler and correspondingly a noticable drop in performance.
+    if (group_blocks != -1) {
+      int4* sh_s_stage = sh_s + s_sh_stage * ((group_blocks / thread_k_blocks) * (pipe / (group_blocks / thread_k_blocks)));
+      reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+    }
+    int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks; i++)
+      ldsm4(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+    frag_b_quant[k % 2] = *reinterpret_cast<I4*>(&sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd]);
+  };
+
+  // Execute the actual tensor core matmul of a sub-tile. 
+  auto matmul = [&] (int k) {
+    // We have the m dimension as the inner loop in order to encourage overlapping dequantization and matmul operations.
+    #pragma unroll
+    for (int j = 0; j < 4; j++) {
+      int b_quant = frag_b_quant[k % 2][j];
+      int b_quant_shift = b_quant >> 8;
+      FragB frag_b0 = dequant(b_quant);
+      // If there are no groups, we can just scale the final output once and can avoid doing so for each weight.
+      if (group_blocks != -1)
+        scale(frag_b0, frag_s[k % 2][j], 0);
+      FragB frag_b1 = dequant(b_quant_shift);
+      if (group_blocks != -1)
+        scale(frag_b1, frag_s[k % 2][j], 1);
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        mma(frag_a[k % 2][i], frag_b0, frag_c[i][j][0]);
+        mma(frag_a[k % 2][i], frag_b1, frag_c[i][j][1]);
+      }
+    }
+  };
+
+  // Since we slice across the k dimension of a tile in order to increase the number of warps while keeping the n
+  // dimension of a tile reasonable, we have multiple warps that accumulate their partial sums of the same output
+  // location; which we have to reduce over in the end. We do in shared memory.
+  auto thread_block_reduce = [&] () {
+    constexpr int red_off = threads / b_sh_stride / 2;
+    if (red_off >= 1) {
+      int red_idx = threadIdx.x / b_sh_stride;
+      constexpr int red_sh_stride = b_sh_stride * 4 * 2;
+      constexpr int red_sh_delta = b_sh_stride; 
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+
+      // Parallel logarithmic shared memory reduction. We make sure to avoid any unnecessary read or write iterations,
+      // e.g., for two warps we write only once by warp 1 and read only once by warp 0. 
+
+      #pragma unroll
+      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
+        #pragma unroll
+        for (int i = red_off; i > 0; i /= 2) {
+          if (i <= red_idx && red_idx < 2 * i) {
+            #pragma unroll
+            for (int j = 0; j < 4 * 2; j++) {
+              int red_sh_wr = red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
+              if (i < red_off) {
+                float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh[red_sh_wr]);
+                #pragma unroll
+                for (int k = 0; k < 4; k++)
+                  reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] += c_rd[k] + c_wr[k];
+              }
+              sh[red_sh_wr] = reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
+            }
+          }
+          __syncthreads();
+        }
+        if (red_idx == 0) {
+          #pragma unroll
+          for (int i = 0; i < 4 * 2; i++) {
+            float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * i + red_sh_rd]);
+            #pragma unroll
+            for (int j = 0; j < 4; j++)
+              reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] += c_rd[j];
+          }
+        }
+        __syncthreads();
+      }
+    }
+  };
+
+  // Since multiple threadblocks may process parts of the same column slice, we finally have to globally reduce over
+  // the results. As the striped partioning minimizes the number of such reductions and our outputs are usually rather
+  // small, we perform this reduction serially in L2 cache.
+  auto global_reduce = [&] (bool first = false, bool last = false) {
+    // We are very careful here to reduce directly in the output buffer to maximize L2 cache utilization in this step. 
+    // To do this, we write out results in FP16 (but still reduce with FP32 compute).
+    constexpr int active_threads = 32 * thread_n_blocks / 4;
+    if (threadIdx.x < active_threads) {
+      int c_gl_stride = prob_n / 8;
+      int c_gl_wr_delta_o = 8 * c_gl_stride;
+      int c_gl_wr_delta_i = 4 * (active_threads / 32);
+      int c_gl_wr = c_gl_stride * ((threadIdx.x % 32) / 4) + 4 * (threadIdx.x / 32) + threadIdx.x % 4;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+      constexpr int c_sh_wr_delta = active_threads;
+      int c_sh_wr = threadIdx.x;
+
+      int row = (threadIdx.x % 32) / 4;
+
+      if (!first) {
+        // Interestingly, doing direct global accesses here really seems to mess up the compiler and lead to slowdowns,
+        // hence we also use async-copies even though these fetches are not actually asynchronous.
+        #pragma unroll
+        for (int i = 0; i < thread_m_blocks * 4; i++) {
+          cp_async4_pred(
+            &sh[c_sh_wr + c_sh_wr_delta * i],
+            &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)],
+            i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m
+          );
+        }
+        cp_async_fence();
+        cp_async_wait<0>();
+      }
+
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks * 4; i++) {
+        if (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) {
+          if (!first) {
+            int4 c_red = sh[c_sh_wr + i * c_sh_wr_delta];
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)] += __half2float(
+                reinterpret_cast<__half*>(&c_red)[j]
+              );
+            }
+          }
+          if (!last) {
+            int4 c;
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<__half*>(&c)[j] = __float2half(
+                reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)]
+              );
+            }
+            C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] = c;
+          }
+        }
+      }
+    }
+  };
+
+  // Write out the reduce final result in the correct layout. We only actually reshuffle matrix fragments in this step,
+  // the reduction above is performed in fragment layout. 
+  auto write_result = [&] () {
+    int c_gl_stride = prob_n / 8;
+    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
+    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
+    constexpr int c_sh_rd_delta = c_sh_stride * (threads / (2 * thread_n_blocks));
+
+    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+    c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    int c_sh_wr = (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
+    c_sh_wr += 32 * (threadIdx.x / 32);
+    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+
+    int c_gl_wr_end = c_gl_stride * prob_m;
+
+    // We first reorder in shared memory to guarantee the most efficient final global write patterns
+    auto write = [&] (int idx, float c0, float c1, FragS& s) {
+      half2 res = __halves2half2(__float2half(c0), __float2half(c1));
+      if (group_blocks == -1) // for per-column quantization we finally apply the scale here
+        res = __hmul2(res, s[0]);
+      ((half2*) sh)[idx] = res;
+    };
+    if (threadIdx.x / 32 < thread_n_blocks / 4) {
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          int wr = c_sh_wr + 8 * j;
+          write(wr + (4 * c_sh_stride) * 0 + 0, frag_c[i][j][0][0], frag_c[i][j][0][1], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 8 + 0, frag_c[i][j][0][2], frag_c[i][j][0][3], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 0 + 4, frag_c[i][j][1][0], frag_c[i][j][1][1], frag_s[j / 2][2 * (j % 2) + 1]);
+          write(wr + (4 * c_sh_stride) * 8 + 4, frag_c[i][j][1][2], frag_c[i][j][1][3], frag_s[j / 2][2 * (j % 2) + 1]);
+        }
+        c_sh_wr += 16 * (4 * c_sh_stride);
+      }
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < ceildiv(16 * thread_m_blocks, threads / (2 * thread_n_blocks)); i++) {
+      if (c_gl_wr < c_gl_wr_end) {
+        C[c_gl_wr] = sh[c_sh_rd];
+        c_gl_wr += c_gl_wr_delta;
+        c_sh_rd += c_sh_rd_delta;
+      }
+    }
+  };
+
+  // Start global fetch and register load pipelines. 
+  auto start_pipes = [&] () {
+    #pragma unroll
+    for (int i = 0; i < stages - 1; i++)
+      fetch_to_shared(i, i, i < slice_iters);
+    zero_accums();
+    wait_for_stage();
+    fetch_to_registers(0, 0);
+    a_gl_rd += a_gl_rd_delta_o * (stages - 1);
+  };
+  start_pipes();
+
+  // Main loop.
+  while (slice_iters) {
+    // We unroll over both the global fetch and the register load pipeline to ensure all shared memory accesses are
+    // static. Note that both pipelines have even length meaning that the next iteration will always start at index 0.
+    #pragma unroll
+    for (int pipe = 0; pipe < stages;) {
+      #pragma unroll
+      for (int k = 0; k < b_sh_wr_iters; k++) {
+        fetch_to_registers(k + 1, pipe % stages);
+        if (k == b_sh_wr_iters - 2) {
+          fetch_to_shared((pipe + stages - 1) % stages, pipe, slice_iters >= stages);
+          pipe++;
+          wait_for_stage();
+        }
+        matmul(k);
+      }
+      slice_iters--;
+      if (slice_iters == 0)
+        break;
+    }
+    a_gl_rd += a_gl_rd_delta_o * stages;
+
+    // Process results and, if necessary, proceed to the next column slice. While this pattern may not be the most
+    // readable, other ways of writing the loop seemed to noticeably worse performance after compliation.
+    if (slice_iters == 0) {
+      cp_async_wait<0>();
+      bool last = slice_idx == slice_count - 1;
+      // For per-column scales, we only fetch them here in the final step before write-out
+      if (group_blocks == -1 && last) {
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s[s_sh_wr], &s[s_gl_rd]);
+        cp_async_fence();
+      }
+      thread_block_reduce();
+      if (group_blocks == -1 && last) {
+        cp_async_wait<0>();
+        __syncthreads();
+        if (threadIdx.x / 32 < thread_n_blocks / 4) {
+          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+        }
+      }
+      if (slice_count > 1) { // only globally reduce if there is more than one block in a slice
+        barrier_acquire(&locks[slice_col], slice_idx);
+        global_reduce(slice_idx == 0, last);
+        barrier_release(&locks[slice_col], last);
+      }
+      if (last) // only the last block in a slice actually writes the result
+        write_result();
+      slice_row = 0;
+      slice_col_par++;
+      slice_col++;
+      init_slice();
+      if (slice_iters) {
+        a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+        #pragma unroll
+        for (int i = 0; i < b_sh_wr_iters; i++)
+          B_ptr[i] += b_sh_stride - b_gl_rd_delta_o * k_tiles;
+        if (slice_col == 0) {
+          #pragma unroll
+          for (int i = 0; i < b_sh_wr_iters; i++)
+            B_ptr[i] -= b_gl_stride;
+        }
+        s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+        start_pipes();
+      }
+    }
+  }
+}
+
+
+// 8 warps are a good choice since every SM has 4 schedulers and having more than 1 warp per schedule allows some more
+// latency hiding. At the same time, we want relatively few warps to have many registers per warp and small tiles.
+const int THREADS = 256;
+const int STAGES = 4; // 4 pipeline stages fit into shared memory
+const int SHARED_MEM = 96 * 1024; // max shared memory on compute capability 8.6 (< 8.0)
+
+#define CALL_IF(THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, GROUP_BLOCKS) \
+  else if ( \
+    thread_m_blocks == THREAD_M_BLOCKS && thread_n_blocks == THREAD_N_BLOCKS && thread_k_blocks == THREAD_K_BLOCKS && \
+    group_blocks == GROUP_BLOCKS \
+  ) { \
+    cudaFuncSetAttribute( \
+      Marlin<THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS>, \
+      cudaFuncAttributeMaxDynamicSharedMemorySize, \
+      SHARED_MEM \
+    ); \
+    Marlin< \
+      THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS \
+    ><<<blocks, THREADS, SHARED_MEM, stream>>>( \
+      A_ptr, B_ptr, C_ptr, s_ptr, \
+      prob_m, prob_n, prob_k, \
+      locks \
+    ); \
+  }
+
+const int ERR_PROB_SHAPE = 1;
+const int ERR_KERN_SHAPE = 2;
+
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 16
+) {
+  int tot_m = prob_m;
+  int tot_m_blocks = ceildiv(tot_m, 16);
+  int pad = 16 * tot_m_blocks - tot_m;
+
+  if (sms == -1)
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+  if (thread_k == -1 || thread_n == -1) {
+    if (prob_m <= 16) {
+      // For small batchizes, better partioning is slightly more important than better compute utilization
+      thread_k = 128;
+      thread_n = 128;
+    } else {
+      thread_k = 64;
+      thread_n = 256;
+    }
+  }
+
+  int thread_k_blocks = thread_k / 16;
+  int thread_n_blocks = thread_n / 16;
+  int group_blocks = (groupsize == -1) ? -1 : groupsize / 16;
+  int blocks = sms;
+
+  if (prob_n % thread_n != 0 || prob_k % thread_k != 0 || (group_blocks != -1 && prob_k % group_blocks != 0))
+    return ERR_PROB_SHAPE;
+  if (prob_m == 0 || prob_n == 0 || prob_k == 0)
+    return 0;
+
+  const int4* A_ptr = (const int4*) A;
+  const int4* B_ptr = (const int4*) B;
+  int4* C_ptr = (int4*) C;
+  const int4* s_ptr = (const int4*) s;
+
+  int cols = prob_n / thread_n;
+  int* locks = (int*) workspace;
+
+  int ret = 0;
+  for (int i = 0; i < tot_m_blocks; i += 4) {
+    int thread_m_blocks = tot_m_blocks - i;
+    prob_m = tot_m - 16 * i;
+    int par = 1;
+    if (thread_m_blocks > 4) {
+      // Note that parallel > 1 currently only works for inputs without any padding
+      par = (16 * thread_m_blocks - pad) / 64;
+      if (par > max_par)
+        par = max_par;
+      prob_m = 64 * par;
+      i += 4 * (par - 1);
+      thread_m_blocks = 4;
+    }
+    
+    // For compilation speed, we only define the kernel configurations that have seemed useful (in terms of performance)
+    // in our testing, however many more are, in principle, possible.
+    if (false) {}
+    CALL_IF(1,  8,  8, -1)
+    CALL_IF(1,  8,  8,  8)
+    CALL_IF(1, 16,  4, -1)
+    CALL_IF(1, 16,  4,  8)
+    CALL_IF(2, 16,  4, -1)
+    CALL_IF(2, 16,  4,  8)
+    CALL_IF(3, 16,  4, -1)
+    CALL_IF(3, 16,  4,  8)
+    CALL_IF(4, 16,  4, -1)
+    CALL_IF(4, 16,  4,  8)
+    else
+      ret = ERR_KERN_SHAPE;
+
+    A_ptr += 16 * thread_m_blocks * (prob_k / 8) * par;
+    C_ptr += 16 * thread_m_blocks * (prob_n / 8) * par;
+  }
+
+  return ret;
+}
+
+
+#endif

--- a/moe_infinity/kernel/marlin_gemm.py
+++ b/moe_infinity/kernel/marlin_gemm.py
@@ -1,0 +1,224 @@
+"""Marlin W4A16 (INT4 weight, FP16 activation) GEMM wrapper.
+
+Bundled from IST-DASLab/marlin (Apache 2.0). Provides weight packing utilities
+and a Python interface to the native CUDA kernel.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import torch
+
+try:
+    import moe_infinity._marlin as _C
+
+    _MARLIN_AVAILABLE = True
+except ImportError:
+    _MARLIN_AVAILABLE = False
+
+
+def is_marlin_available() -> bool:
+    return _MARLIN_AVAILABLE
+
+
+def _get_perms() -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    perm: list[int] = []
+    for i in range(32):
+        perm1: list[int] = []
+        col = i // 4
+        for block in [0, 1]:
+            for row in [
+                2 * (i % 4),
+                2 * (i % 4) + 1,
+                2 * (i % 4 + 4),
+                2 * (i % 4 + 4) + 1,
+            ]:
+                perm1.append(16 * row + col + 8 * block)
+        for j in range(4):
+            perm.extend([p + 256 * j for p in perm1])
+
+    perm_tensor = torch.tensor(perm, dtype=torch.int32)
+
+    scale_perm: list[int] = []
+    for i in range(8):
+        scale_perm.extend([i + 8 * j for j in range(8)])
+    scale_perm_tensor = torch.tensor(scale_perm, dtype=torch.int32)
+
+    scale_perm_single: list[int] = []
+    for i in range(4):
+        scale_perm_single.extend([2 * i + j for j in range(2)] * 4)
+    scale_perm_single_tensor = torch.tensor(
+        scale_perm_single, dtype=torch.int32
+    )
+
+    return perm_tensor, scale_perm_tensor, scale_perm_single_tensor
+
+
+_PERM, _SCALE_PERM, _SCALE_PERM_SINGLE = _get_perms()
+
+
+def pack_marlin_weight(
+    weight: torch.Tensor,
+    scales: torch.Tensor,
+    groupsize: int = -1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Pack FP16 quantized weight + scales into Marlin format.
+
+    Args:
+        weight: INT32 quantized weight [K, N] with values in [0, 15]
+        scales: FP16 scales [K//groupsize, N] or [1, N]
+        groupsize: -1 (per-column) or 128
+
+    Returns:
+        (packed_weight, packed_scales) in Marlin layout
+    """
+    assert groupsize in (-1, 128)
+
+    K, N = weight.shape
+    assert K % 128 == 0, f"K={K} must be divisible by 128"
+    assert N % 256 == 0, f"N={N} must be divisible by 256"
+
+    tile = 16
+    perm = _PERM.to(weight.device)
+
+    w = weight.reshape(K // tile, tile, N // tile, tile)
+    w = w.permute(0, 2, 1, 3).contiguous()
+    w = w.reshape(K // tile, N * tile)
+
+    w = w.reshape(-1, perm.numel())[:, perm].reshape(w.shape)
+
+    packed = torch.zeros(
+        (w.shape[0], w.shape[1] // 8), dtype=torch.int32, device=w.device
+    )
+    for shift in range(8):
+        packed |= (w[:, shift::8].to(torch.int32) & 0xF) << (4 * shift)
+
+    if groupsize == -1:
+        s_perm = _SCALE_PERM_SINGLE.to(scales.device)
+    else:
+        s_perm = _SCALE_PERM.to(scales.device)
+
+    s = scales.reshape(-1, s_perm.numel())[:, s_perm]
+    s = s.reshape(-1, N).contiguous()
+
+    return packed, s
+
+
+def marlin_quantize(
+    weight: torch.Tensor,
+    groupsize: int = -1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Quantize FP16 weight to Marlin INT4 format.
+
+    Args:
+        weight: FP16 weight [K, N]
+        groupsize: -1 (per-column) or 128
+
+    Returns:
+        (packed_weight, scales) ready for marlin_gemm
+    """
+    assert groupsize in (-1, 128)
+    K, N = weight.shape
+    assert K % 128 == 0, f"K={K} must be divisible by 128"
+    assert N % 256 == 0, f"N={N} must be divisible by 256"
+
+    maxq = 15
+
+    if groupsize == -1:
+        scales = weight.abs().amax(dim=0, keepdim=True) / (maxq / 2)
+        scales = scales.clamp(min=1e-10)
+        w_int = torch.round(weight / scales).int() + (maxq + 1) // 2
+    else:
+        n_groups = K // groupsize
+        w_reshaped = weight.reshape(n_groups, groupsize, N)
+        scales = w_reshaped.abs().amax(dim=1) / (maxq / 2)
+        scales = scales.clamp(min=1e-10)
+        w_int = (
+            torch.round(w_reshaped / scales.unsqueeze(1)).int()
+            + (maxq + 1) // 2
+        )
+        w_int = w_int.reshape(K, N)
+
+    w_int = w_int.clamp(0, maxq)
+    scales = scales.to(torch.float16)
+
+    return pack_marlin_weight(w_int, scales, groupsize)
+
+
+def prepare_workspace(prob_n: int, device: torch.device) -> torch.Tensor:
+    return torch.zeros(prob_n // 128 * 16, dtype=torch.int32, device=device)
+
+
+def marlin_gemm(
+    input: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scales: torch.Tensor,
+    workspace: torch.Tensor,
+) -> torch.Tensor:
+    """Marlin FP16 x INT4 GEMM.
+
+    Args:
+        input: [M, K] float16
+        packed_weight: Marlin-packed INT4 weights
+        scales: Packed FP16 scales
+        workspace: From prepare_workspace()
+
+    Returns:
+        [M, N] float16 output
+    """
+    if not _MARLIN_AVAILABLE:
+        raise RuntimeError(
+            "moe_infinity._marlin not available. "
+            "Rebuild with CUDA support: pip install -e ."
+        )
+
+    M, K = input.shape
+    N = scales.shape[1]
+
+    output = torch.empty((M, N), dtype=torch.float16, device=input.device)
+
+    _C.mul(
+        input.to(torch.float16).contiguous(),
+        packed_weight.contiguous(),
+        output,
+        scales.contiguous(),
+        workspace.contiguous(),
+        -1,
+        -1,
+        -1,
+        16,
+    )
+
+    return output
+
+
+def reference_dequant_gemm(
+    input: torch.Tensor,
+    packed_weight: torch.Tensor,
+    scales: torch.Tensor,
+    K: int,
+    N: int,
+    groupsize: int = -1,
+) -> torch.Tensor:
+    """Reference implementation: unpack INT4, dequantize, matmul."""
+    w_int = torch.zeros((K, N), dtype=torch.int32, device=packed_weight.device)
+    for shift in range(8):
+        w_int[shift::8, :] = (packed_weight >> (4 * shift)) & 0xF
+
+    perm = _PERM.to(w_int.device)
+    inv_perm = torch.argsort(perm)
+    w_int = w_int.reshape(-1, perm.numel())[:, inv_perm].reshape(K, N)
+
+    w_fp = w_int.float() - 8.0
+
+    if groupsize == -1:
+        w_fp = w_fp * scales.float()
+    else:
+        n_groups = K // groupsize
+        w_fp = w_fp.reshape(n_groups, groupsize, N) * scales.float().unsqueeze(
+            1
+        )
+        w_fp = w_fp.reshape(K, N)
+
+    return input.float() @ w_fp.float()

--- a/moe_infinity/utils/gptq.py
+++ b/moe_infinity/utils/gptq.py
@@ -6,6 +6,8 @@ from typing import Optional, Protocol
 
 GPTQ_PACKED_SUFFIXES = (".qweight", ".qzeros")
 GPTQ_COMPONENT_SUFFIXES = (".qweight", ".qzeros", ".scales", ".g_idx")
+MARLIN_PACKED_SUFFIXES = (".qweight", ".scales")
+MARLIN_COMPONENT_SUFFIXES = (".qweight", ".scales", ".bits", ".group_size")
 
 
 class _QuantizationConfigLike(Protocol):
@@ -63,3 +65,72 @@ def is_gptq_packed_tensor(name: str) -> bool:
 
 def is_gptq_component(name: str) -> bool:
     return any(name.endswith(s) for s in GPTQ_COMPONENT_SUFFIXES)
+
+
+def _get_scalar(value):
+    if value is None:
+        return None
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (TypeError, ValueError):
+            return value
+    return value
+
+
+def detect_marlin_weights(state_dict: dict) -> bool:
+    qweight_keys = [name for name in state_dict if name.endswith(".qweight")]
+    if not qweight_keys:
+        return False
+    if not any(name.endswith(".scales") for name in state_dict):
+        return False
+
+    for qweight_key in qweight_keys:
+        prefix = qweight_key[: -len(".qweight")]
+        scales_key = prefix + ".scales"
+        if scales_key not in state_dict:
+            return False
+
+        qweight = state_dict[qweight_key]
+        scales = state_dict[scales_key]
+        qshape = getattr(qweight, "shape", None)
+        sshape = getattr(scales, "shape", None)
+        if (
+            qshape is None
+            or sshape is None
+            or len(qshape) != 2
+            or len(sshape) != 2
+        ):
+            return False
+        if str(getattr(qweight, "dtype", None)) != "torch.int32":
+            return False
+        if qshape[0] % 8 != 0:
+            return False
+        if qshape[1] != sshape[1] * 2:
+            return False
+
+    return True
+
+
+def is_marlin_compatible(state_dict: dict) -> bool:
+    qweight_keys = [name for name in state_dict if name.endswith(".qweight")]
+    if not qweight_keys:
+        return False
+    if not any(name.endswith(".scales") for name in state_dict):
+        return False
+
+    for qweight_key in qweight_keys:
+        prefix = qweight_key[: -len(".qweight")]
+        scales_key = prefix + ".scales"
+        if scales_key not in state_dict:
+            return False
+
+        bits = _get_scalar(state_dict.get(prefix + ".bits"))
+        if bits is not None and bits != 4:
+            return False
+
+        group_size = _get_scalar(state_dict.get(prefix + ".group_size"))
+        if group_size is not None and group_size not in (-1, 128):
+            return False
+
+    return True

--- a/scripts/compile_kernels.py
+++ b/scripts/compile_kernels.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import inspect
+import json
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+KERNEL_DIR = REPO_ROOT / "moe_infinity" / "kernel"
+DEFAULT_OUTPUT_DIR = KERNEL_DIR / "_compiled"
+DEFAULT_TARGET_ARCHS = ("80", "90", "120")
+KERNEL_PACKAGE_PREFIX = "moe_infinity.kernel"
+
+
+@dataclass(frozen=True)
+class TritonConfigSpec:
+    kwargs: dict[str, Any]
+    num_warps: int | None = None
+    num_stages: int | None = None
+
+
+@dataclass(frozen=True)
+class KernelSpec:
+    signature: dict[str, str]
+    constants: dict[str, Any]
+    configs: tuple[TritonConfigSpec, ...] = ()
+
+
+@dataclass(frozen=True)
+class KernelCandidate:
+    module_name: str
+    file_path: Path
+    function_name: str
+
+
+_SPEC_OVERRIDES: dict[tuple[str, str], KernelSpec] = {
+    (
+        "moe_infinity.kernel.router",
+        "softmax_kernel",
+    ): KernelSpec(
+        signature={
+            "output_ptr": "*bf16",
+            "input_ptr": "*bf16",
+            "input_row_stride": "i32",
+            "output_row_stride": "i32",
+            "n_rows": "i32",
+            "n_cols": "i32",
+        },
+        constants={"BLOCK_SIZE": 128, "num_stages": 4},
+    ),
+    (
+        "moe_infinity.kernel.router",
+        "fused_softmax_topk_kernel_nobias",
+    ): KernelSpec(
+        signature={
+            "hidden_ptr": "*bf16",
+            "weight_ptr": "*bf16",
+            "routing_mask_ptr": "*i1",
+            "routing_weight_ptr": "*bf16",
+            "B": "i32",
+            "H": "i32",
+            "E": "i32",
+        },
+        constants={"TOPK": 2, "BLOCK_E": 128, "normalize_topk": True},
+    ),
+    (
+        "moe_infinity.kernel.fused_qkv",
+        "_fused_qkv_kernel",
+    ): KernelSpec(
+        signature={
+            "hidden_ptr": "*bf16",
+            "weight_ptr": "*bf16",
+            "q_ptr": "*bf16",
+            "k_ptr": "*bf16",
+            "v_ptr": "*bf16",
+            "M": "i32",
+            "N": "i32",
+            "K": "i32",
+            "Q_DIM": "i32",
+            "KV_DIM": "i32",
+            "stride_hidden_m": "i32",
+            "stride_hidden_k": "i32",
+            "stride_weight_k": "i32",
+            "stride_weight_n": "i32",
+            "stride_q_m": "i32",
+            "stride_q_n": "i32",
+            "stride_k_m": "i32",
+            "stride_k_n": "i32",
+            "stride_v_m": "i32",
+            "stride_v_n": "i32",
+        },
+        constants={"OUTPUT_IS_BF16": True},
+        configs=(
+            TritonConfigSpec(
+                kwargs={"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32},
+                num_warps=4,
+                num_stages=3,
+            ),
+        ),
+    ),
+    (
+        "moe_infinity.kernel.fused_ffn",
+        "_silu",
+    ): KernelSpec(signature={"x": "fp32"}, constants={}),
+    (
+        "moe_infinity.kernel.fused_ffn",
+        "_fused_gate_up_silu_kernel",
+    ): KernelSpec(
+        signature={
+            "x_ptr": "*bf16",
+            "gate_weight_ptr": "*bf16",
+            "up_weight_ptr": "*bf16",
+            "intermediate_ptr": "*bf16",
+            "M": "i32",
+            "N": "i32",
+            "K": "i32",
+            "stride_x_m": "i32",
+            "stride_x_k": "i32",
+            "stride_gate_n": "i32",
+            "stride_gate_k": "i32",
+            "stride_up_n": "i32",
+            "stride_up_k": "i32",
+            "stride_intermediate_m": "i32",
+            "stride_intermediate_n": "i32",
+        },
+        constants={},
+        configs=(
+            TritonConfigSpec(
+                kwargs={"BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 32},
+                num_warps=4,
+                num_stages=3,
+            ),
+        ),
+    ),
+    (
+        "moe_infinity.kernel.fused_decode_attn",
+        "_fused_decode_attention_kernel",
+    ): KernelSpec(
+        signature={
+            "query_ptr": "*bf16",
+            "key_ptr": "*bf16",
+            "value_ptr": "*bf16",
+            "block_tables_ptr": "*i32",
+            "seq_lens_ptr": "*i32",
+            "out_ptr": "*bf16",
+            "scale": "fp32",
+            "head_dim": "i32",
+            "block_size": "i32",
+            "max_blocks_per_seq": "i32",
+            "q_stride_b": "i32",
+            "q_stride_t": "i32",
+            "q_stride_h": "i32",
+            "q_stride_d": "i32",
+            "k_stride_block": "i32",
+            "k_stride_token": "i32",
+            "k_stride_head": "i32",
+            "k_stride_d": "i32",
+            "v_stride_block": "i32",
+            "v_stride_token": "i32",
+            "v_stride_head": "i32",
+            "v_stride_d": "i32",
+            "bt_stride_b": "i32",
+            "bt_stride_block": "i32",
+            "out_stride_b": "i32",
+            "out_stride_h": "i32",
+            "out_stride_d": "i32",
+        },
+        constants={"QUERY_GROUP_SIZE": 8, "HEAD_DIM": 128},
+        configs=(
+            TritonConfigSpec(
+                kwargs={"BLOCK_KV": 64},
+                num_warps=4,
+                num_stages=2,
+            ),
+        ),
+    ),
+    (
+        "moe_infinity.kernel.mxfp4_gemm",
+        "_fp4_lookup",
+    ): KernelSpec(signature={"idx": "i32"}, constants={}),
+    (
+        "moe_infinity.kernel.mxfp4_gemm",
+        "_ldexp",
+    ): KernelSpec(
+        signature={"mantissa": "fp32", "exponent": "i32"},
+        constants={},
+    ),
+    (
+        "moe_infinity.kernel.mxfp4_gemm",
+        "_fused_mxfp4_gemm_kernel",
+    ): KernelSpec(
+        signature={
+            "lhs_ptr": "*bf16",
+            "rhs_packed_ptr": "*u8",
+            "rhs_scales_ptr": "*u8",
+            "bias_ptr": "*bf16",
+            "out_ptr": "*bf16",
+            "M": "i32",
+            "N": "i32",
+            "K": "i32",
+            "stride_lhs_m": "i32",
+            "stride_lhs_k": "i32",
+            "stride_rhs_n": "i32",
+            "stride_rhs_k": "i32",
+            "stride_scales_n": "i32",
+            "stride_scales_k": "i32",
+            "stride_out_m": "i32",
+            "stride_out_n": "i32",
+        },
+        constants={"HAS_BIAS": False},
+        configs=(
+            TritonConfigSpec(
+                kwargs={"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 32},
+                num_warps=4,
+                num_stages=3,
+            ),
+        ),
+    ),
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Pre-compile Triton kernels for multiple GPU architectures."
+    )
+    parser.add_argument(
+        "--target-archs",
+        default=",".join(DEFAULT_TARGET_ARCHS),
+        help="Comma-separated compute capabilities to compile for.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_DIR),
+        help="Directory where compiled artifacts should be written.",
+    )
+    return parser.parse_args()
+
+
+def _parse_target_archs(raw_value: str) -> list[str]:
+    archs = [
+        part.strip().replace("sm_", "").replace("sm", "")
+        for part in raw_value.split(",")
+    ]
+    normalized = [arch for arch in archs if arch]
+    if not normalized:
+        raise ValueError("at least one target architecture must be provided")
+    return normalized
+
+
+def _module_imports_triton(tree: ast.Module) -> bool:
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            if any(alias.name == "triton" for alias in node.names):
+                return True
+        if isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "triton" or node.module.startswith("triton."):
+                return True
+    return False
+
+
+def _is_triton_jit_decorator(node: ast.expr) -> bool:
+    if isinstance(node, ast.Call):
+        return _is_triton_jit_decorator(node.func)
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "jit"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "triton"
+    )
+
+
+def _is_constexpr_annotation(node: ast.expr | None) -> bool:
+    if not isinstance(node, ast.Attribute):
+        return False
+    if node.attr != "constexpr":
+        return False
+    return isinstance(node.value, ast.Name) and node.value.id == "tl"
+
+
+def _discover_kernel_candidates() -> list[KernelCandidate]:
+    candidates: list[KernelCandidate] = []
+    for file_path in sorted(KERNEL_DIR.glob("*.py")):
+        source = file_path.read_text()
+        tree = ast.parse(source, filename=str(file_path))
+        if not _module_imports_triton(tree):
+            continue
+        module_name = f"{KERNEL_PACKAGE_PREFIX}.{file_path.stem}"
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if any(
+                _is_triton_jit_decorator(decorator)
+                for decorator in node.decorator_list
+            ):
+                candidates.append(
+                    KernelCandidate(
+                        module_name=module_name,
+                        file_path=file_path,
+                        function_name=node.name,
+                    )
+                )
+    return candidates
+
+
+def _default_signature_type(argument_name: str) -> str:
+    if argument_name.endswith("_ptr"):
+        if any(token in argument_name for token in ("packed", "scales")):
+            return "*u8"
+        if any(token in argument_name for token in ("table", "seq_len")):
+            return "*i32"
+        if argument_name.endswith("mask_ptr"):
+            return "*i1"
+        return "*bf16"
+    if argument_name == "scale":
+        return "fp32"
+    return "i32"
+
+
+def _default_constant_value(argument_name: str) -> Any:
+    defaults: dict[str, Any] = {
+        "BLOCK_M": 64,
+        "BLOCK_N": 64,
+        "BLOCK_K": 32,
+        "BLOCK_KV": 64,
+        "BLOCK_E": 128,
+        "BLOCK_SIZE": 128,
+        "HEAD_DIM": 128,
+        "QUERY_GROUP_SIZE": 8,
+        "HAS_BIAS": False,
+        "OUTPUT_IS_BF16": True,
+        "num_stages": 4,
+        "normalize_topk": True,
+        "TOPK": 2,
+    }
+    return defaults.get(argument_name, 1)
+
+
+def _build_fallback_spec(candidate: KernelCandidate) -> KernelSpec:
+    tree = ast.parse(
+        candidate.file_path.read_text(), filename=str(candidate.file_path)
+    )
+    for node in tree.body:
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == candidate.function_name
+        ):
+            signature: dict[str, str] = {}
+            constants: dict[str, Any] = {}
+            for argument in node.args.args:
+                if _is_constexpr_annotation(argument.annotation):
+                    constants[argument.arg] = _default_constant_value(
+                        argument.arg
+                    )
+                else:
+                    signature[argument.arg] = _default_signature_type(
+                        argument.arg
+                    )
+            return KernelSpec(signature=signature, constants=constants)
+    raise ValueError(
+        f"failed to rebuild fallback spec for {candidate.function_name}"
+    )
+
+
+def _get_kernel_spec(candidate: KernelCandidate) -> KernelSpec:
+    override = _SPEC_OVERRIDES.get(
+        (candidate.module_name, candidate.function_name)
+    )
+    if override is not None:
+        return override
+    return _build_fallback_spec(candidate)
+
+
+def _import_triton():
+    try:
+        import triton  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - environment-dependent
+        raise RuntimeError(
+            "triton must be installed to compile kernels"
+        ) from exc
+    return triton
+
+
+def _import_symbol(
+    module_names: tuple[str, ...], symbol_name: str
+) -> Any | None:
+    for module_name in module_names:
+        try:
+            module = importlib.import_module(module_name)
+            return getattr(module, symbol_name)
+        except Exception:
+            continue
+    return None
+
+
+def _make_target(arch: str) -> Any:
+    target_arch = int(arch)
+    gputarget = _import_symbol(
+        ("triton.backends.compiler", "triton.compiler.compiler"),
+        "GPUTarget",
+    )
+    if gputarget is None:
+        return f"sm_{target_arch}"
+    return gputarget("cuda", target_arch, 32)
+
+
+def _resolve_ast_source() -> Any | None:
+    return _import_symbol(
+        ("triton.compiler.compiler", "triton.compiler"), "ASTSource"
+    )
+
+
+def _make_triton_config(triton_module: Any, spec: TritonConfigSpec) -> Any:
+    return triton_module.Config(
+        spec.kwargs,
+        num_warps=spec.num_warps,
+        num_stages=spec.num_stages,
+    )
+
+
+def _compile_with_best_effort(
+    triton_module: Any,
+    kernel_fn: Any,
+    kernel_spec: KernelSpec,
+    arch: str,
+) -> Any:
+    compile_signature = inspect.signature(triton_module.compile)
+    target = _make_target(arch)
+    if "signature" in compile_signature.parameters:
+        kwargs: dict[str, Any] = {
+            "signature": kernel_spec.signature,
+            "constants": kernel_spec.constants,
+            "output_name": f"{kernel_fn.__name__}_{arch}",
+        }
+        if kernel_spec.configs:
+            kwargs["configs"] = [
+                _make_triton_config(triton_module, config)
+                for config in kernel_spec.configs
+            ]
+        if "target" in compile_signature.parameters:
+            kwargs["target"] = target
+        return triton_module.compile(kernel_fn, **kwargs)
+
+    ast_source_cls = _resolve_ast_source()
+    if ast_source_cls is None:
+        raise RuntimeError(
+            "unable to locate Triton ASTSource for AOT compilation"
+        )
+
+    constants = dict(kernel_spec.constants)
+    options: dict[str, Any] = {}
+    if kernel_spec.configs:
+        selected_config = kernel_spec.configs[0]
+        constants.update(selected_config.kwargs)
+        if selected_config.num_warps is not None:
+            options["num_warps"] = selected_config.num_warps
+        if selected_config.num_stages is not None:
+            options["num_stages"] = selected_config.num_stages
+
+    source = ast_source_cls(
+        kernel_fn, signature=kernel_spec.signature, constexprs=constants
+    )
+    return triton_module.compile(source, target=target, options=options)
+
+
+def _extract_metadata_path(metadata_group: dict[str, str]) -> Path:
+    for path in metadata_group.values():
+        candidate = Path(path)
+        if candidate.suffix == ".json":
+            return candidate
+    raise RuntimeError("compiled kernel metadata JSON was not produced")
+
+
+def _extract_binary_path(metadata_group: dict[str, str]) -> Path:
+    binary_candidates = [
+        Path(path)
+        for path in metadata_group.values()
+        if Path(path).suffix != ".json"
+    ]
+    if not binary_candidates:
+        raise RuntimeError("compiled kernel binary artifact was not produced")
+    suffix_priority = (".cubin", ".hsaco", ".so", ".ptx")
+    for suffix in suffix_priority:
+        for candidate in reversed(binary_candidates):
+            if candidate.suffix == suffix:
+                return candidate
+    return binary_candidates[-1]
+
+
+def _write_manifest(
+    manifest_path: Path,
+    candidate: KernelCandidate,
+    kernel_spec: KernelSpec,
+) -> None:
+    manifest = {
+        "module": candidate.module_name,
+        "function": candidate.function_name,
+        "signature": kernel_spec.signature,
+        "constants": kernel_spec.constants,
+    }
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def _persist_compiled_artifact(
+    compiled_kernel: Any,
+    output_dir: Path,
+    candidate: KernelCandidate,
+    kernel_spec: KernelSpec,
+    arch: str,
+) -> None:
+    metadata_group = getattr(compiled_kernel, "metadata_group", None)
+    if not isinstance(metadata_group, dict) or not metadata_group:
+        raise RuntimeError("compiled kernel did not expose metadata_group")
+
+    metadata_path = _extract_metadata_path(metadata_group)
+    binary_path = _extract_binary_path(metadata_group)
+    stem = f"{candidate.function_name}_{arch}"
+    shutil.copyfile(binary_path, output_dir / f"{stem}.so")
+    shutil.copyfile(metadata_path, output_dir / f"{stem}.json")
+    _write_manifest(output_dir / f"{stem}.manifest", candidate, kernel_spec)
+
+
+def _compile_candidate(
+    triton_module: Any,
+    candidate: KernelCandidate,
+    arch: str,
+    output_dir: Path,
+) -> tuple[bool, str]:
+    try:
+        module = importlib.import_module(candidate.module_name)
+        kernel_fn = getattr(module, candidate.function_name)
+        kernel_spec = _get_kernel_spec(candidate)
+        compiled_kernel = _compile_with_best_effort(
+            triton_module,
+            kernel_fn,
+            kernel_spec,
+            arch,
+        )
+        _persist_compiled_artifact(
+            compiled_kernel,
+            output_dir,
+            candidate,
+            kernel_spec,
+            arch,
+        )
+        return True, "compiled"
+    except Exception as exc:
+        return False, f"{type(exc).__name__}: {exc}"
+
+
+def main() -> int:
+    args = _parse_args()
+    output_dir = Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "__init__.py").touch(exist_ok=True)
+
+    try:
+        archs = _parse_target_archs(args.target_archs)
+        triton_module = _import_triton()
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    candidates = _discover_kernel_candidates()
+    compiled = 0
+    failed = 0
+
+    for candidate in candidates:
+        for arch in archs:
+            success, message = _compile_candidate(
+                triton_module,
+                candidate,
+                arch,
+                output_dir,
+            )
+            status = "ok" if success else "skip"
+            print(f"[{status}] {candidate.function_name} sm_{arch}: {message}")
+            if success:
+                compiled += 1
+            else:
+                failed += 1
+
+    print(
+        "summary: "
+        f"files={len({candidate.file_path for candidate in candidates})} "
+        f"kernels={len(candidates)} compiled={compiled} skipped={failed}"
+    )
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -265,6 +265,11 @@ _PAGED_ATTN_SOURCES = [
     "extensions/kernel/paged_attention.cu",
 ]
 
+_MARLIN_SOURCES = [
+    "moe_infinity/kernel/marlin/marlin_cuda.cpp",
+    "moe_infinity/kernel/marlin/marlin_cuda_kernel.cu",
+]
+
 # Note: _engine needs CUTLASS for fused_glu_cuda.cu
 
 ext_modules = []
@@ -324,6 +329,17 @@ if cuda_available:
             include_dirs=COMMON_INCLUDE_PATHS,
             extra_compile_args={
                 "nvcc": COMMON_NVCC_ARGS + _cuda_arch_flags,
+            },
+        )
+    )
+
+    ext_modules.append(
+        cpp_extension.CUDAExtension(
+            name="moe_infinity._marlin",
+            sources=_MARLIN_SOURCES,
+            extra_compile_args={
+                "nvcc": ["-O3", "--use_fast_math", "-std=c++17"]
+                + _cuda_arch_flags,
             },
         )
     )

--- a/tests/python/ops/test_aot_kernel_parity.py
+++ b/tests/python/ops/test_aot_kernel_parity.py
@@ -1,0 +1,145 @@
+import importlib
+
+import pytest
+
+torch = importlib.import_module("torch")
+
+_LOADER = importlib.import_module("moe_infinity.kernel._loader")
+_ROUTER = importlib.import_module("moe_infinity.kernel.router")
+_FUSED_QKV = importlib.import_module("moe_infinity.kernel.fused_qkv")
+
+from tests.python.ops.conftest import (
+    BF16_ATOL,
+    BF16_RTOL,
+    requires_cuda,
+    requires_triton,
+    seed_everything,
+)
+
+
+def _load_first_available(*kernel_names):
+    for kernel_name in kernel_names:
+        kernel = _LOADER.load_compiled_kernel(kernel_name)
+        if kernel is not None:
+            return kernel
+    return None
+
+
+def test_loader_returns_none_without_compiled():
+    assert _LOADER.load_compiled_kernel("nonexistent") is None
+
+
+def test_loader_cache_is_dict():
+    assert isinstance(_LOADER._KERNEL_CACHE, dict)
+
+
+@requires_cuda
+@requires_triton
+def test_aot_vs_jit_router_kernel(seed_everything):
+    aot_kernel = _load_first_available(
+        "fused_softmax_topk_kernel_nobias",
+        "router",
+    )
+    if aot_kernel is None:
+        pytest.skip("AOT not compiled")
+
+    batch, hidden_dim, num_experts, top_k = 16, 128, 128, 2
+    hidden_states = torch.randn(
+        batch,
+        hidden_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    weight = torch.randn(
+        num_experts,
+        hidden_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    jit_mask, jit_weight = _ROUTER.launch_fused_softmax_topk_nobias(
+        hidden_states,
+        weight,
+        top_k,
+    )
+    aot_mask = torch.empty_like(jit_mask)
+    aot_weight = torch.empty_like(jit_weight)
+    aot_kernel[(batch,)](
+        hidden_states,
+        weight,
+        aot_mask,
+        aot_weight,
+        batch,
+        hidden_dim,
+        num_experts,
+    )
+
+    assert torch.equal(aot_mask, jit_mask)
+    torch.testing.assert_close(
+        aot_weight, jit_weight, rtol=BF16_RTOL, atol=BF16_ATOL
+    )
+
+
+@requires_cuda
+@requires_triton
+def test_aot_vs_jit_fused_qkv(seed_everything):
+    aot_kernel = _load_first_available("_fused_qkv_kernel", "fused_qkv_kernel")
+    if aot_kernel is None:
+        pytest.skip("AOT not compiled")
+
+    tokens, hidden_dim = 16, 256
+    num_q_heads, num_kv_heads, head_dim = 8, 4, 16
+    total_dim = (num_q_heads + 2 * num_kv_heads) * head_dim
+
+    hidden_states = torch.randn(
+        tokens,
+        hidden_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    weight_qkv = torch.randn(
+        hidden_dim,
+        total_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    jit_q, jit_k, jit_v = _FUSED_QKV.fused_qkv_proj(
+        hidden_states,
+        weight_qkv,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+    )
+    aot_q = torch.empty_like(jit_q)
+    aot_k = torch.empty_like(jit_k)
+    aot_v = torch.empty_like(jit_v)
+    hidden_2d = hidden_states.reshape(-1, hidden_dim).contiguous()
+    q_dim = num_q_heads * head_dim
+    kv_dim = num_kv_heads * head_dim
+    aot_kernel[(1, 2)](
+        hidden_2d,
+        weight_qkv,
+        aot_q.reshape(tokens, q_dim),
+        aot_k.reshape(tokens, kv_dim),
+        aot_v.reshape(tokens, kv_dim),
+        tokens,
+        total_dim,
+        hidden_dim,
+        q_dim,
+        kv_dim,
+        hidden_2d.stride(0),
+        hidden_2d.stride(1),
+        weight_qkv.stride(0),
+        weight_qkv.stride(1),
+        aot_q.reshape(tokens, q_dim).stride(0),
+        aot_q.reshape(tokens, q_dim).stride(1),
+        aot_k.reshape(tokens, kv_dim).stride(0),
+        aot_k.reshape(tokens, kv_dim).stride(1),
+        aot_v.reshape(tokens, kv_dim).stride(0),
+        aot_v.reshape(tokens, kv_dim).stride(1),
+    )
+
+    torch.testing.assert_close(aot_q, jit_q, rtol=BF16_RTOL, atol=BF16_ATOL)
+    torch.testing.assert_close(aot_k, jit_k, rtol=BF16_RTOL, atol=BF16_ATOL)
+    torch.testing.assert_close(aot_v, jit_v, rtol=BF16_RTOL, atol=BF16_ATOL)

--- a/tests/python/ops/test_auxiliary_loss.py
+++ b/tests/python/ops/test_auxiliary_loss.py
@@ -10,9 +10,9 @@ This module verifies:
 import importlib.machinery
 import sys
 import types
+from importlib import import_module
 
 import pytest
-from importlib import import_module
 
 from tests.python.ops.conftest import (
     BF16_ATOL,
@@ -47,6 +47,7 @@ _deepseek_v2_modeling = import_module(
 if hasattr(_deepseek_v2_modeling, "AddAuxiliaryLoss"):
     AddAuxiliaryLoss = _deepseek_v2_modeling.AddAuxiliaryLoss
 else:
+
     class AddAuxiliaryLoss(torch.autograd.Function):
         """Compatibility shim for the removed upstream DeepSeek helper."""
 
@@ -61,7 +62,9 @@ else:
         def backward(ctx, grad_output):
             grad_loss = None
             if ctx.loss_requires_grad:
-                grad_loss = torch.ones((), dtype=ctx.loss_dtype, device=ctx.loss_device)
+                grad_loss = torch.ones(
+                    (), dtype=ctx.loss_dtype, device=ctx.loss_device
+                )
             return grad_output, grad_loss
 
 

--- a/tests/python/ops/test_deepseek_v2_gate_consistency.py
+++ b/tests/python/ops/test_deepseek_v2_gate_consistency.py
@@ -265,8 +265,8 @@ def test_v2_routing_mask_conversion(seed_everything, norm_topk_prob):
 
     with torch.no_grad():
         topk_idx, topk_weight = block.gate(hidden_states)
-        router_mask, routing_weights_mask, _ = (
-            prepare_expert_route(hidden_states)
+        router_mask, routing_weights_mask, _ = prepare_expert_route(
+            hidden_states
         )
 
     manual_mask = torch.zeros_like(router_mask)

--- a/tests/python/ops/test_fused_decode_attn.py
+++ b/tests/python/ops/test_fused_decode_attn.py
@@ -1,0 +1,174 @@
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tests.python.ops.conftest import (
+    BF16_ATOL,
+    BF16_RTOL,
+    requires_cuda,
+    requires_triton,
+)
+
+
+def _run_sdpa(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    try:
+        return F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            scale=scale,
+            is_causal=False,
+        )
+    except TypeError:
+        return F.scaled_dot_product_attention(
+            query * scale,
+            key,
+            value,
+            is_causal=False,
+        )
+
+
+def _make_paged_kv(
+    batch: int,
+    seq_len: int,
+    num_kv_heads: int,
+    head_dim: int,
+    block_size: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    blocks_per_seq = math.ceil(seq_len / block_size)
+    num_blocks = batch * blocks_per_seq
+    key_cache = torch.randn(
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.float32,
+    ).to(torch.bfloat16)
+    value_cache = torch.randn(
+        num_blocks,
+        block_size,
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.float32,
+    ).to(torch.bfloat16)
+
+    physical_blocks = torch.randperm(
+        num_blocks, device=device, dtype=torch.int64
+    )
+    block_tables = physical_blocks.reshape(batch, blocks_per_seq).to(
+        torch.int32
+    )
+    seq_lens = torch.full((batch,), seq_len, device=device, dtype=torch.int32)
+    return key_cache, value_cache, block_tables, seq_lens
+
+
+def _reference_decode_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    batch, _, num_heads, head_dim = query.shape
+    _, block_size, num_kv_heads, _ = key_cache.shape
+    query_group_size = num_heads // num_kv_heads
+
+    outputs: list[torch.Tensor] = []
+    for batch_idx in range(batch):
+        seq_len = int(seq_lens[batch_idx].item())
+        blocks_per_seq = math.ceil(seq_len / block_size)
+        k_blocks: list[torch.Tensor] = []
+        v_blocks: list[torch.Tensor] = []
+
+        for block_idx in range(blocks_per_seq):
+            physical_block = int(block_tables[batch_idx, block_idx].item())
+            valid_tokens = min(block_size, seq_len - block_idx * block_size)
+            k_blocks.append(key_cache[physical_block, :valid_tokens])
+            v_blocks.append(value_cache[physical_block, :valid_tokens])
+
+        key = torch.cat(k_blocks, dim=0).permute(1, 0, 2)
+        value = torch.cat(v_blocks, dim=0).permute(1, 0, 2)
+        if query_group_size > 1:
+            key = key.repeat_interleave(query_group_size, dim=0)
+            value = value.repeat_interleave(query_group_size, dim=0)
+
+        q = query[batch_idx, 0].unsqueeze(1)
+        out = _run_sdpa(q, key, value, scale)
+        outputs.append(out.squeeze(1))
+
+    return torch.stack(outputs, dim=0).reshape(batch, num_heads, head_dim)
+
+
+@requires_cuda
+@requires_triton
+@pytest.mark.parametrize("batch", [1, 4, 8])
+@pytest.mark.parametrize("seq_len", [32, 128, 512, 2048])
+@pytest.mark.parametrize("num_heads", [32])
+@pytest.mark.parametrize("num_kv_heads", [8, 32])
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("block_size", [16])
+def test_fused_decode_attention_matches_reference(
+    batch: int,
+    seq_len: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    block_size: int,
+) -> None:
+    from moe_infinity.kernel.fused_decode_attn import fused_decode_attention
+
+    device = torch.device("cuda")
+    query = torch.randn(
+        batch,
+        1,
+        num_heads,
+        head_dim,
+        device=device,
+        dtype=torch.float32,
+    ).to(torch.bfloat16)
+    key_cache, value_cache, block_tables, seq_lens = _make_paged_kv(
+        batch=batch,
+        seq_len=seq_len,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        device=device,
+    )
+    scale = 1.0 / math.sqrt(float(head_dim))
+
+    output = fused_decode_attention(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+    )
+    reference = _reference_decode_attention(
+        query,
+        key_cache,
+        value_cache,
+        block_tables,
+        seq_lens,
+        scale,
+    )
+
+    assert output.shape == (batch, num_heads, head_dim)
+    assert output.dtype == torch.bfloat16
+    torch.testing.assert_close(
+        output.float(),
+        reference.float(),
+        atol=BF16_ATOL,
+        rtol=BF16_RTOL,
+    )

--- a/tests/python/ops/test_fused_ffn.py
+++ b/tests/python/ops/test_fused_ffn.py
@@ -1,0 +1,73 @@
+import importlib
+import importlib.util
+from functools import lru_cache
+from pathlib import Path
+
+import pytest
+
+from tests.python.ops.conftest import (
+    BF16_ATOL,
+    BF16_RTOL,
+    requires_cuda,
+    requires_triton,
+)
+
+torch = importlib.import_module("torch")
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MODULE_PATH = _REPO_ROOT / "moe_infinity/kernel/fused_ffn.py"
+
+
+@lru_cache(maxsize=1)
+def _load_fused_ffn_module():
+    spec = importlib.util.spec_from_file_location(
+        "standalone_fused_ffn",
+        _MODULE_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@requires_cuda
+@requires_triton
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("intermediate_size", [5504, 11008])
+@pytest.mark.parametrize("M", [1, 4, 16, 64])
+def test_fused_ffn_matches_reference(
+    seed_everything,
+    M,
+    hidden_dim,
+    intermediate_size,
+):
+    fused_ffn_module = _load_fused_ffn_module()
+
+    x = torch.randn(
+        M, hidden_dim, dtype=torch.bfloat16, device="cuda"
+    ).contiguous()
+    gate_w = torch.randn(
+        intermediate_size,
+        hidden_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    up_w = torch.randn(
+        intermediate_size,
+        hidden_dim,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    down_w = torch.randn(
+        hidden_dim,
+        intermediate_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    fused = fused_ffn_module.fused_ffn(x, gate_w, up_w, down_w)
+    ref = fused_ffn_module.reference_ffn(x, gate_w, up_w, down_w)
+
+    assert torch.allclose(fused, ref, atol=BF16_ATOL, rtol=BF16_RTOL)

--- a/tests/python/ops/test_fused_qkv.py
+++ b/tests/python/ops/test_fused_qkv.py
@@ -1,0 +1,109 @@
+import importlib
+
+import pytest
+
+from tests.python.ops.conftest import (
+    BF16_ATOL,
+    BF16_RTOL,
+    requires_cuda,
+    requires_triton,
+)
+
+torch = importlib.import_module("torch")
+
+_FUSED_QKV = importlib.import_module("moe_infinity.kernel.fused_qkv")
+
+
+def _reference_fused_qkv(
+    hidden_states,
+    weight_qkv,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+):
+    q_dim = num_q_heads * head_dim
+    kv_dim = num_kv_heads * head_dim
+
+    weight_q = weight_qkv[:, :q_dim]
+    weight_k = weight_qkv[:, q_dim : q_dim + kv_dim]
+    weight_v = weight_qkv[:, q_dim + kv_dim :]
+
+    q = hidden_states @ weight_q
+    k = hidden_states @ weight_k
+    v = hidden_states @ weight_v
+
+    return (
+        q.reshape(hidden_states.size(0), num_q_heads, head_dim),
+        k.reshape(hidden_states.size(0), num_kv_heads, head_dim),
+        v.reshape(hidden_states.size(0), num_kv_heads, head_dim),
+    )
+
+
+@requires_cuda
+@requires_triton
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "tokens,hidden_dim",
+    [(1, 2048), (4, 2048), (16, 4096), (32, 2048)],
+)
+@pytest.mark.parametrize(
+    "num_q_heads,num_kv_heads,head_dim",
+    [(32, 8, 128), (16, 16, 64), (64, 8, 128)],
+)
+def test_fused_qkv_matches_reference(
+    seed_everything,
+    dtype,
+    tokens,
+    hidden_dim,
+    num_q_heads,
+    num_kv_heads,
+    head_dim,
+):
+    total_dim = (num_q_heads + 2 * num_kv_heads) * head_dim
+
+    hidden_states = torch.randn(
+        tokens,
+        hidden_dim,
+        dtype=dtype,
+        device="cuda",
+    ).contiguous()
+    weight_qkv = torch.randn(
+        hidden_dim,
+        total_dim,
+        dtype=dtype,
+        device="cuda",
+    ).contiguous()
+
+    fused_q, fused_k, fused_v = _FUSED_QKV.fused_qkv_proj(
+        hidden_states,
+        weight_qkv,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+    )
+    ref_q, ref_k, ref_v = _reference_fused_qkv(
+        hidden_states,
+        weight_qkv,
+        num_q_heads,
+        num_kv_heads,
+        head_dim,
+    )
+
+    torch.testing.assert_close(
+        fused_q,
+        ref_q,
+        rtol=BF16_RTOL,
+        atol=BF16_ATOL,
+    )
+    torch.testing.assert_close(
+        fused_k,
+        ref_k,
+        rtol=BF16_RTOL,
+        atol=BF16_ATOL,
+    )
+    torch.testing.assert_close(
+        fused_v,
+        ref_v,
+        rtol=BF16_RTOL,
+        atol=BF16_ATOL,
+    )

--- a/tests/python/ops/test_marlin_gemm.py
+++ b/tests/python/ops/test_marlin_gemm.py
@@ -1,0 +1,88 @@
+import importlib
+
+import pytest
+
+from tests.python.ops.conftest import requires_cuda
+
+torch = importlib.import_module("torch")
+
+
+def _marlin_available():
+    try:
+        importlib.import_module("moe_infinity._marlin")
+        return True
+    except ImportError:
+        return False
+
+
+requires_marlin = pytest.mark.skipif(
+    not _marlin_available(), reason="moe_infinity._marlin not compiled"
+)
+
+
+@pytest.fixture
+def marlin_module():
+    return importlib.import_module("moe_infinity.kernel.marlin_gemm")
+
+
+class TestMarlinQuantize:
+    @requires_cuda
+    @pytest.mark.parametrize("groupsize", [-1, 128])
+    @pytest.mark.parametrize("K,N", [(4096, 4096), (4096, 11008), (2048, 8192)])
+    def test_pack_roundtrip(self, marlin_module, K, N, groupsize):
+        weight = torch.randn(K, N, dtype=torch.float16, device="cuda")
+        packed, scales = marlin_module.marlin_quantize(weight, groupsize)
+
+        assert packed.dtype == torch.int32
+        assert scales.dtype == torch.float16
+        assert packed.shape == (K // 16, N * 16 // 8)
+
+    @requires_cuda
+    @pytest.mark.parametrize("groupsize", [-1, 128])
+    def test_quantize_deterministic(self, marlin_module, groupsize):
+        weight = torch.randn(2048, 256, dtype=torch.float16, device="cuda")
+        p1, s1 = marlin_module.marlin_quantize(weight, groupsize)
+        p2, s2 = marlin_module.marlin_quantize(weight, groupsize)
+        assert torch.equal(p1, p2)
+        assert torch.equal(s1, s2)
+
+
+class TestMarlinGemm:
+    @requires_cuda
+    @requires_marlin
+    @pytest.mark.parametrize("groupsize", [-1, 128])
+    @pytest.mark.parametrize(
+        "M,K,N", [(1, 4096, 4096), (16, 4096, 11008), (32, 2048, 8192)]
+    )
+    def test_correctness(self, marlin_module, M, K, N, groupsize):
+        weight = torch.randn(K, N, dtype=torch.float16, device="cuda")
+        packed, scales = marlin_module.marlin_quantize(weight, groupsize)
+        workspace = marlin_module.prepare_workspace(N, torch.device("cuda"))
+        input_tensor = torch.randn(M, K, dtype=torch.float16, device="cuda")
+
+        output = marlin_module.marlin_gemm(
+            input_tensor, packed, scales, workspace
+        )
+        reference = marlin_module.reference_dequant_gemm(
+            input_tensor, packed, scales, K, N, groupsize
+        )
+
+        assert output.shape == (M, N)
+        assert output.dtype == torch.float16
+        assert torch.allclose(
+            output.float(), reference.float(), atol=1e-2, rtol=1e-2
+        )
+
+    @requires_cuda
+    @requires_marlin
+    def test_workspace_size(self, marlin_module):
+        N = 4096
+        workspace = marlin_module.prepare_workspace(N, torch.device("cuda"))
+        assert workspace.shape == (N // 128 * 16,)
+        assert workspace.dtype == torch.int32
+
+
+class TestMarlinAvailability:
+    def test_is_marlin_available_returns_bool(self, marlin_module):
+        result = marlin_module.is_marlin_available()
+        assert isinstance(result, bool)

--- a/tests/python/serving/test_deterministic.py
+++ b/tests/python/serving/test_deterministic.py
@@ -1,0 +1,81 @@
+import importlib
+import os
+import sys
+
+import torch
+import torch.nn.functional as F
+
+from tests.python.ops.conftest import requires_cuda
+
+MODULE_NAME = "moe_infinity.kernel.deterministic_matmul"
+
+
+def _load_module():
+    sys.modules.pop(MODULE_NAME, None)
+    return importlib.import_module(MODULE_NAME)
+
+
+def test_enable_disable_deterministic_mode():
+    module = _load_module()
+    original_algorithms = torch.are_deterministic_algorithms_enabled()
+    original_cublas = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    original_nccl = os.environ.get("NCCL_ALGO")
+
+    module.enable_deterministic_mode()
+
+    assert torch.are_deterministic_algorithms_enabled()
+    assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":16:8"
+    assert os.environ["NCCL_ALGO"] == "Tree"
+
+    module.disable_deterministic_mode()
+
+    assert torch.are_deterministic_algorithms_enabled() == original_algorithms
+    assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == original_cublas
+    assert os.environ.get("NCCL_ALGO") == original_nccl
+
+
+def test_deterministic_linear_cpu():
+    module = _load_module()
+    input = torch.arange(12, dtype=torch.float32).reshape(3, 4) / 10
+    weight = torch.arange(20, dtype=torch.float32).reshape(5, 4) / 7
+    bias = torch.arange(5, dtype=torch.float32) / 11
+
+    output = module.deterministic_linear(input, weight, bias)
+    expected = F.linear(input, weight, bias)
+
+    assert torch.equal(output, expected)
+
+
+@requires_cuda
+def test_deterministic_linear_batch_invariant():
+    module = _load_module()
+    input = torch.randn(8, 16, device="cuda")
+    weight = torch.randn(32, 16, device="cuda")
+    bias = torch.randn(32, device="cuda")
+
+    batched = module.deterministic_linear(input, weight, bias)
+    individual = torch.stack(
+        [module.deterministic_linear(sample, weight, bias) for sample in input],
+        dim=0,
+    )
+
+    assert torch.equal(batched, individual)
+
+
+def test_env_var_auto_enable(monkeypatch):
+    original_algorithms = torch.are_deterministic_algorithms_enabled()
+    original_cublas = os.environ.get("CUBLAS_WORKSPACE_CONFIG")
+    original_nccl = os.environ.get("NCCL_ALGO")
+
+    monkeypatch.setenv("MOE_DETERMINISTIC", "1")
+    module = _load_module()
+
+    assert torch.are_deterministic_algorithms_enabled()
+    assert os.environ["CUBLAS_WORKSPACE_CONFIG"] == ":16:8"
+    assert os.environ["NCCL_ALGO"] == "Tree"
+
+    module.disable_deterministic_mode()
+
+    assert torch.are_deterministic_algorithms_enabled() == original_algorithms
+    assert os.environ.get("CUBLAS_WORKSPACE_CONFIG") == original_cublas
+    assert os.environ.get("NCCL_ALGO") == original_nccl

--- a/tests/python/serving/test_deterministic.py
+++ b/tests/python/serving/test_deterministic.py
@@ -43,7 +43,10 @@ def test_deterministic_linear_cpu():
     output = module.deterministic_linear(input, weight, bias)
     expected = F.linear(input, weight, bias)
 
-    assert torch.equal(output, expected)
+    # deterministic_linear computes per-sample GEMV for batch invariance, which
+    # may differ from F.linear's batched GEMM by float32 rounding/BLAS backend;
+    # bitwise equality is not part of the kernel's contract, closeness is.
+    torch.testing.assert_close(output, expected, atol=1e-6, rtol=1e-5)
 
 
 @requires_cuda


### PR DESCRIPTION
## Summary

Adds AOT-compiled fused kernels with eager fallbacks, plus a Marlin INT4 GEMM extension.

- **Fused kernels**: `fused_qkv`, `fused_ffn`, `fused_decode_attn`, and a deterministic matmul path. Opt out via `MOE_DISABLE_FUSED_KERNELS=1`.
- **Marlin INT4 GEMM**: `moe_infinity._marlin` extension + GPTQ/Marlin tensor-detection helpers in `utils/gptq`.
- **Kernel loader** (`_loader`) and `_compiled` package for AOT artifacts; `scripts/compile_kernels.py` to build them.

## Tests
`tests/python/ops/` — fused QKV/FFN/decode-attn parity, AOT kernel parity harness, Marlin GEMM. `tests/python/serving/test_deterministic.py` covers the deterministic matmul path.

## Notes
- `setup.py` adds the `_marlin` CUDA extension.
- Building the kernels requires CUDA; eager fallbacks keep CPU/test paths working.