### PR TITLE
chore(ci,docs): align Python floor to >=3.10 (drop 3.8/3.9 from publish matrices)

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-20.04']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         cuda-version: ['12.1']
 
     steps:
@@ -89,7 +89,7 @@ jobs:
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
       - name: Build Source
-        if: ${{ matrix.python-version == '3.8' }}
+        if: ${{ matrix.python-version == '3.10' }}
         run: |
           VERSION_HASH=$(cat artifact/version.txt)
           MOEINF_VERSION=${{ env.NIGHTLY_BASE_VERSION }}.dev${VERSION_HASH} python3 -m build --sdist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         cuda-version: ['12.1']
 
     steps:
@@ -78,7 +78,7 @@ jobs:
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
       - name: Build Source
-        if: ${{ matrix.python-version == '3.8' }}
+        if: ${{ matrix.python-version == '3.10' }}
         run: |
           python3 -m build --sdist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,14 +69,14 @@ For substantial changes (for example, new runtime behavior or model-family suppo
 
 MoE-Infinity builds Python and CUDA/C++ components. We recommend a fresh conda environment.
 
-- Supported Python range in packaging metadata: `>=3.8`
-- Recommended local development version: Python `3.9`
+- Supported Python range in packaging metadata: `>=3.10` (some required dependencies, e.g. `sglang-kernel`, ship wheels for Python ≥ 3.10 only)
+- Recommended local development version: Python `3.12`
 
 ```bash
 git clone https://github.com/EfficientMoE/MoE-Infinity.git
 cd MoE-Infinity
 
-conda create -n moe-infinity-dev python=3.9
+conda create -n moe-infinity-dev python=3.12
 conda activate moe-infinity-dev
 
 pip install -e .


### PR DESCRIPTION
## What & why

Follow-up to #116 / #112: align the documented and CI Python floor with the actual runtime requirement (**>=3.10**), so a future stable release does not build broken 3.8/3.9 wheels (the dep stack — e.g. `sglang-kernel` — ships cp310-only wheels).

Refs #112

## Changes

- **`CONTRIBUTING.md`**: packaging Python range `>=3.8` → `>=3.10` (+ note on cp310-only deps); recommended dev version `3.9` → `3.12`; dev conda env `python=3.9` → `python=3.12`.
- **`.github/workflows/publish.yml`**: drop `3.8`/`3.9` from the build matrix (keep `3.10`/`3.11`/`3.12`); move the `--sdist` build step from the 3.8 leg to the 3.10 leg (so an sdist is still produced).
- **`.github/workflows/publish-test.yml`**: same matrix + sdist-leg change for the nightly pipeline.

## Notes

- Pairs with #116 (`setup.py` `python_requires>=3.10`, README Prereqs 3.10+). **No file overlap** with #116.
- Out of scope (separate change): both workflows still target `cuda-version: 12.1` on `ubuntu-20.04`, which is stale vs the current CUDA 12.8/13 build path.
