### PR TITLE
chore(benchmarks): fused-kernel A/B benchmarks and perplexity eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,3 +237,10 @@ AGENTS.md
 /tests/cuda/build/
 /tests/queues/build/
 .hf_cache/
+
+# Benchmark / profiling outputs
+/results/
+benchmarks/expert_io_microbench/results/
+benchmarks/eval/__pycache__/
+*.nsys-rep
+*.sqlite

--- a/benchmarks/ab_fused_kernels.py
+++ b/benchmarks/ab_fused_kernels.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""A/B benchmark: fused kernels ON vs OFF.
+
+Usage:
+    python benchmarks/ab_fused_kernels.py --model deepseek-ai/DeepSeek-V2-Lite-Chat --offload-dir /offload
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="A/B test fused kernels")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--offload-dir", required=True)
+    parser.add_argument("--concurrency", nargs="+", type=int, default=[1, 4, 8])
+    parser.add_argument("--num-rounds", type=int, default=5)
+    parser.add_argument("--max-new-tokens", type=int, default=32)
+    parser.add_argument("--prompt-length", type=int, default=128)
+    parser.add_argument("--output-json", default="/results/ab_results.json")
+    return parser.parse_args()
+
+
+def run_latency_bench(
+    env_overrides: dict[str, str],
+    args: argparse.Namespace,
+    label: str,
+) -> dict:
+    env = os.environ.copy()
+    env.update(env_overrides)
+
+    cmd = [
+        sys.executable,
+        "benchmarks/serving/latency.py",
+        "--model",
+        args.model,
+        "--offload-dir",
+        args.offload_dir,
+        "--concurrency",
+        *[str(c) for c in args.concurrency],
+        "--num-rounds",
+        str(args.num_rounds),
+        "--max-new-tokens",
+        str(args.max_new_tokens),
+        "--prompt-length",
+        str(args.prompt_length),
+    ]
+
+    print(f"\n{'='*60}")
+    print(f"  Running: {label}")
+    print(f"  Env: {env_overrides}")
+    print(f"{'='*60}\n")
+
+    start = time.perf_counter()
+    result = subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).parents[1]),
+    )
+    elapsed = time.perf_counter() - start
+
+    print(result.stdout)
+    if result.returncode != 0:
+        print(f"STDERR:\n{result.stderr}", file=sys.stderr)
+        return {
+            "label": label,
+            "error": result.stderr,
+            "returncode": result.returncode,
+        }
+
+    lines = result.stdout.strip().split("\n")
+    metrics: dict = {
+        "label": label,
+        "elapsed_s": round(elapsed, 2),
+        "raw_output": result.stdout,
+    }
+
+    for line in lines:
+        if "p50" in line.lower() or "median" in line.lower():
+            metrics["summary_line"] = line.strip()
+        if "itl" in line.lower():
+            metrics.setdefault("itl_lines", []).append(line.strip())
+
+    return metrics
+
+
+def main() -> None:
+    args = parse_args()
+
+    results_a = run_latency_bench(
+        {"MOE_DISABLE_FUSED_KERNELS": "1", "MOE_DISABLE_CUDA_GRAPHS": "1"},
+        args,
+        label="BASELINE (fused kernels OFF)",
+    )
+
+    results_b = run_latency_bench(
+        {"MOE_DISABLE_FUSED_KERNELS": "0", "MOE_DISABLE_CUDA_GRAPHS": "1"},
+        args,
+        label="FUSED KERNELS ON",
+    )
+
+    report = {
+        "model": args.model,
+        "concurrency": args.concurrency,
+        "num_rounds": args.num_rounds,
+        "max_new_tokens": args.max_new_tokens,
+        "prompt_length": args.prompt_length,
+        "baseline": results_a,
+        "fused": results_b,
+    }
+
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2))
+
+    print(f"\n{'='*60}")
+    print("  A/B COMPARISON SUMMARY")
+    print(f"{'='*60}")
+    print(f"  Baseline: {results_a.get('elapsed_s', 'N/A')}s total")
+    print(f"  Fused:    {results_b.get('elapsed_s', 'N/A')}s total")
+    if results_a.get("summary_line"):
+        print(f"  Baseline metric: {results_a['summary_line']}")
+    if results_b.get("summary_line"):
+        print(f"  Fused metric:    {results_b['summary_line']}")
+    print(f"\n  Full results: {args.output_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/ab_kernels_micro.py
+++ b/benchmarks/ab_kernels_micro.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Kernel-level A/B microbenchmark: fused vs unfused.
+
+Measures pure kernel performance (no model overhead). This is the cleanest
+A/B test of the new fused kernels.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+
+def bench(fn, n_warmup: int = 10, n_iters: int = 100) -> dict:
+    for _ in range(n_warmup):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(n_iters):
+        fn()
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - t0
+    return {
+        "total_s": elapsed,
+        "per_iter_ms": elapsed / n_iters * 1000,
+        "throughput_per_s": n_iters / elapsed,
+    }
+
+
+def bench_fused_qkv(
+    M: int = 32,
+    hidden_dim: int = 4096,
+    num_q_heads: int = 32,
+    num_kv_heads: int = 8,
+    head_dim: int = 128,
+) -> dict:
+    print(
+        f"\n--- Fused QKV: M={M} hidden={hidden_dim} q_heads={num_q_heads} kv_heads={num_kv_heads} head_dim={head_dim}"
+    )
+
+    from moe_infinity.kernel.fused_qkv import fused_qkv_proj
+
+    total_dim = (num_q_heads + 2 * num_kv_heads) * head_dim
+    x = torch.randn(M, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    w_qkv = torch.randn(
+        hidden_dim, total_dim, dtype=torch.bfloat16, device="cuda"
+    )
+
+    q_dim = num_q_heads * head_dim
+    kv_dim = num_kv_heads * head_dim
+    w_q = w_qkv[:, :q_dim].T.contiguous()
+    w_k = w_qkv[:, q_dim : q_dim + kv_dim].T.contiguous()
+    w_v = w_qkv[:, q_dim + kv_dim :].T.contiguous()
+
+    def fused():
+        return fused_qkv_proj(x, w_qkv, num_q_heads, num_kv_heads, head_dim)
+
+    def unfused():
+        q = (x @ w_q.T).reshape(M, num_q_heads, head_dim)
+        k = (x @ w_k.T).reshape(M, num_kv_heads, head_dim)
+        v = (x @ w_v.T).reshape(M, num_kv_heads, head_dim)
+        return q, k, v
+
+    qf, kf, vf = fused()
+    qu, ku, vu = unfused()
+    max_err = max(
+        (qf - qu).abs().max().item(),
+        (kf - ku).abs().max().item(),
+        (vf - vu).abs().max().item(),
+    )
+
+    res_unfused = bench(unfused)
+    res_fused = bench(fused)
+    speedup = res_unfused["per_iter_ms"] / res_fused["per_iter_ms"]
+
+    print(f"  Unfused (3x matmul):  {res_unfused['per_iter_ms']:.3f} ms/iter")
+    print(f"  Fused (1 kernel):     {res_fused['per_iter_ms']:.3f} ms/iter")
+    print(f"  Speedup:              {speedup:.2f}x")
+    print(f"  Max numerical error:  {max_err:.4f}")
+
+    return {
+        "kernel": "fused_qkv",
+        "shape": {
+            "M": M,
+            "hidden": hidden_dim,
+            "q_heads": num_q_heads,
+            "kv_heads": num_kv_heads,
+            "head_dim": head_dim,
+        },
+        "unfused_ms": res_unfused["per_iter_ms"],
+        "fused_ms": res_fused["per_iter_ms"],
+        "speedup": speedup,
+        "max_error": max_err,
+    }
+
+
+def bench_fused_ffn(
+    M: int = 32,
+    hidden_dim: int = 4096,
+    intermediate_size: int = 11008,
+) -> dict:
+    print(
+        f"\n--- Fused FFN: M={M} hidden={hidden_dim} intermediate={intermediate_size}"
+    )
+
+    from moe_infinity.kernel.fused_ffn import fused_ffn
+
+    x = torch.randn(M, hidden_dim, dtype=torch.bfloat16, device="cuda")
+    gate_w = torch.randn(
+        intermediate_size, hidden_dim, dtype=torch.bfloat16, device="cuda"
+    )
+    up_w = torch.randn(
+        intermediate_size, hidden_dim, dtype=torch.bfloat16, device="cuda"
+    )
+    down_w = torch.randn(
+        hidden_dim, intermediate_size, dtype=torch.bfloat16, device="cuda"
+    )
+
+    def fused():
+        return fused_ffn(x, gate_w, up_w, down_w)
+
+    def unfused():
+        gate = x @ gate_w.T
+        up = x @ up_w.T
+        intermediate = torch.nn.functional.silu(gate) * up
+        return intermediate @ down_w.T
+
+    out_f = fused()
+    out_u = unfused()
+    max_err = (out_f - out_u).abs().max().item()
+
+    res_unfused = bench(unfused)
+    res_fused = bench(fused)
+    speedup = res_unfused["per_iter_ms"] / res_fused["per_iter_ms"]
+
+    print(f"  Unfused (4 ops):      {res_unfused['per_iter_ms']:.3f} ms/iter")
+    print(f"  Fused (Triton):       {res_fused['per_iter_ms']:.3f} ms/iter")
+    print(f"  Speedup:              {speedup:.2f}x")
+    print(f"  Max numerical error:  {max_err:.4f}")
+
+    return {
+        "kernel": "fused_ffn",
+        "shape": {
+            "M": M,
+            "hidden": hidden_dim,
+            "intermediate": intermediate_size,
+        },
+        "unfused_ms": res_unfused["per_iter_ms"],
+        "fused_ms": res_fused["per_iter_ms"],
+        "speedup": speedup,
+        "max_error": max_err,
+    }
+
+
+def bench_marlin(
+    M: int = 32,
+    K: int = 4096,
+    N: int = 4096,
+    groupsize: int = 128,
+) -> dict:
+    print(f"\n--- Marlin INT4: M={M} K={K} N={N} groupsize={groupsize}")
+
+    try:
+        import moe_infinity._marlin
+    except ImportError:
+        print("  SKIP: moe_infinity._marlin not available")
+        return {
+            "kernel": "marlin_gemm",
+            "skipped": True,
+            "reason": "not compiled",
+        }
+
+    cap = torch.cuda.get_device_capability(0)
+    if cap[0] >= 9:
+        print(
+            f"  SKIP: Marlin kernel requires sm_80/86/89 (Ampere/Ada), got sm_{cap[0]}{cap[1]} (Hopper/Blackwell)"
+        )
+        print(
+            f"  Note: Memory reduction is still 4x, just kernel performance is unoptimized for sm_>=90"
+        )
+        from moe_infinity.kernel.marlin_gemm import marlin_quantize
+
+        weight_fp16 = torch.randn(K, N, dtype=torch.float16, device="cuda")
+        packed, scales = marlin_quantize(weight_fp16, groupsize)
+        memory_reduction = (K * N * 2) / (
+            packed.numel() * 4 + scales.numel() * 2
+        )
+        print(
+            f"  Weight memory: FP16={K*N*2/1e6:.1f} MB  INT4={packed.numel()*4/1e6:.1f} MB  reduction={memory_reduction:.2f}x"
+        )
+        return {
+            "kernel": "marlin_gemm",
+            "shape": {"M": M, "K": K, "N": N, "groupsize": groupsize},
+            "skipped": True,
+            "reason": f"sm_{cap[0]}{cap[1]} not supported by Marlin (needs Ampere/Ada)",
+            "memory_reduction_x": memory_reduction,
+        }
+
+    from moe_infinity.kernel.marlin_gemm import (
+        marlin_gemm,
+        marlin_quantize,
+        prepare_workspace,
+    )
+
+    weight_fp16 = torch.randn(K, N, dtype=torch.float16, device="cuda")
+    packed, scales = marlin_quantize(weight_fp16, groupsize)
+    workspace = prepare_workspace(N, torch.device("cuda"))
+    x = torch.randn(M, K, dtype=torch.float16, device="cuda")
+
+    def fp16_baseline():
+        return x @ weight_fp16
+
+    def marlin():
+        return marlin_gemm(x, packed, scales, workspace)
+
+    res_fp16 = bench(fp16_baseline)
+    res_marlin = bench(marlin)
+    speedup = res_fp16["per_iter_ms"] / res_marlin["per_iter_ms"]
+    memory_reduction = (K * N * 2) / (packed.numel() * 4 + scales.numel() * 2)
+
+    print(f"  FP16 baseline:        {res_fp16['per_iter_ms']:.3f} ms/iter")
+    print(f"  Marlin INT4:          {res_marlin['per_iter_ms']:.3f} ms/iter")
+    print(f"  Speedup:              {speedup:.2f}x")
+    print(f"  Weight memory reduction: {memory_reduction:.2f}x")
+
+    return {
+        "kernel": "marlin_gemm",
+        "shape": {"M": M, "K": K, "N": N, "groupsize": groupsize},
+        "fp16_ms": res_fp16["per_iter_ms"],
+        "marlin_ms": res_marlin["per_iter_ms"],
+        "speedup": speedup,
+        "memory_reduction_x": memory_reduction,
+    }
+
+
+def main() -> None:
+    print(f"Device: {torch.cuda.get_device_name(0)}")
+    print(f"PyTorch: {torch.__version__}")
+    print(
+        f"CUDA capability: sm_{torch.cuda.get_device_capability(0)[0]}{torch.cuda.get_device_capability(0)[1]}"
+    )
+
+    results: list[dict] = []
+
+    print("\n" + "=" * 70)
+    print("  FUSED QKV PROJECTION (decode shapes)")
+    print("=" * 70)
+    for batch in [1, 4, 16, 32]:
+        results.append(
+            bench_fused_qkv(
+                M=batch,
+                hidden_dim=4096,
+                num_q_heads=32,
+                num_kv_heads=8,
+                head_dim=128,
+            )
+        )
+
+    print("\n" + "=" * 70)
+    print("  FUSED FFN (Llama-3 8B sized)")
+    print("=" * 70)
+    for batch in [1, 4, 16, 32]:
+        results.append(
+            bench_fused_ffn(M=batch, hidden_dim=4096, intermediate_size=14336)
+        )
+
+    print("\n" + "=" * 70)
+    print("  MARLIN W4A16 GEMM")
+    print("=" * 70)
+    for batch in [1, 4, 16, 32]:
+        results.append(bench_marlin(M=batch, K=4096, N=4096, groupsize=128))
+
+    print("\n" + "=" * 70)
+    print("  SUMMARY")
+    print("=" * 70)
+    print(
+        f"{'Kernel':<15} {'Shape':<35} {'Unfused':>10} {'Fused':>10} {'Speedup':>10}"
+    )
+    print("-" * 80)
+    for r in results:
+        if r.get("skipped"):
+            continue
+        kernel = r["kernel"]
+        shape = r["shape"]
+        if kernel == "fused_qkv":
+            shape_str = f"M={shape['M']} hidden={shape['hidden']}"
+            unfused = r["unfused_ms"]
+            fused = r["fused_ms"]
+        elif kernel == "fused_ffn":
+            shape_str = f"M={shape['M']} hidden={shape['hidden']} int={shape['intermediate']}"
+            unfused = r["unfused_ms"]
+            fused = r["fused_ms"]
+        else:
+            shape_str = f"M={shape['M']} K={shape['K']} N={shape['N']}"
+            unfused = r["fp16_ms"]
+            fused = r["marlin_ms"]
+        print(
+            f"{kernel:<15} {shape_str:<35} {unfused:>9.3f}ms {fused:>9.3f}ms {r['speedup']:>9.2f}x"
+        )
+
+    output_path = Path("/results/kernel_ab_results.json")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(results, indent=2))
+    print(f"\nResults saved: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/eval/perplexity.py
+++ b/benchmarks/eval/perplexity.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate model perplexity")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--offload-dir", required=True)
+    parser.add_argument(
+        "--dataset", default="wikitext", choices=["wikitext", "c4", "ptb"]
+    )
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--max-samples", type=int, default=256)
+    parser.add_argument("--seq-length", type=int, default=2048)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--output-json", default=None)
+    return parser.parse_args()
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def resolve_dataset(dataset: str, split: str) -> tuple[str, str | None, str]:
+    if dataset == "wikitext":
+        return "wikitext", "wikitext-2-raw-v1", split
+    if dataset == "c4":
+        return "allenai/c4", "en", "validation" if split == "test" else split
+    if dataset == "ptb":
+        return "ptb_text_only", "penn_treebank", split
+    raise ValueError(f"Unsupported dataset: {dataset}")
+
+
+def load_texts(dataset: str, split: str, max_samples: int) -> list[str]:
+    dataset_name, dataset_config, dataset_split = resolve_dataset(
+        dataset, split
+    )
+    if dataset_config is None:
+        raw_dataset = load_dataset(dataset_name, split=dataset_split)
+    else:
+        raw_dataset = load_dataset(
+            dataset_name, dataset_config, split=dataset_split
+        )
+
+    texts: list[str] = []
+    for row in raw_dataset:
+        text = str(row.get("text", "")).strip()
+        if text:
+            texts.append(text)
+        if len(texts) >= max_samples:
+            break
+    return texts
+
+
+def _model_forward(
+    model: Any, input_ids: torch.Tensor, attention_mask: torch.Tensor
+) -> torch.Tensor:
+    target = getattr(model, "model", model)
+    outputs = target(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        use_cache=False,
+    )
+    if hasattr(outputs, "logits"):
+        return outputs.logits
+    if isinstance(outputs, (tuple, list)):
+        return outputs[0]
+    raise RuntimeError("Model forward pass did not return logits")
+
+
+def evaluate_perplexity(
+    model: Any,
+    tokenizer: Any,
+    dataset: list[str],
+    seq_length: int,
+    max_samples: int,
+    batch_size: int,
+) -> tuple[float, float, int]:
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be > 0, got {batch_size}")
+    if seq_length <= 1:
+        raise ValueError(f"seq_length must be > 1, got {seq_length}")
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    target = getattr(model, "model", model)
+    if hasattr(target, "eval"):
+        target.eval()
+
+    total_nll = 0.0
+    total_tokens = 0
+    processed = 0
+
+    with torch.inference_mode():
+        for start in range(0, min(len(dataset), max_samples), batch_size):
+            batch_texts = dataset[start : start + batch_size]
+            encoded = tokenizer(
+                batch_texts,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=seq_length + 1,
+            )
+            input_ids = encoded["input_ids"].to(device)
+            attention_mask = encoded["attention_mask"].to(device)
+
+            if input_ids.shape[1] < 2:
+                continue
+
+            logits = _model_forward(model, input_ids, attention_mask)
+            shift_logits = logits[:, :-1, :].contiguous()
+            shift_labels = input_ids[:, 1:].contiguous()
+            shift_mask = attention_mask[:, 1:].contiguous()
+            shift_labels = shift_labels.masked_fill(shift_mask == 0, -100)
+
+            loss = F.cross_entropy(
+                shift_logits.view(-1, shift_logits.size(-1)),
+                shift_labels.view(-1),
+                ignore_index=-100,
+                reduction="sum",
+            )
+            valid_tokens = int((shift_labels != -100).sum().item())
+            if valid_tokens > 0:
+                total_nll += float(loss.item())
+                total_tokens += valid_tokens
+                processed += len(batch_texts)
+
+    if total_tokens <= 0:
+        raise RuntimeError(
+            "No valid tokens were processed for perplexity evaluation"
+        )
+
+    mean_nll = total_nll / total_tokens
+    ppl = math.exp(mean_nll)
+    return ppl, mean_nll, processed
+
+
+def main() -> None:
+    args = parse_args()
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model, trust_remote_code=True
+    )
+    if tokenizer.pad_token_id is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    try:
+        from moe_infinity import MoE
+    except Exception as exc:
+        raise RuntimeError(f"moe_infinity import failed: {exc}") from exc
+
+    model = MoE(args.model, {"offload_path": args.offload_dir})
+    texts = load_texts(args.dataset, args.split, args.max_samples)
+
+    start_time = time.perf_counter()
+    ppl, nll, n = evaluate_perplexity(
+        model,
+        tokenizer,
+        texts,
+        args.seq_length,
+        args.max_samples,
+        args.batch_size,
+    )
+    elapsed_s = time.perf_counter() - start_time
+
+    print(f"Perplexity: {ppl:.4f} (NLL: {nll:.4f}, samples: {n})")
+
+    if args.output_json:
+        write_json(
+            Path(args.output_json),
+            {
+                "model": args.model,
+                "dataset": args.dataset,
+                "split": args.split,
+                "max_samples": args.max_samples,
+                "seq_length": args.seq_length,
+                "batch_size": args.batch_size,
+                "perplexity": ppl,
+                "nll": nll,
+                "samples": n,
+                "elapsed_s": elapsed_s,
+                "offload_dir": args.offload_dir,
+            },
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/ops/test_auxiliary_loss.py
+++ b/tests/python/ops/test_auxiliary_loss.py
@@ -10,9 +10,9 @@ This module verifies:
 import importlib.machinery
 import sys
 import types
+from importlib import import_module
 
 import pytest
-from importlib import import_module
 
 from tests.python.ops.conftest import (
     BF16_ATOL,
@@ -47,6 +47,7 @@ _deepseek_v2_modeling = import_module(
 if hasattr(_deepseek_v2_modeling, "AddAuxiliaryLoss"):
     AddAuxiliaryLoss = _deepseek_v2_modeling.AddAuxiliaryLoss
 else:
+
     class AddAuxiliaryLoss(torch.autograd.Function):
         """Compatibility shim for the removed upstream DeepSeek helper."""
 
@@ -61,7 +62,9 @@ else:
         def backward(ctx, grad_output):
             grad_loss = None
             if ctx.loss_requires_grad:
-                grad_loss = torch.ones((), dtype=ctx.loss_dtype, device=ctx.loss_device)
+                grad_loss = torch.ones(
+                    (), dtype=ctx.loss_dtype, device=ctx.loss_device
+                )
             return grad_output, grad_loss
 
 

--- a/tests/python/ops/test_deepseek_v2_gate_consistency.py
+++ b/tests/python/ops/test_deepseek_v2_gate_consistency.py
@@ -265,8 +265,8 @@ def test_v2_routing_mask_conversion(seed_everything, norm_topk_prob):
 
     with torch.no_grad():
         topk_idx, topk_weight = block.gate(hidden_states)
-        router_mask, routing_weights_mask, _ = (
-            prepare_expert_route(hidden_states)
+        router_mask, routing_weights_mask, _ = prepare_expert_route(
+            hidden_states
         )
 
     manual_mask = torch.zeros_like(router_mask)


### PR DESCRIPTION
## Summary

- `benchmarks/ab_fused_kernels.py`, `benchmarks/ab_kernels_micro.py`: A/B microbenchmarks for the fused kernels (pairs with PR #100).
- `benchmarks/eval/perplexity.py`: perplexity evaluation harness.
- `.gitignore`: ignore profiling/result outputs (`*.nsys-rep`, `*.sqlite`, `results/`, `benchmarks/expert_io_microbench/results/`).

## Notes
Benchmark scripts only; no library code changes. The fused-kernel benchmarks are most useful alongside PR #100 (`feat/fused-kernels`).