### PR TITLE
feat(serving): CUDA graph capture, incremental writer, and hot reload

### DIFF
--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -1684,6 +1684,55 @@ async def list_models():
     return ModelList(data=[card])
 
 
+@app.post("/v1/reload")
+async def reload_modules(payload: dict[str, Any]) -> JSONResponse:
+    modules = payload.get("modules", [])
+    if not isinstance(modules, list) or not all(
+        isinstance(m, str) for m in modules
+    ):
+        raise HTTPException(
+            status_code=400, detail="'modules' must be a list of strings"
+        )
+    reloaded = []
+    errors = []
+    for module_name in modules:
+        try:
+            mod = importlib.import_module(module_name)
+            importlib.reload(mod)
+            reloaded.append(module_name)
+        except Exception as e:
+            errors.append({"module": module_name, "error": str(e)})
+    status = "ok" if not errors else "partial"
+    return JSONResponse(
+        content={"status": status, "reloaded": reloaded, "errors": errors}
+    )
+
+
+@app.get("/v1/config")
+async def get_config() -> JSONResponse:
+    if engine is None:
+        return create_error_response(
+            status_code=503,
+            message="Service starting",
+            error_type="server_error",
+            code="service_starting",
+        )
+    return JSONResponse(content=engine.get_config())
+
+
+@app.post("/v1/config")
+async def update_config(payload: dict[str, Any]) -> JSONResponse:
+    if engine is None:
+        return create_error_response(
+            status_code=503,
+            message="Service starting",
+            error_type="server_error",
+            code="service_starting",
+        )
+    updated = engine.update_config(payload)
+    return JSONResponse(content={"status": "ok", "updated": updated})
+
+
 def _resolve_int_attr(config: object, *names: str) -> Optional[int]:
     for name in names:
         value = getattr(config, name, None)

--- a/moe_infinity/serving/cuda_graph.py
+++ b/moe_infinity/serving/cuda_graph.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import threading
+
+import torch
+
+from .batch import BatchMetadata
+from .model_runner import ModelRunner
+
+
+class _CapturedGraphState:
+    graph: torch.cuda.CUDAGraph
+    input_ids: torch.Tensor
+    position_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    logits: torch.Tensor
+
+    def __init__(
+        self,
+        graph: torch.cuda.CUDAGraph,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        logits: torch.Tensor,
+    ) -> None:
+        self.graph = graph
+        self.input_ids = input_ids
+        self.position_ids = position_ids
+        self.attention_mask = attention_mask
+        self.logits = logits
+
+
+class CudaGraphRunner:
+    model_runner: ModelRunner
+    max_batch_sizes: tuple[int, ...]
+
+    def __init__(
+        self,
+        model_runner: ModelRunner,
+        max_batch_sizes: tuple[int, ...] = (1, 2, 4, 8, 16, 32),
+    ) -> None:
+        self.model_runner = model_runner
+        self.max_batch_sizes = tuple(
+            sorted(
+                {batch_size for batch_size in max_batch_sizes if batch_size > 0}
+            )
+        )
+        self._graphs: dict[int, _CapturedGraphState] = {}
+        self._warmed_batch_sizes: set[int] = set()
+        self._lock = threading.Lock()
+        self._disabled = (
+            __import__("os").getenv("MOE_DISABLE_CUDA_GRAPHS") == "1"
+        )
+
+    def is_compatible(self, batch: BatchMetadata) -> bool:
+        """Check if batch can use a captured graph (decode-only, matching size)."""
+        if not self._is_enabled():
+            return False
+
+        batch_size = len(batch.seq_ids)
+        return (
+            batch_size > 0
+            and self._is_decode_batch(batch)
+            and batch_size in self._graphs
+        )
+
+    def capture(self, batch: BatchMetadata) -> None:
+        """Capture CUDA graph for the given batch shape. Requires warmup first."""
+        if not self._is_enabled():
+            return
+
+        batch_size = self._validate_batch_for_graph(batch)
+        with self._lock:
+            if batch_size not in self._warmed_batch_sizes:
+                raise RuntimeError(
+                    "warmup() must be called before capture() for this batch size"
+                )
+
+            model_inputs = self.model_runner.prepare_inputs(batch)
+            example_logits = self._forward_decode(model_inputs)
+
+            static_input_ids = model_inputs["input_ids"].clone()
+            static_position_ids = model_inputs["position_ids"].clone()
+            static_attention_mask = model_inputs["attention_mask"].clone()
+            static_logits = torch.empty(
+                example_logits.shape,
+                dtype=example_logits.dtype,
+                device=example_logits.device,
+            )
+
+            graph = torch.cuda.CUDAGraph()
+            torch.cuda.synchronize(self.model_runner.device)
+            with torch.cuda.graph(graph):
+                captured_logits = self._forward_decode(
+                    {
+                        "input_ids": static_input_ids,
+                        "position_ids": static_position_ids,
+                        "attention_mask": static_attention_mask,
+                    }
+                )
+                static_logits.copy_(captured_logits)
+
+            self._graphs[batch_size] = _CapturedGraphState(
+                graph=graph,
+                input_ids=static_input_ids,
+                position_ids=static_position_ids,
+                attention_mask=static_attention_mask,
+                logits=static_logits,
+            )
+
+    def replay(self, batch: BatchMetadata) -> torch.Tensor:
+        """Copy inputs into captured buffers and replay graph."""
+        if len(batch.seq_ids) == 0 or batch.total_tokens == 0:
+            return self.model_runner._empty_logits()
+
+        if not self._is_enabled():
+            raise RuntimeError("CUDA graphs are disabled")
+
+        batch_size = self._validate_batch_for_graph(batch)
+        with self._lock:
+            state = self._graphs.get(batch_size)
+            if state is None:
+                raise RuntimeError(
+                    f"no CUDA graph has been captured for batch size {batch_size}"
+                )
+
+            model_inputs = self.model_runner.prepare_inputs(batch)
+            state.input_ids.copy_(model_inputs["input_ids"])
+            state.position_ids.copy_(model_inputs["position_ids"])
+            state.attention_mask.copy_(model_inputs["attention_mask"])
+            state.graph.replay()
+            return state.logits.clone()
+
+    def warmup(self, batch: BatchMetadata, num_iters: int = 3) -> None:
+        """Run warmup iterations before capture."""
+        if not self._is_enabled():
+            return
+
+        if num_iters < 1:
+            raise ValueError("num_iters must be at least 1")
+
+        batch_size = self._validate_batch_for_graph(batch)
+        with self._lock:
+            for _ in range(num_iters):
+                model_inputs = self.model_runner.prepare_inputs(batch)
+                _ = self._forward_decode(model_inputs)
+
+            torch.cuda.synchronize(self.model_runner.device)
+            self._warmed_batch_sizes.add(batch_size)
+
+    def invalidate(self) -> None:
+        """Clear all captured graphs (call on model reload)."""
+        with self._lock:
+            self._graphs.clear()
+            self._warmed_batch_sizes.clear()
+
+    def _forward_decode(
+        self, model_inputs: dict[str, torch.Tensor]
+    ) -> torch.Tensor:
+        eval_fn = getattr(self.model_runner.model, "eval", None)
+        if callable(eval_fn):
+            _ = eval_fn()
+
+        forward_fn = getattr(self.model_runner.model, "forward", None)
+        if not callable(forward_fn):
+            raise ValueError("model must define callable forward()")
+
+        with torch.no_grad():
+            outputs = forward_fn(
+                input_ids=model_inputs["input_ids"],
+                position_ids=model_inputs["position_ids"],
+                attention_mask=model_inputs["attention_mask"],
+                use_cache=True,
+            )
+
+        logits = self.model_runner._extract_logits(outputs)
+        batch_size = model_inputs["input_ids"].shape[0]
+        if logits.dim() == 3:
+            if logits.shape[0] != batch_size or logits.shape[1] != 1:
+                raise ValueError(
+                    "CUDA graph decode capture requires rank-3 logits with seq_len=1"
+                )
+            return logits[:, 0, :]
+
+        if logits.dim() != 2:
+            raise ValueError(
+                f"model output logits must be rank-2 or rank-3, got rank-{logits.dim()}"
+            )
+        if logits.shape[0] != batch_size:
+            raise ValueError(
+                "decode logits row count must match the decode batch size"
+            )
+        return logits
+
+    def _validate_batch_for_graph(self, batch: BatchMetadata) -> int:
+        if not self._is_cuda_device():
+            raise RuntimeError(
+                "CUDA graph capture requires a CUDA ModelRunner device"
+            )
+
+        batch_size = len(batch.seq_ids)
+        if batch_size == 0 or batch.total_tokens == 0:
+            raise ValueError(
+                "empty batches are not eligible for CUDA graph capture"
+            )
+        if batch_size not in self.max_batch_sizes:
+            raise ValueError(
+                f"batch size {batch_size} is not configured for CUDA graph capture"
+            )
+        if not self._is_decode_batch(batch):
+            raise ValueError(
+                "CUDA graphs only support decode batches with seq_len=1"
+            )
+        return batch_size
+
+    def _is_enabled(self) -> bool:
+        return not self._disabled and self._is_cuda_device()
+
+    def _is_cuda_device(self) -> bool:
+        return (
+            self.model_runner.device.type == "cuda"
+            and torch.cuda.is_available()
+        )
+
+    @staticmethod
+    def _is_decode_batch(batch: BatchMetadata) -> bool:
+        if len(batch.seq_ids) == 0 or batch.total_tokens == 0:
+            return False
+        if any(batch.is_prefill):
+            return False
+        if any(seq_len != 1 for seq_len in batch.seq_lengths):
+            return False
+        return batch.total_tokens == len(batch.seq_ids)
+
+
+__all__ = ["CudaGraphRunner"]

--- a/moe_infinity/serving/incremental_writer.py
+++ b/moe_infinity/serving/incremental_writer.py
@@ -1,0 +1,56 @@
+"""Append-only JSONL writer for crash recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+
+
+class IncrementalWriter:
+    def __init__(self, path: str | Path):
+        self._path = Path(path)
+        self._lock = threading.Lock()
+        self._file = self._path.open("a", encoding="utf-8")
+
+    def save(
+        self, seq_id: str, output_tokens: list[int], metadata: dict
+    ) -> None:
+        record = {
+            "seq_id": seq_id,
+            "output_tokens": output_tokens,
+            "metadata": metadata,
+            "timestamp": time.time(),
+        }
+        line = json.dumps(record, ensure_ascii=False)
+        with self._lock:
+            self._file.write(line)
+            self._file.write("\n")
+            self._file.flush()
+            os.fsync(self._file.fileno())
+
+    def load_completed(self) -> set[str]:
+        with self._lock:
+            try:
+                completed: set[str] = set()
+                with self._path.open("r", encoding="utf-8") as handle:
+                    for raw in handle:
+                        raw = raw.strip()
+                        if not raw:
+                            continue
+                        obj = json.loads(raw)
+                        seq_id = obj.get("seq_id")
+                        if isinstance(seq_id, str):
+                            completed.add(seq_id)
+                return completed
+            except FileNotFoundError:
+                return set()
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._file.closed:
+                self._file.flush()
+                os.fsync(self._file.fileno())
+                self._file.close()

--- a/tests/python/ops/test_auxiliary_loss.py
+++ b/tests/python/ops/test_auxiliary_loss.py
@@ -10,9 +10,9 @@ This module verifies:
 import importlib.machinery
 import sys
 import types
+from importlib import import_module
 
 import pytest
-from importlib import import_module
 
 from tests.python.ops.conftest import (
     BF16_ATOL,
@@ -47,6 +47,7 @@ _deepseek_v2_modeling = import_module(
 if hasattr(_deepseek_v2_modeling, "AddAuxiliaryLoss"):
     AddAuxiliaryLoss = _deepseek_v2_modeling.AddAuxiliaryLoss
 else:
+
     class AddAuxiliaryLoss(torch.autograd.Function):
         """Compatibility shim for the removed upstream DeepSeek helper."""
 
@@ -61,7 +62,9 @@ else:
         def backward(ctx, grad_output):
             grad_loss = None
             if ctx.loss_requires_grad:
-                grad_loss = torch.ones((), dtype=ctx.loss_dtype, device=ctx.loss_device)
+                grad_loss = torch.ones(
+                    (), dtype=ctx.loss_dtype, device=ctx.loss_device
+                )
             return grad_output, grad_loss
 
 

--- a/tests/python/ops/test_deepseek_v2_gate_consistency.py
+++ b/tests/python/ops/test_deepseek_v2_gate_consistency.py
@@ -265,8 +265,8 @@ def test_v2_routing_mask_conversion(seed_everything, norm_topk_prob):
 
     with torch.no_grad():
         topk_idx, topk_weight = block.gate(hidden_states)
-        router_mask, routing_weights_mask, _ = (
-            prepare_expert_route(hidden_states)
+        router_mask, routing_weights_mask, _ = prepare_expert_route(
+            hidden_states
         )
 
     manual_mask = torch.zeros_like(router_mask)

--- a/tests/python/serving/test_cuda_graph.py
+++ b/tests/python/serving/test_cuda_graph.py
@@ -1,0 +1,237 @@
+# pyright: reportAny=false, reportImplicitOverride=false, reportPrivateUsage=false
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+from tests.python.ops.conftest import requires_cuda
+
+ROOT = Path(__file__).resolve().parents[3]
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(module_name: str, file_path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("moe_infinity", ROOT / "moe_infinity")
+_ensure_package("moe_infinity.serving", ROOT / "moe_infinity" / "serving")
+
+_SEQUENCE_MODULE = _load_module(
+    "moe_infinity.serving.sequence",
+    ROOT / "moe_infinity" / "serving" / "sequence.py",
+)
+_BATCH_MODULE = _load_module(
+    "moe_infinity.serving.batch",
+    ROOT / "moe_infinity" / "serving" / "batch.py",
+)
+_MODEL_RUNNER_MODULE = _load_module(
+    "moe_infinity.serving.model_runner",
+    ROOT / "moe_infinity" / "serving" / "model_runner.py",
+)
+_CUDA_GRAPH_MODULE = _load_module(
+    "moe_infinity.serving.cuda_graph",
+    ROOT / "moe_infinity" / "serving" / "cuda_graph.py",
+)
+
+SamplingParams = _SEQUENCE_MODULE.SamplingParams
+BatchMetadata = _BATCH_MODULE.BatchMetadata
+ModelRunner = _MODEL_RUNNER_MODULE.ModelRunner
+CudaGraphRunner = _CUDA_GRAPH_MODULE.CudaGraphRunner
+
+
+class _MockOutput:
+    logits: torch.Tensor
+
+    def __init__(self, logits: torch.Tensor) -> None:
+        self.logits = logits
+
+
+class _MockModel:
+    config: types.SimpleNamespace
+
+    def __init__(self, vocab_size: int = 8) -> None:
+        self.config = types.SimpleNamespace(vocab_size=vocab_size)
+
+    def eval(self) -> None:
+        return None
+
+    def forward(self, input_ids: torch.Tensor, **_: object) -> _MockOutput:
+        batch_size, seq_len = input_ids.shape
+        logits = torch.zeros(batch_size, seq_len, self.config.vocab_size)
+        return _MockOutput(logits=logits)
+
+
+class _MockEngine:
+    def _generate_request_id(self) -> int:
+        return 0
+
+
+class _CudaModel(_MockModel):
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        **_: object,
+    ) -> _MockOutput:
+        values = (
+            input_ids.to(dtype=torch.float32)
+            + position_ids.to(dtype=torch.float32)
+            + attention_mask.to(dtype=torch.float32)
+        )
+        logits = torch.stack((values, values + 1.0, values + 2.0), dim=-1)
+        return _MockOutput(logits=logits)
+
+
+def _make_decode_batch(
+    *,
+    batch_size: int = 2,
+    context_lengths: list[int] | None = None,
+    input_token_ids: list[int] | None = None,
+) -> BatchMetadata:
+    if context_lengths is None:
+        context_lengths = list(range(batch_size))
+    if input_token_ids is None:
+        input_token_ids = [idx + 10 for idx in range(batch_size)]
+    return BatchMetadata(
+        seq_ids=list(range(batch_size)),
+        input_token_ids=input_token_ids,
+        seq_lengths=[1] * batch_size,
+        context_lengths=context_lengths,
+        is_prefill=[False] * batch_size,
+        block_tables=[[0] for _ in range(batch_size)],
+        token_offsets=list(range(batch_size + 1)),
+        sampling_params=[SamplingParams() for _ in range(batch_size)],
+    )
+
+
+def test_is_compatible_requires_decode_only_captured_batch() -> None:
+    runner = CudaGraphRunner(
+        ModelRunner(_MockModel(), _MockEngine(), device=torch.device("cpu")),
+        max_batch_sizes=(2,),
+    )
+    runner._is_cuda_device = lambda: True
+    runner._graphs[2] = types.SimpleNamespace()
+
+    decode_batch = _make_decode_batch(batch_size=2)
+    prefill_batch = BatchMetadata(
+        seq_ids=[1, 2],
+        input_token_ids=[11, 12],
+        seq_lengths=[1, 1],
+        context_lengths=[0, 0],
+        is_prefill=[True, False],
+        block_tables=[[0], [0]],
+        token_offsets=[0, 1, 2],
+        sampling_params=[SamplingParams(), SamplingParams()],
+    )
+    multi_token_batch = BatchMetadata(
+        seq_ids=[1],
+        input_token_ids=[11, 12],
+        seq_lengths=[2],
+        context_lengths=[0],
+        is_prefill=[False],
+        block_tables=[[0]],
+        token_offsets=[0, 2],
+        sampling_params=[SamplingParams()],
+    )
+
+    assert runner.is_compatible(decode_batch)
+    assert not runner.is_compatible(prefill_batch)
+    assert not runner.is_compatible(multi_token_batch)
+
+
+def test_invalidate_clears_captured_state() -> None:
+    runner = CudaGraphRunner(
+        ModelRunner(_MockModel(), _MockEngine(), device=torch.device("cpu")),
+        max_batch_sizes=(2,),
+    )
+    runner._graphs[2] = types.SimpleNamespace()
+    runner._warmed_batch_sizes.add(2)
+
+    runner.invalidate()
+
+    assert runner._graphs == {}
+    assert runner._warmed_batch_sizes == set()
+
+
+def test_replay_empty_batch_returns_empty_logits_without_graph() -> None:
+    runner = CudaGraphRunner(
+        ModelRunner(
+            _MockModel(vocab_size=5), _MockEngine(), device=torch.device("cpu")
+        ),
+        max_batch_sizes=(1,),
+    )
+    empty_batch = BatchMetadata(
+        seq_ids=[1],
+        input_token_ids=[],
+        seq_lengths=[0],
+        context_lengths=[7],
+        is_prefill=[False],
+        block_tables=[[0]],
+        token_offsets=[0, 0],
+        sampling_params=[SamplingParams()],
+    )
+
+    logits = runner.replay(empty_batch)
+
+    assert logits.shape == (0, 5)
+
+
+def test_env_flag_disables_graph_compatibility(monkeypatch) -> None:
+    monkeypatch.setenv("MOE_DISABLE_CUDA_GRAPHS", "1")
+    runner = CudaGraphRunner(
+        ModelRunner(_MockModel(), _MockEngine(), device=torch.device("cuda")),
+        max_batch_sizes=(2,),
+    )
+    runner._graphs[2] = types.SimpleNamespace()
+
+    assert not runner.is_compatible(_make_decode_batch(batch_size=2))
+
+    monkeypatch.delenv("MOE_DISABLE_CUDA_GRAPHS", raising=False)
+
+
+@requires_cuda
+def test_capture_and_replay_decode_batch_on_cuda() -> None:
+    os.environ.pop("MOE_DISABLE_CUDA_GRAPHS", None)
+    model_runner = ModelRunner(_CudaModel(vocab_size=3), _MockEngine())
+    runner = CudaGraphRunner(model_runner, max_batch_sizes=(2,))
+    capture_batch = _make_decode_batch(
+        batch_size=2,
+        context_lengths=[3, 7],
+        input_token_ids=[20, 30],
+    )
+    replay_batch = _make_decode_batch(
+        batch_size=2,
+        context_lengths=[4, 10],
+        input_token_ids=[21, 31],
+    )
+
+    runner.warmup(capture_batch, num_iters=1)
+    runner.capture(capture_batch)
+    logits = runner.replay(replay_batch)
+
+    expected = torch.tensor(
+        [[26.0, 27.0, 28.0], [42.0, 43.0, 44.0]], device=logits.device
+    )
+    assert runner.is_compatible(replay_batch)
+    assert torch.allclose(logits, expected)

--- a/tests/python/serving/test_hot_reload.py
+++ b/tests/python/serving/test_hot_reload.py
@@ -1,0 +1,112 @@
+# pyright: reportAny=false, reportCallIssue=false, reportExplicitAny=false, reportMissingParameterType=false, reportMissingTypeArgument=false, reportUnknownArgumentType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownVariableType=false
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+try:
+    from fastapi.testclient import TestClient
+
+    import moe_infinity.entrypoints.openai.api_server_v2 as srv
+except TypeError:
+    pytest.skip(
+        "Pydantic v1 incompatible with Python 3.12+", allow_module_level=True
+    )
+
+
+def _snapshot_runtime_state() -> dict[str, Any]:
+    return {
+        "engine": srv.engine,
+        "stream_manager": srv.stream_manager,
+        "tokenizer": srv.tokenizer,
+        "model_name_global": srv.model_name_global,
+        "_engine_task": srv._engine_task,
+        "_engine_shutdown_event": srv._engine_shutdown_event,
+        "_startup_args": getattr(srv, "_startup_args", None),
+        "_model_init_task": getattr(srv, "_model_init_task", None),
+    }
+
+
+def _restore_runtime_state(state: dict[str, Any]) -> None:
+    for key, value in state.items():
+        setattr(srv, key, value)
+
+
+def test_reload_valid_module(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_state = _snapshot_runtime_state()
+
+    def _reload(module: Any) -> Any:
+        return module
+
+    monkeypatch.setattr(importlib, "reload", _reload)
+
+    try:
+        with TestClient(srv.app) as client:
+            response = client.post("/v1/reload", json={"modules": ["json"]})
+
+        body = response.json()
+        assert response.status_code == 200
+        assert body["status"] == "ok"
+        assert body["reloaded"] == ["json"]
+        assert body["errors"] == []
+    finally:
+        _restore_runtime_state(original_state)
+
+
+def test_reload_invalid_module() -> None:
+    original_state = _snapshot_runtime_state()
+
+    try:
+        with TestClient(srv.app) as client:
+            response = client.post(
+                "/v1/reload", json={"modules": ["nonexistent.module"]}
+            )
+
+        body = response.json()
+        assert response.status_code == 200
+        assert body["status"] == "partial"
+        assert body["reloaded"] == []
+        assert body["errors"][0]["module"] == "nonexistent.module"
+    finally:
+        _restore_runtime_state(original_state)
+
+
+def test_reload_bad_payload() -> None:
+    original_state = _snapshot_runtime_state()
+
+    try:
+        with TestClient(srv.app) as client:
+            response = client.post("/v1/reload", json={"modules": "not_a_list"})
+
+        assert response.status_code == 400
+    finally:
+        _restore_runtime_state(original_state)
+
+
+def test_config_get_no_engine() -> None:
+    original_state = _snapshot_runtime_state()
+    srv.engine = None
+
+    try:
+        with TestClient(srv.app) as client:
+            response = client.get("/v1/config")
+
+        assert response.status_code == 503
+    finally:
+        _restore_runtime_state(original_state)
+
+
+def test_config_post_no_engine() -> None:
+    original_state = _snapshot_runtime_state()
+    srv.engine = None
+
+    try:
+        with TestClient(srv.app) as client:
+            response = client.post("/v1/config", json={"foo": "bar"})
+
+        assert response.status_code == 503
+    finally:
+        _restore_runtime_state(original_state)

--- a/tests/python/serving/test_incremental_writer.py
+++ b/tests/python/serving/test_incremental_writer.py
@@ -1,0 +1,126 @@
+# pyright: reportAny=false, reportImplicitOverride=false
+
+import importlib.util
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(module_name: str, file_path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("moe_infinity", ROOT / "moe_infinity")
+_ensure_package("moe_infinity.serving", ROOT / "moe_infinity" / "serving")
+
+_INCREMENTAL_WRITER_MODULE = _load_module(
+    "moe_infinity.serving.incremental_writer",
+    ROOT / "moe_infinity" / "serving" / "incremental_writer.py",
+)
+
+IncrementalWriter = _INCREMENTAL_WRITER_MODULE.IncrementalWriter
+
+
+def test_write_and_load_completed(tmp_path: Path) -> None:
+    path = tmp_path / "incremental.jsonl"
+    writer = IncrementalWriter(path)
+
+    try:
+        for index in range(3):
+            writer.save(f"seq-{index}", [index], {"index": index})
+
+        assert writer.load_completed() == {"seq-0", "seq-1", "seq-2"}
+    finally:
+        writer.close()
+
+
+def test_partial_recovery(tmp_path: Path) -> None:
+    path = tmp_path / "incremental.jsonl"
+    writer = IncrementalWriter(path)
+
+    try:
+        writer.save("seq-1", [1], {"index": 1})
+        writer.save("seq-2", [2], {"index": 2})
+    finally:
+        writer.close()
+
+    recovered = IncrementalWriter(path)
+    try:
+        assert recovered.load_completed() == {"seq-1", "seq-2"}
+    finally:
+        recovered.close()
+
+
+def test_empty_file(tmp_path: Path) -> None:
+    path = tmp_path / "missing.jsonl"
+    writer = IncrementalWriter(path)
+
+    try:
+        writer.close()
+        path.unlink()
+        assert writer.load_completed() == set()
+    finally:
+        if path.exists():
+            path.unlink()
+
+
+def test_concurrent_writes(tmp_path: Path) -> None:
+    path = tmp_path / "incremental.jsonl"
+    writer = IncrementalWriter(path)
+    barrier = threading.Barrier(10)
+
+    def worker(index: int) -> None:
+        barrier.wait()
+        writer.save(f"seq-{index}", [index], {"index": index})
+
+    threads = [
+        threading.Thread(target=worker, args=(index,)) for index in range(10)
+    ]
+
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert writer.load_completed() == {
+            f"seq-{index}" for index in range(10)
+        }
+    finally:
+        writer.close()
+
+
+def test_performance_fsync(tmp_path: Path) -> None:
+    path = tmp_path / "incremental.jsonl"
+    writer = IncrementalWriter(path)
+
+    try:
+        start = time.perf_counter()
+        for index in range(100):
+            writer.save(f"seq-{index}", [index], {"index": index})
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 5
+        assert len(writer.load_completed()) == 100
+    finally:
+        writer.close()


### PR DESCRIPTION
## Summary

- **`serving/cuda_graph.py`**: CUDA graph capture/replay for the decode path.
- **`serving/incremental_writer.py`**: incremental output streaming writer.
- **`api_server_v2`**: `/reload_modules`, `/get_config`, `/update_config` endpoints for hot reload and runtime configuration.

## Tests
`tests/python/serving/` — CUDA graph capture, incremental writer, and hot-reload endpoints.

## ⚠️ Merge note
This PR modifies `moe_infinity/entrypoints/openai/api_server_v2.py` by **adding** the reload/config endpoints. The branch `feat/server-production-features` also modifies the same file with a different set of additions (engine/sampler/scheduler hardening). If both land, expect a **merge conflict in `api_server_v2.py`** that needs manual reconciliation — the changes are additive and complementary, not overlapping in intent.