### PR TITLE
ci: relax exact setuptools pin in build-system requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=75.3.2,<76", "wheel", "torch"]
+requires = ["setuptools>=75.3.2", "wheel", "torch"]
 build-backend = "setuptools.build_meta"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==75.3.2", "wheel", "torch"]
+requires = ["setuptools>=75.3.2,<76", "wheel", "torch"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
python -m build --no-isolation fails its build-dependency check ("Missing dependencies: setuptools==75.3.2") on current GitHub-hosted runners even when that exact version is installed, because the equality check is brittle against duplicate/shadowed setuptools installs on the runner image. Loosening the pin to a range avoids the exact-match check while keeping the same tested version.

## Description
Briefly describe your changes.

## Motivation
Explain why this change is needed and what problem it solves.
If it fixes an issue, link it https://github.com/EfficientMoE/MoE-Infinity/issues/120

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
- [ ] I have updated the tests (if applicable).
- [ ] I have updated the documentation (if applicable).
