### PR TITLE
fix(security): bump setuptools to >=78.1.1,<82 (dependabot HIGH)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools==75.3.2 wheel build
+          pip install "setuptools>=78.1.1,<82" wheel build
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build sdist

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Install build tools
         run: |
-          pip install setuptools==75.3.2 wheel build
+          pip install "setuptools>=78.1.1,<82" wheel build
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build sdist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ COPY requirements.txt .
 
 # Install Python build dependencies first (torch is already in the base image)
 RUN pip install --no-cache-dir \
-    setuptools>=75 \
+    "setuptools>=78.1.1,<82" \
     wheel \
     ninja \
     py-cpuinfo

--- a/docker/Dockerfile.benchmark
+++ b/docker/Dockerfile.benchmark
@@ -34,7 +34,7 @@ RUN git clone --branch v3.2.2 --depth 1 https://github.com/NVIDIA/NVTX.git /tmp/
 WORKDIR /workspace/MoE-Infinity
 
 COPY requirements.txt .
-RUN pip install --no-cache-dir setuptools>=75 wheel ninja py-cpuinfo
+RUN pip install --no-cache-dir "setuptools>=78.1.1,<82" wheel ninja py-cpuinfo
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/docker/Dockerfile.blackwell
+++ b/docker/Dockerfile.blackwell
@@ -44,7 +44,7 @@ RUN git clone --branch v3.2.2 --depth 1 https://github.com/NVIDIA/NVTX.git /tmp/
 WORKDIR /workspace/MoE-Infinity
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir setuptools>=75 wheel ninja py-cpuinfo pytest pytest-timeout
+RUN pip install --no-cache-dir "setuptools>=78.1.1,<82" wheel ninja py-cpuinfo pytest pytest-timeout
 RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install --no-cache-dir --no-deps contextpilot && \
     pip install --no-cache-dir elasticsearch ujson

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==75.3.2", "wheel", "torch"]
+requires = ["setuptools>=78.1.1,<82", "wheel", "torch"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
## Summary
Fixes the **HIGH** dependabot alert: `setuptools < 78.1.1` has a path-traversal / arbitrary-file-write vulnerability in `PackageIndex.download`.

## Changes
Bumped the setuptools floor to `>=78.1.1` across all build/CI/Docker pins:
- `pyproject.toml` (build-system requires)
- `.github/workflows/build-test.yml`, `.github/workflows/ci-pr.yml`
- `docker/Dockerfile`, `docker/Dockerfile.blackwell`, `docker/Dockerfile.benchmark` (were `>=75`, which still permitted the vulnerable 75.3.2)

## Why the `<82` cap
`torch` requires `setuptools<82`. Without the cap, the floor resolves to 82.0.1 and breaks the build with a dependency conflict. Verified: `>=78.1.1,<82` resolves to 81.0.0 and **sdist build passes**.

## Verification
- Fresh sdist build in a clean venv with patched setuptools (81.0.0): pass.
- pre-commit (yaml/dockerfile checks): pass.