### PR TITLE
feat(mixtral): support transformers v5 batched expert checkpoints (Phase 2/3)

### DIFF
--- a/moe_infinity/models/mixtral.py
+++ b/moe_infinity/models/mixtral.py
@@ -8,11 +8,31 @@ from typing import Dict
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers.models.mixtral.modeling_mixtral import (
-    MixtralBlockSparseTop2MLP,
-)
+from transformers.activations import ACT2FN
 
 from moe_infinity.utils import ArcherConfig
+
+
+class MixtralExpertMLP(nn.Module):
+    # Self-contained replica of transformers v4 MixtralBlockSparseTop2MLP, which
+    # was removed in transformers v5 (experts were batched into MixtralExperts).
+    # Keeps the v4 w1/w2/w3 layout so per-expert offload keys stay unchanged.
+    def __init__(self, config):
+        super().__init__()
+        self.ffn_dim = config.intermediate_size
+        self.hidden_dim = config.hidden_size
+
+        self.w1 = nn.Linear(self.hidden_dim, self.ffn_dim, bias=False)
+        self.w2 = nn.Linear(self.ffn_dim, self.hidden_dim, bias=False)
+        self.w3 = nn.Linear(self.hidden_dim, self.ffn_dim, bias=False)
+
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        current_hidden_states = self.act_fn(self.w1(hidden_states)) * self.w3(
+            hidden_states
+        )
+        return self.w2(current_hidden_states)
 
 
 class SyncMixtralSparseMoeBlock(nn.Module):
@@ -30,7 +50,7 @@ class SyncMixtralSparseMoeBlock(nn.Module):
         self.gate = nn.Linear(self.hidden_dim, self.num_experts, bias=False)
 
         self.experts = nn.ModuleList(
-            [MixtralBlockSparseTop2MLP(config) for _ in range(self.num_experts)]
+            [MixtralExpertMLP(config) for _ in range(self.num_experts)]
         )
 
         self.expert_executor = None

--- a/moe_infinity/runtime/compile.py
+++ b/moe_infinity/runtime/compile.py
@@ -3,15 +3,14 @@ import os
 import torch
 from transformers.models.deepseek_v2.modeling_deepseek_v2 import DeepseekV2MLP
 from transformers.models.deepseek_v3.modeling_deepseek_v3 import DeepseekV3MLP
-from transformers.models.mixtral.modeling_mixtral import (
-    MixtralBlockSparseTop2MLP,
-)
 from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeMLP
+
+from moe_infinity.models.mixtral import MixtralExpertMLP
 
 EXPERT_CLS = {
     "deepseek_v2": DeepseekV2MLP,
     "deepseek_v3": DeepseekV3MLP,
-    "mixtral": MixtralBlockSparseTop2MLP,
+    "mixtral": MixtralExpertMLP,
     # "nllb_moe": NllbMoeDenseActDense,
     "qwen3_moe": Qwen3MoeMLP,
 }

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -88,6 +88,39 @@ prefetch_op = None
 logger = logging.getLogger(__name__)
 
 
+def _remap_mixtral_v5_experts(state_dict: Dict[str, torch.Tensor]) -> None:
+    # transformers v5 stores Mixtral experts as batched 3D tensors
+    # (experts.gate_up_proj [E, 2I, H], experts.down_proj [E, H, I]) instead of
+    # v4 per-expert w1/w2/w3. Expand them back to per-expert keys so the
+    # per-expert offload scheme and parse_expert_id keep working unchanged.
+    # gate_up_proj[e] splits on dim 0 into w1 (gate) and w3 (up); down_proj[e]
+    # is w2. Verified numerically equivalent to the v5 forward.
+    gate_up_suffix = ".gate_up_proj"
+    batched_keys = [
+        k
+        for k in list(state_dict.keys())
+        if k.endswith("experts" + gate_up_suffix)
+    ]
+    for gate_up_key in batched_keys:
+        prefix = gate_up_key[: -len(gate_up_suffix)]
+        down_key = prefix + ".down_proj"
+        if down_key not in state_dict:
+            continue
+        gate_up = state_dict[gate_up_key]
+        down = state_dict[down_key]
+        if gate_up.dim() != 3 or down.dim() != 3:
+            continue
+        num_experts = gate_up.shape[0]
+        for expert_idx in range(num_experts):
+            gate_w, up_w = gate_up[expert_idx].chunk(2, dim=0)
+            base = f"{prefix}.{expert_idx}"
+            state_dict[f"{base}.w1.weight"] = gate_w.contiguous()
+            state_dict[f"{base}.w3.weight"] = up_w.contiguous()
+            state_dict[f"{base}.w2.weight"] = down[expert_idx].contiguous()
+        del state_dict[gate_up_key]
+        del state_dict[down_key]
+
+
 def _compute_config_fingerprint(config: object) -> str:
     fields = [
         "model_type",
@@ -552,6 +585,8 @@ class OffloadEngine(object):
                                     state_dict[k] = f.get_tensor(k)
                         else:
                             state_dict = torch.load(ckpt)
+
+                        _remap_mixtral_v5_experts(state_dict)
 
                         is_gptq_ckpt = is_gptq_quantized(self.config)
                         self._cast_state_dict_tensors(

--- a/tests/python/unit/test_mixtral_v5_remap.py
+++ b/tests/python/unit/test_mixtral_v5_remap.py
@@ -1,0 +1,75 @@
+import torch
+import torch.nn.functional as F
+
+from moe_infinity.runtime.model_offload import _remap_mixtral_v5_experts
+
+
+def _v5_expert_forward(gate_up_e, down_e, x):
+    gate, up = F.linear(x, gate_up_e).chunk(2, dim=-1)
+    return F.linear(F.silu(gate) * up, down_e)
+
+
+def _v4_expert_forward(w1, w2, w3, x):
+    return F.linear(F.silu(F.linear(x, w1)) * F.linear(x, w3), w2)
+
+
+def test_remap_expands_batched_keys_to_per_expert():
+    num_experts, hidden, inter = 4, 8, 16
+    prefix = "model.layers.0.block_sparse_moe.experts"
+    state_dict = {
+        f"{prefix}.gate_up_proj": torch.randn(num_experts, 2 * inter, hidden),
+        f"{prefix}.down_proj": torch.randn(num_experts, hidden, inter),
+        "model.layers.0.block_sparse_moe.gate.weight": torch.randn(
+            num_experts, hidden
+        ),
+    }
+
+    _remap_mixtral_v5_experts(state_dict)
+
+    assert f"{prefix}.gate_up_proj" not in state_dict
+    assert f"{prefix}.down_proj" not in state_dict
+    for e in range(num_experts):
+        assert state_dict[f"{prefix}.{e}.w1.weight"].shape == (inter, hidden)
+        assert state_dict[f"{prefix}.{e}.w3.weight"].shape == (inter, hidden)
+        assert state_dict[f"{prefix}.{e}.w2.weight"].shape == (hidden, inter)
+    assert "model.layers.0.block_sparse_moe.gate.weight" in state_dict
+
+
+def test_remap_is_numerically_equivalent_to_v5_forward():
+    num_experts, hidden, inter = 3, 8, 16
+    prefix = "model.layers.0.block_sparse_moe.experts"
+    gate_up = torch.randn(num_experts, 2 * inter, hidden)
+    down = torch.randn(num_experts, hidden, inter)
+    x = torch.randn(5, hidden)
+
+    state_dict = {
+        f"{prefix}.gate_up_proj": gate_up.clone(),
+        f"{prefix}.down_proj": down.clone(),
+    }
+    _remap_mixtral_v5_experts(state_dict)
+
+    for e in range(num_experts):
+        ref = _v5_expert_forward(gate_up[e], down[e], x)
+        out = _v4_expert_forward(
+            state_dict[f"{prefix}.{e}.w1.weight"],
+            state_dict[f"{prefix}.{e}.w2.weight"],
+            state_dict[f"{prefix}.{e}.w3.weight"],
+            x,
+        )
+        assert torch.allclose(ref, out, atol=1e-6)
+
+
+def test_remap_noop_on_v4_per_expert_keys():
+    prefix = "model.layers.0.block_sparse_moe.experts"
+    state_dict = {
+        f"{prefix}.0.w1.weight": torch.randn(16, 8),
+        f"{prefix}.0.w2.weight": torch.randn(8, 16),
+        f"{prefix}.0.w3.weight": torch.randn(16, 8),
+    }
+    before = {k: v.clone() for k, v in state_dict.items()}
+
+    _remap_mixtral_v5_experts(state_dict)
+
+    assert set(state_dict.keys()) == set(before.keys())
+    for k in before:
+        assert torch.equal(state_dict[k], before[k])


### PR DESCRIPTION
## Summary
transformers v5 removed `MixtralBlockSparseTop2MLP` and changed the Mixtral checkpoint layout from **per-expert** keys (`experts.{E}.w1/w2/w3`) to **batched 3D tensors** (`experts.gate_up_proj [E, 2I, H]`, `experts.down_proj [E, H, I]`). This would break MoE-Infinity's per-expert offloading (the `parse_expert_id` regex would never match v5 keys).

This PR preserves per-expert offloading on both transformers 4.x and 5.x:

- **`MixtralExpertMLP`** (`models/mixtral.py`): a self-contained replica of the removed upstream class, keeping the v4 `w1/w2/w3` layout. Used in `SyncMixtralSparseMoeBlock` and `runtime/compile.py`'s `EXPERT_CLS`.
- **`_remap_mixtral_v5_experts()`** (`runtime/model_offload.py`): runs at the state_dict loader hook, expanding v5 batched expert tensors into per-expert `w1/w2/w3` keys. `gate_up_proj[e].chunk(2, dim=0)` → `w1` (gate) / `w3` (up); `down_proj[e]` → `w2`. **No-op on v4 checkpoints.**

## Correctness
The split orientation (`chunk(2, dim=0)` on the weight) is the subtle point — it's mathematically identical to the v5 forward, which chunks the linear *output* on `dim=-1`. **Numerically verified** against the real transformers 5.12.1 `MixtralExperts.forward`:
- Remap → per-expert SwiGLU forward matches v5 expert forward to `atol=1e-6`.

## Tests (`tests/python/unit/test_mixtral_v5_remap.py`)
- `test_remap_expands_batched_keys_to_per_expert` — shapes + key expansion.
- `test_remap_is_numerically_equivalent_to_v5_forward` — golden equivalence to v5 math.
- `test_remap_noop_on_v4_per_expert_keys` — v4 checkpoints untouched.

## Verification
- New tests: 3 passed (directory collection, CI parity).
- Full CPU suite: **492 passed, 2 skipped** (was 489; +3), no regressions.
- pre-commit (ruff, codespell): pass.

## Scope / remaining
No `transformers` version bump in this PR — the code is forward-compatible. The only remaining step for full v5 adoption is the **Mixtral GPU golden-decode validation** against the real `mistralai/Mixtral-8x7B` checkpoint (~90 GB, not cached here) + the pin bump, which should run in a checkpoint-equipped session. See `.sisyphus/plans/transformers-v5-migration.md`.