### PR TITLE
build(deps): bump transformers to >=5.3.0,<6 (closes CVE-2026-1839)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ scipy
 sentencepiece
 sglang-kernel>=0.4.0
 sphinx
-transformers==4.57.6
+transformers>=5.3.0,<6
 uvicorn


### PR DESCRIPTION
## Summary
Final step of the transformers v5 migration: bump the pin `transformers==4.57.6` → `transformers>=5.3.0,<6`. This **resolves the dependabot alert CVE-2026-1839** (Trainer RCE, patched only in 5.0.0rc3+; not exploitable here since MoE-Infinity is inference-only and never uses `Trainer`, but this moves us onto a supported, security-patched line).

## Prerequisite work (all merged to dev)
All v5 breakages were fixed in backward-compatible PRs before this bump:
- **#106** — `resolve_config_dtype` shim (`config.torch_dtype` → `config.dtype`).
- **#107** — `PretrainedConfig` import moved to `transformers` top-level.
- **#108/#109** — Mixtral batched-expert support + `.mlp`→`.block_sparse_moe` normalization.
- **#110** — generalized batched-expert remap (Qwen3/DeepSeek; GPT-OSS excluded).

## Validation
Installed the new pin (resolves to **transformers 5.12.1**) and also tested 5.3.0:
- Full CPU suite: **497 passed, 2 skipped** (identical to 4.57.6 baseline).
- All model adapters import cleanly.
- Batched-expert remap tests: 8 passed.
- Verified synthetic e2e on Mixtral / Qwen3-MoE / DeepSeek-V3: exact weight remap (0.0 numeric diff), `parse_expert_id` matches, shared_experts preserved.

## Remaining (post-merge, optional)
A real-checkpoint GPU golden-decode (Mixtral-8x7B etc., ~90 GB) is the belt-and-suspenders final check. The synthetic tests prove the remap is mathematically exact, so this is verification-of-verification rather than a blocker.