### PR TITLE
fix(mixtral): normalize v5 .mlp MoE block to .block_sparse_moe in remap

### DIFF
--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -89,12 +89,15 @@ logger = logging.getLogger(__name__)
 
 
 def _remap_mixtral_v5_experts(state_dict: Dict[str, torch.Tensor]) -> None:
-    # transformers v5 stores Mixtral experts as batched 3D tensors
-    # (experts.gate_up_proj [E, 2I, H], experts.down_proj [E, H, I]) instead of
-    # v4 per-expert w1/w2/w3. Expand them back to per-expert keys so the
-    # per-expert offload scheme and parse_expert_id keep working unchanged.
-    # gate_up_proj[e] splits on dim 0 into w1 (gate) and w3 (up); down_proj[e]
-    # is w2. Verified numerically equivalent to the v5 forward.
+    # Canonicalizes transformers v5 Mixtral checkpoints to the v4 offload layout.
+    # v5: batched ".mlp" submodule -> mlp.experts.gate_up_proj [E, 2I, H],
+    #     mlp.experts.down_proj [E, H, I], mlp.gate.weight.
+    # v4 (target): per-expert ".block_sparse_moe" -> experts.{E}.w1/w2/w3.weight,
+    #     block_sparse_moe.gate.weight. parse_expert_id keys off
+    #     "block_sparse_moe.experts.{E}", so both the per-expert split and the
+    #     ".mlp" -> ".block_sparse_moe" block path are required.
+    # gate_up_proj[e] splits on dim 0 into w1 (gate) and w3 (up); down_proj[e] is
+    # w2. Numerically equivalent to the v5 expert forward.
     gate_up_suffix = ".gate_up_proj"
     batched_keys = [
         k
@@ -102,18 +105,31 @@ def _remap_mixtral_v5_experts(state_dict: Dict[str, torch.Tensor]) -> None:
         if k.endswith("experts" + gate_up_suffix)
     ]
     for gate_up_key in batched_keys:
-        prefix = gate_up_key[: -len(gate_up_suffix)]
-        down_key = prefix + ".down_proj"
+        experts_prefix = gate_up_key[: -len(gate_up_suffix)]
+        down_key = experts_prefix + ".down_proj"
         if down_key not in state_dict:
             continue
         gate_up = state_dict[gate_up_key]
         down = state_dict[down_key]
         if gate_up.dim() != 3 or down.dim() != 3:
             continue
+
+        # experts_prefix is e.g. "model.layers.0.mlp.experts"; block_prefix is
+        # the MoE block path. Normalize a v5 ".mlp" block to ".block_sparse_moe".
+        block_prefix = experts_prefix[: -len(".experts")]
+        if block_prefix.endswith(".mlp"):
+            out_block = block_prefix[: -len(".mlp")] + ".block_sparse_moe"
+            gate_key = block_prefix + ".gate.weight"
+            out_gate_key = out_block + ".gate.weight"
+            if gate_key in state_dict and out_gate_key not in state_dict:
+                state_dict[out_gate_key] = state_dict.pop(gate_key)
+        else:
+            out_block = block_prefix
+
         num_experts = gate_up.shape[0]
         for expert_idx in range(num_experts):
             gate_w, up_w = gate_up[expert_idx].chunk(2, dim=0)
-            base = f"{prefix}.{expert_idx}"
+            base = f"{out_block}.experts.{expert_idx}"
             state_dict[f"{base}.w1.weight"] = gate_w.contiguous()
             state_dict[f"{base}.w3.weight"] = up_w.contiguous()
             state_dict[f"{base}.w2.weight"] = down[expert_idx].contiguous()

--- a/tests/python/unit/test_mixtral_v5_remap.py
+++ b/tests/python/unit/test_mixtral_v5_remap.py
@@ -13,50 +13,96 @@ def _v4_expert_forward(w1, w2, w3, x):
     return F.linear(F.silu(F.linear(x, w1)) * F.linear(x, w3), w2)
 
 
-def test_remap_expands_batched_keys_to_per_expert():
+def test_remap_expands_and_normalizes_v5_mlp_prefix():
     num_experts, hidden, inter = 4, 8, 16
-    prefix = "model.layers.0.block_sparse_moe.experts"
+    v5_experts = "model.layers.0.mlp.experts"
+    out = "model.layers.0.block_sparse_moe"
     state_dict = {
-        f"{prefix}.gate_up_proj": torch.randn(num_experts, 2 * inter, hidden),
-        f"{prefix}.down_proj": torch.randn(num_experts, hidden, inter),
-        "model.layers.0.block_sparse_moe.gate.weight": torch.randn(
-            num_experts, hidden
+        f"{v5_experts}.gate_up_proj": torch.randn(
+            num_experts, 2 * inter, hidden
         ),
+        f"{v5_experts}.down_proj": torch.randn(num_experts, hidden, inter),
+        "model.layers.0.mlp.gate.weight": torch.randn(num_experts, hidden),
     }
 
     _remap_mixtral_v5_experts(state_dict)
 
-    assert f"{prefix}.gate_up_proj" not in state_dict
-    assert f"{prefix}.down_proj" not in state_dict
+    assert f"{v5_experts}.gate_up_proj" not in state_dict
+    assert f"{v5_experts}.down_proj" not in state_dict
+    assert "model.layers.0.mlp.gate.weight" not in state_dict
+    assert f"{out}.gate.weight" in state_dict
     for e in range(num_experts):
-        assert state_dict[f"{prefix}.{e}.w1.weight"].shape == (inter, hidden)
-        assert state_dict[f"{prefix}.{e}.w3.weight"].shape == (inter, hidden)
-        assert state_dict[f"{prefix}.{e}.w2.weight"].shape == (hidden, inter)
-    assert "model.layers.0.block_sparse_moe.gate.weight" in state_dict
+        assert state_dict[f"{out}.experts.{e}.w1.weight"].shape == (
+            inter,
+            hidden,
+        )
+        assert state_dict[f"{out}.experts.{e}.w3.weight"].shape == (
+            inter,
+            hidden,
+        )
+        assert state_dict[f"{out}.experts.{e}.w2.weight"].shape == (
+            hidden,
+            inter,
+        )
 
 
 def test_remap_is_numerically_equivalent_to_v5_forward():
     num_experts, hidden, inter = 3, 8, 16
-    prefix = "model.layers.0.block_sparse_moe.experts"
+    v5_experts = "model.layers.0.mlp.experts"
+    out_experts = "model.layers.0.block_sparse_moe.experts"
     gate_up = torch.randn(num_experts, 2 * inter, hidden)
     down = torch.randn(num_experts, hidden, inter)
     x = torch.randn(5, hidden)
 
     state_dict = {
-        f"{prefix}.gate_up_proj": gate_up.clone(),
-        f"{prefix}.down_proj": down.clone(),
+        f"{v5_experts}.gate_up_proj": gate_up.clone(),
+        f"{v5_experts}.down_proj": down.clone(),
     }
     _remap_mixtral_v5_experts(state_dict)
 
     for e in range(num_experts):
         ref = _v5_expert_forward(gate_up[e], down[e], x)
         out = _v4_expert_forward(
-            state_dict[f"{prefix}.{e}.w1.weight"],
-            state_dict[f"{prefix}.{e}.w2.weight"],
-            state_dict[f"{prefix}.{e}.w3.weight"],
+            state_dict[f"{out_experts}.{e}.w1.weight"],
+            state_dict[f"{out_experts}.{e}.w2.weight"],
+            state_dict[f"{out_experts}.{e}.w3.weight"],
             x,
         )
         assert torch.allclose(ref, out, atol=1e-6)
+
+
+def test_remapped_keys_match_parse_expert_id():
+    from types import SimpleNamespace
+    from typing import cast
+
+    from transformers import PretrainedConfig
+
+    from moe_infinity.utils.hf_config import parse_expert_id
+
+    num_experts, hidden, inter = 4, 8, 16
+    v5_experts = "model.layers.1.mlp.experts"
+    state_dict = {
+        f"{v5_experts}.gate_up_proj": torch.randn(
+            num_experts, 2 * inter, hidden
+        ),
+        f"{v5_experts}.down_proj": torch.randn(num_experts, hidden, inter),
+    }
+    _remap_mixtral_v5_experts(state_dict)
+
+    cfg = cast(
+        PretrainedConfig,
+        cast(
+            object,
+            SimpleNamespace(
+                architectures=["MixtralForCausalLM"],
+                num_hidden_layers=2,
+                num_local_experts=num_experts,
+            ),
+        ),
+    )
+    for e in range(num_experts):
+        key = f"model.layers.1.block_sparse_moe.experts.{e}.w1.weight"
+        assert parse_expert_id(key, cfg) == (1, e)
 
 
 def test_remap_noop_on_v4_per_expert_keys():


### PR DESCRIPTION
## Summary
Found by **actually running the migration under transformers 5.3.0** (not just import-probing). v5 renamed Mixtral's MoE submodule from `block_sparse_moe` (v4) to `mlp`. The #108 remap correctly expanded the batched expert tensors but kept the `mlp` prefix, producing keys like `model.layers.N.mlp.experts.E.w1.weight`. MoE-Infinity's `parse_expert_id` keys off `block_sparse_moe.experts.{E}`, so it returned `(None, None)` for every v5 Mixtral expert weight → **expert routing silently broken**.

## Fix
During remap, normalize the MoE block path `…​.mlp` → `…​.block_sparse_moe` (both the per-expert weights and the sibling `gate.weight`), so all downstream offload logic (`parse_expert_id`, `name_id_map`, the `SyncMixtralSparseMoeBlock` structure) works unchanged. No-op on v4 checkpoints (which already use `block_sparse_moe`).

## Validation (under real transformers 5.3.0)
- Built a tiny synthetic v5 Mixtral; confirmed v5 keys are `model.layers.N.mlp.experts.gate_up_proj`.
- After remap: **0 leftover `.mlp` expert/gate keys**, **0 `parse_expert_id` failures**, **0.0 numeric diff** vs the v5 expert forward.
- Full CPU suite under transformers 5.3.0: **493 passed, 2 skipped**.
- New test `test_remapped_keys_match_parse_expert_id` asserts the integration; existing tests updated to use the v5 `.mlp` prefix.

## Why this wasn't caught in #108
#108's tests used `block_sparse_moe`-prefixed inputs (the v4 name), so they exercised the tensor math but not the v5 module rename. This PR's tests now use the actual v5 `.mlp` keys.