### PR TITLE
refactor(config): resolve_config_dtype shim for transformers v5 compat (Phase 1)

### DIFF
--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -243,7 +243,9 @@ class MoE:
 
     @staticmethod
     def _resolve_torch_dtype(model_config: object) -> torch.dtype:
-        torch_dtype = getattr(model_config, "torch_dtype", None)
+        torch_dtype = getattr(model_config, "dtype", None)
+        if torch_dtype is None:
+            torch_dtype = getattr(model_config, "torch_dtype", None)
         if isinstance(torch_dtype, torch.dtype):
             return torch_dtype
         if isinstance(torch_dtype, str):

--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -1744,7 +1744,9 @@ def _resolve_int_attr(config: object, *names: str) -> Optional[int]:
 def _resolve_dtype(model: object) -> str:
     model_config = getattr(model, "config", None)
     if model_config is not None:
-        torch_dtype = getattr(model_config, "torch_dtype", None)
+        torch_dtype = getattr(model_config, "dtype", None)
+        if torch_dtype is None:
+            torch_dtype = getattr(model_config, "torch_dtype", None)
         if isinstance(torch_dtype, str):
             return torch_dtype.replace("torch.", "")
         if torch_dtype is not None:

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -60,6 +60,7 @@ from moe_infinity.utils import (
     parse_expert_dtype,
     parse_expert_id,
     parse_moe_param,
+    resolve_config_dtype,
 )
 from moe_infinity.utils.arguments import (
     copy_args_to_device,
@@ -506,11 +507,9 @@ class OffloadEngine(object):
                     )
 
                 self.dtype = parse_expert_dtype(self.config)
-                self.dtype_cls = self.config.torch_dtype
+                self.dtype_cls = resolve_config_dtype(self.config)
                 if self.dtype_cls is None:
-                    self.dtype_cls = getattr(
-                        self.config, "dtype", torch.bfloat16
-                    )
+                    self.dtype_cls = torch.bfloat16
 
                 if self.config.model_type == "deepseek_v3":
                     self.dtype_cls = torch.float8_e4m3fn

--- a/moe_infinity/utils/__init__.py
+++ b/moe_infinity/utils/__init__.py
@@ -15,6 +15,7 @@ from .hf_config import (
     parse_expert_dtype,
     parse_expert_id,
     parse_moe_param,
+    resolve_config_dtype,
 )
 from .quantization import (
     QuantizationInfo,
@@ -39,6 +40,7 @@ __all__ = [
     "parse_expert_dtype",
     "parse_expert_id",
     "parse_moe_param",
+    "resolve_config_dtype",
     "QuantizationInfo",
     "validate_quantization_support",
     "wait_transfer",

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -47,10 +47,17 @@ def ensure_config_compat(config: PretrainedConfig) -> PretrainedConfig:
     return config
 
 
-def parse_expert_dtype(config: PretrainedConfig) -> int:
-    dtype = config.torch_dtype
+def resolve_config_dtype(config: object) -> Optional[torch.dtype]:
+    # transformers v5 renamed config.torch_dtype -> config.dtype. Read the new
+    # name first, fall back to the old one so both 4.x and 5.x configs work.
+    dtype = getattr(config, "dtype", None)
     if dtype is None:
-        dtype = getattr(config, "dtype", None)
+        dtype = getattr(config, "torch_dtype", None)
+    return dtype
+
+
+def parse_expert_dtype(config: PretrainedConfig) -> int:
+    dtype = resolve_config_dtype(config)
     if dtype is None:
         dtype = torch.bfloat16
     if dtype == torch.bfloat16:

--- a/tests/python/unit/test_utils_hf_config.py
+++ b/tests/python/unit/test_utils_hf_config.py
@@ -9,6 +9,7 @@ from moe_infinity.utils.hf_config import (
     parse_expert_dtype,
     parse_expert_id,
     parse_moe_param,
+    resolve_config_dtype,
 )
 
 
@@ -31,6 +32,34 @@ def test_parse_expert_dtype_unsupported():
     cfg = _cfg(torch_dtype=torch.int32)
     with pytest.raises(AssertionError):
         parse_expert_dtype(cfg)
+
+
+def test_resolve_config_dtype_v5_shape():
+    cfg = _cfg(dtype=torch.bfloat16)
+    assert resolve_config_dtype(cfg) == torch.bfloat16
+
+
+def test_resolve_config_dtype_v4_shape():
+    cfg = _cfg(torch_dtype=torch.float16)
+    assert resolve_config_dtype(cfg) == torch.float16
+
+
+def test_resolve_config_dtype_prefers_new_name():
+    cfg = _cfg(dtype=torch.float32, torch_dtype=torch.float16)
+    assert resolve_config_dtype(cfg) == torch.float32
+
+
+def test_resolve_config_dtype_missing_returns_none():
+    cfg = _cfg(hidden_size=128)
+    assert resolve_config_dtype(cfg) is None
+
+
+def test_parse_expert_dtype_v5_shape():
+    cfg = _cfg(dtype=torch.bfloat16)
+    assert parse_expert_dtype(cfg) == 0
+
+    cfg = _cfg(dtype=torch.float16)
+    assert parse_expert_dtype(cfg) == 2
 
 
 def test_parse_moe_param_nllb():


### PR DESCRIPTION
## Summary
Phase 1 of the transformers 4.x → 5.x migration (plan: `.sisyphus/plans/transformers-v5-migration.md`).

transformers v5 renames `config.torch_dtype` → `config.dtype`. Direct attribute access (`self.config.torch_dtype`) raises `AttributeError` on v5. This PR adds a **backward-compatible** shim and routes all dtype-read sites through it, so the codebase works on **both** 4.x and 5.x.

## Changes
- New `resolve_config_dtype(config)` in `moe_infinity/utils/hf_config.py` — reads `dtype`, falls back to `torch_dtype`. Exported from `moe_infinity.utils`.
- `runtime/model_offload.py` — replaced direct `self.config.torch_dtype` read with the shim.
- `utils/hf_config.py:parse_expert_dtype` — now uses the shim.
- `entrypoints/big_modeling.py:_resolve_torch_dtype` and `entrypoints/openai/api_server_v2.py:_resolve_dtype` — now read `dtype` first (were `torch_dtype`-only, would silently return a wrong default dtype on v5).

## Why this is safe to land now (before the version bump)
The shim reads both attribute names, so it's a no-op on the current 4.57.6 and forward-compatible with 5.x. No `transformers` version change in this PR.

## Verification
- New tests in `test_utils_hf_config.py`: v4-shape config, v5-shape config, precedence, missing-attr → 11 passed (+5).
- Full CPU suite: **489 passed, 2 skipped** (was 484; +5 new), zero regressions.
- pre-commit (ruff, mypy, codespell): pass.

## Scope note
Phases 2–5 (actual `transformers>=5.3.0` bump, deep model-internal import fixes, monkey-patch re-init validation, e2e golden comparison) are **not** in this PR — they require installing v5 and per-arch testing. This PR removes the single highest-severity crash point in a fully backward-compatible way.