### PR TITLE
refactor(config): import PretrainedConfig from transformers top-level (v5 compat, Phase 2)

### DIFF
--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -35,7 +35,8 @@ except ImportError:
 
 from safetensors import safe_open
 from tqdm import tqdm
-from transformers.modeling_utils import PretrainedConfig, PreTrainedModel
+from transformers import PretrainedConfig
+from transformers.modeling_utils import PreTrainedModel
 
 import moe_infinity
 from moe_infinity.common import parse_expert_type


### PR DESCRIPTION
## Summary
transformers v5 stopped re-exporting `PretrainedConfig` from `transformers.modeling_utils`. This one-line import move reads it from the `transformers` top-level (verified importable on both 4.57.6 and 5.3.0); `PreTrainedModel` stays in `modeling_utils` (still present on v5).

Part of the transformers v5 migration (plan: `.sisyphus/plans/transformers-v5-migration.md`). Backward-compatible, no version bump.

## Verification
- Import smoke: `import moe_infinity.runtime.model_offload` OK on 4.57.6.
- Reconnaissance confirmed `transformers.PretrainedConfig` and `transformers.configuration_utils.PretrainedConfig` both exist on 5.3.0.
- Full CPU suite: 489 passed, 2 skipped (no regressions).
- pre-commit: pass.

## Remaining v5 work (not in this PR)
The only other 5.x import break is the Mixtral expert-class restructure (`MixtralBlockSparseTop2MLP` removed → batched `MixtralExperts`), which needs a real adapter change + GPU e2e validation. Under investigation.