### PR TITLE
feat(qwen3.5): Qwen3.5-35B-A3B MoE support (text-only, expert offload)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/c
 | DeepSeek-V4-Flash (FP4 expert offloading) | requires a `transformers` build shipping `DeepseekV4ForCausalLM` |
 | [Mixtral](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1) | `mistralai/Mixtral-8x7B-Instruct-v0.1`, `Mixtral-8x22B` |
 | [Qwen3-MoE](https://huggingface.co/Qwen/Qwen3-30B-A3B) | `Qwen/Qwen3-30B-A3B` |
+| [Qwen3.5-MoE](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) | `Qwen/Qwen3.5-35B-A3B` (text-only; see note) |
 | [GPT-OSS](https://huggingface.co/models?search=gpt-oss) | `openai/gpt-oss-*` |
 | [DBRX](https://huggingface.co/models?search=dbrx) | `databricks/dbrx-instruct` |
 | [Jamba](https://huggingface.co/models?search=jamba) | `ai21labs/Jamba-*` |
@@ -69,6 +70,8 @@ MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/c
 | [Meta NLLB-MoE](https://huggingface.co/facebook/nllb-moe-54b) | `facebook/nllb-moe-54b` |
 
 > DeepSeek-V4-Flash is only registered when your installed `transformers` provides `DeepseekV4ForCausalLM`; otherwise it is skipped automatically.
+
+> Qwen3.5-MoE (`Qwen3_5MoeForConditionalGeneration`, requires `transformers` >= 5.12) is a vision-language checkpoint served **text-only**: its 256 routed experts are offloaded while the small text backbone — token embeddings, the hybrid linear (GatedDeltaNet) / full attention layers, shared expert, and `lm_head` — stays resident on GPU. The v5 packed expert tensors are expanded to per-expert on load. Vision and MTP weights are present but unused for text generation.
 
 ## Installation
 

--- a/moe_infinity/common/constants.py
+++ b/moe_infinity/common/constants.py
@@ -17,6 +17,11 @@ try:
 except ImportError:
     DeepseekV4ForCausalLM = None
 
+try:
+    from transformers import Qwen3_5MoeForConditionalGeneration
+except ImportError:
+    Qwen3_5MoeForConditionalGeneration = None
+
 MODEL_MAPPING_NAMES = {
     "nllb": NllbMoeForConditionalGeneration,
     "mixtral": MixtralForCausalLM,
@@ -50,13 +55,24 @@ if DeepseekV4ForCausalLM is not None:
     MODEL_MAPPING_NAMES["deepseekv4"] = DeepseekV4ForCausalLM
     MODEL_MAPPING_TYPES["deepseekv4"] = 5
 
+# Qwen3.5-MoE (arch "Qwen3_5MoeForConditionalGeneration") uses per-expert
+# gate_proj/up_proj/down_proj weights (expert-type 5, like Qwen3/DeepSeek); the
+# v5 packed checkpoint tensors are expanded to per-expert on load. Registered
+# only when the HF class is importable (mirrors the V4 guard above).
+if Qwen3_5MoeForConditionalGeneration is not None:
+    MODEL_MAPPING_NAMES["qwen3_5"] = Qwen3_5MoeForConditionalGeneration
+    MODEL_MAPPING_TYPES["qwen3_5"] = 5
+
 
 def parse_expert_type(config: PretrainedConfig) -> int:
     architecture = (
         config.architectures[0].lower() if config.architectures else ""
     )
     arch = None
-    for supp_arch in MODEL_MAPPING_NAMES:
+    # Match the most specific key first: "qwen3_5" and "deepseek_v3" both
+    # contain shorter keys ("qwen3", "deepseek") as substrings, so longest-key
+    # order prevents a shorter key from shadowing a more specific architecture.
+    for supp_arch in sorted(MODEL_MAPPING_NAMES, key=len, reverse=True):
         if supp_arch in architecture:
             arch = supp_arch
             break

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -101,7 +101,9 @@ class MoE:
         architecture = str(architectures[0]).lower()
 
         arch = None
-        for supp_arch in MODEL_MAPPING_NAMES:
+        # Longest key first so specific arches ("qwen3_5", "deepseek_v3") win
+        # over the shorter keys they contain ("qwen3", "deepseek").
+        for supp_arch in sorted(MODEL_MAPPING_NAMES, key=len, reverse=True):
             if supp_arch in architecture:
                 arch = supp_arch
                 break
@@ -149,6 +151,11 @@ class MoE:
         self.use_native_engine = bool(
             getattr(engine_config, "use_native_engine", True)
         )
+        # Qwen3.5-MoE interleaves linear (GatedDeltaNet) and full attention; the
+        # native paged-KV engine assumes uniform full attention across layers, so
+        # Phase 1 drives generation through HF's own forward instead.
+        if getattr(model_config, "model_type", "") == "qwen3_5_moe":
+            self.use_native_engine = False
         default_max_seq_length = getattr(
             model_config, "max_position_embeddings", None
         )
@@ -195,6 +202,7 @@ class MoE:
                 or arch == "deepseek_v3"
                 or arch == "nllb"
                 or arch == "gptoss"
+                or arch == "qwen3_5"
             ):
                 is_flash_attn_available = False
         except ImportError:
@@ -235,10 +243,19 @@ class MoE:
     def _resolve_model_int_attr(
         model_config: object, *names: str
     ) -> Optional[int]:
-        for name in names:
-            value = getattr(model_config, name, None)
-            if isinstance(value, int):
-                return value
+        get_text = getattr(model_config, "get_text_config", None)
+        text_config = (
+            get_text()
+            if callable(get_text)
+            else getattr(model_config, "text_config", None)
+        )
+        for cfg in (model_config, text_config):
+            if cfg is None:
+                continue
+            for name in names:
+                value = getattr(cfg, name, None)
+                if isinstance(value, int):
+                    return value
         return None
 
     @staticmethod

--- a/moe_infinity/models/__init__.py
+++ b/moe_infinity/models/__init__.py
@@ -18,6 +18,7 @@ from .model_utils import (
 from .nllb_moe import SyncNllbMoeSparseMLP
 from .olmoe import SyncOlmoeMoEBlock
 from .qwen import Qwen3MoEBlock
+from .qwen3_5_moe import SyncQwen3_5MoeSparseMoeBlock
 
 # Qwen3PagedAttention is lazily imported to avoid a circular dependency:
 # model_offload -> moe_infinity.models -> qwen3_paged_attention
@@ -35,6 +36,7 @@ __all__ = [
     "SyncMixtralSparseMoeBlock",
     "SyncNllbMoeSparseMLP",
     "SyncOlmoeMoEBlock",
+    "SyncQwen3_5MoeSparseMoeBlock",
     "apply_rotary_pos_emb",
     "apply_rotary_pos_emb_deepseek",
     "rotate_half",

--- a/moe_infinity/models/qwen3_5_moe.py
+++ b/moe_infinity/models/qwen3_5_moe.py
@@ -1,0 +1,104 @@
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+    Qwen3_5MoeMLP,
+    Qwen3_5MoeTopKRouter,
+)
+
+
+class SyncQwen3_5MoeSparseMoeBlock(nn.Module):
+    archer_config = None
+    layer_id: Optional[int] = None
+
+    def __init__(self, config):
+        super().__init__()
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+
+        self.gate = Qwen3_5MoeTopKRouter(config)
+        self.experts = nn.ModuleList(
+            [
+                Qwen3_5MoeMLP(
+                    config, intermediate_size=config.moe_intermediate_size
+                )
+                for _ in range(self.num_experts)
+            ]
+        )
+        self.shared_expert = Qwen3_5MoeMLP(
+            config, intermediate_size=config.shared_expert_intermediate_size
+        )
+        self.shared_expert_gate = nn.Linear(config.hidden_size, 1, bias=False)
+
+        self.expert_executor = None
+        self.expert_prefetcher = None
+        self.expert_tracer = None
+        self.expert_predictor = None
+        self.archer_engine = None
+        self.lib = None
+
+    def _route(self, hidden_flat):
+        router_logits, routing_weights, selected_experts = self.gate(hidden_flat)
+        num_tokens = hidden_flat.shape[0]
+        router_mask = torch.zeros(
+            num_tokens,
+            self.num_experts,
+            dtype=torch.bool,
+            device=hidden_flat.device,
+        )
+        router_mask.scatter_(1, selected_experts, True)
+        routing_weights_mask = torch.zeros(
+            num_tokens,
+            self.num_experts,
+            dtype=routing_weights.dtype,
+            device=hidden_flat.device,
+        )
+        routing_weights_mask.scatter_(1, selected_experts, routing_weights)
+        return router_mask, routing_weights_mask, router_logits
+
+    def _local_experts(self, hidden_flat, router_mask, routing_weights_mask):
+        final_hidden = torch.zeros_like(hidden_flat)
+        for expert_idx in range(self.num_experts):
+            token_mask = router_mask[:, expert_idx]
+            if not token_mask.any():
+                continue
+            expert_out = self.experts[expert_idx](hidden_flat[token_mask])
+            weight = routing_weights_mask[token_mask, expert_idx].unsqueeze(-1)
+            final_hidden[token_mask] += (weight * expert_out).to(
+                final_hidden.dtype
+            )
+        return final_hidden
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_flat = hidden_states.view(-1, hidden_dim)
+
+        router_mask, routing_weights_mask, router_logits = self._route(
+            hidden_flat
+        )
+
+        if self.expert_executor is not None:
+            self.expert_executor.dispatch_local(
+                self.layer_id,
+                hidden_flat,
+                router_mask,
+                routing_weights_mask,
+                router_logits=router_logits,
+            )
+            expert_output = self.expert_executor.wait_dispatch_local()
+        else:
+            expert_output = self._local_experts(
+                hidden_flat, router_mask, routing_weights_mask
+            )
+
+        shared_output = self.shared_expert(hidden_flat)
+        shared_output = (
+            F.sigmoid(self.shared_expert_gate(hidden_flat)) * shared_output
+        )
+
+        expert_output = expert_output.view(-1, hidden_dim) + shared_output
+        return expert_output.view(
+            batch_size, sequence_length, hidden_dim
+        ).to(hidden_states.dtype)

--- a/moe_infinity/models/qwen3_5_moe.py
+++ b/moe_infinity/models/qwen3_5_moe.py
@@ -40,7 +40,9 @@ class SyncQwen3_5MoeSparseMoeBlock(nn.Module):
         self.lib = None
 
     def _route(self, hidden_flat):
-        router_logits, routing_weights, selected_experts = self.gate(hidden_flat)
+        router_logits, routing_weights, selected_experts = self.gate(
+            hidden_flat
+        )
         num_tokens = hidden_flat.shape[0]
         router_mask = torch.zeros(
             num_tokens,
@@ -99,6 +101,6 @@ class SyncQwen3_5MoeSparseMoeBlock(nn.Module):
         )
 
         expert_output = expert_output.view(-1, hidden_dim) + shared_output
-        return expert_output.view(
-            batch_size, sequence_length, hidden_dim
-        ).to(hidden_states.dtype)
+        return expert_output.view(batch_size, sequence_length, hidden_dim).to(
+            hidden_states.dtype
+        )

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -53,6 +53,7 @@ from moe_infinity.models import (
     SyncMixtralSparseMoeBlock,
     SyncNllbMoeSparseMLP,
     SyncOlmoeMoEBlock,
+    SyncQwen3_5MoeSparseMoeBlock,
 )
 from moe_infinity.runtime.compile import script_expert
 from moe_infinity.runtime.hooks import *
@@ -115,22 +116,12 @@ def _remap_v5_batched_experts(
         return
 
     is_mixtral = "mixtral" in arch
-    gate_up_suffix = ".gate_up_proj"
-    batched_keys = [
-        k
-        for k in list(state_dict.keys())
-        if k.endswith("experts" + gate_up_suffix)
-    ]
-    for gate_up_key in batched_keys:
-        experts_prefix = gate_up_key[: -len(gate_up_suffix)]
-        down_key = experts_prefix + ".down_proj"
-        if down_key not in state_dict:
-            continue
-        gate_up = state_dict[gate_up_key]
-        down = state_dict[down_key]
-        if gate_up.dim() != 3 or down.dim() != 3:
-            continue
+    if is_mixtral:
+        gate_name, up_name, down_name = "w1", "w3", "w2"
+    else:
+        gate_name, up_name, down_name = "gate_proj", "up_proj", "down_proj"
 
+    def _out_block(experts_prefix: str) -> str:
         block_prefix = experts_prefix[: -len(".experts")]
         if is_mixtral and block_prefix.endswith(".mlp"):
             out_block = block_prefix[: -len(".mlp")] + ".block_sparse_moe"
@@ -138,28 +129,38 @@ def _remap_v5_batched_experts(
             out_gate_key = out_block + ".gate.weight"
             if gate_key in state_dict and out_gate_key not in state_dict:
                 state_dict[out_gate_key] = state_dict.pop(gate_key)
-        else:
-            out_block = block_prefix
+            return out_block
+        return block_prefix
 
-        if is_mixtral:
-            gate_name, up_name, down_name = "w1", "w3", "w2"
-        else:
-            gate_name, up_name, down_name = (
-                "gate_proj",
-                "up_proj",
-                "down_proj",
-            )
-
-        num_experts = gate_up.shape[0]
-        for expert_idx in range(num_experts):
+    # In sharded checkpoints, a layer's gate_up_proj and down_proj can live in
+    # different shards, so expand each independently instead of requiring both
+    # in the same per-shard state_dict slice.
+    for gate_up_key in [
+        k for k in list(state_dict) if k.endswith("experts.gate_up_proj")
+    ]:
+        gate_up = state_dict[gate_up_key]
+        if gate_up.dim() != 3:
+            continue
+        out_block = _out_block(gate_up_key[: -len(".gate_up_proj")])
+        for expert_idx in range(gate_up.shape[0]):
             gate_w, up_w = gate_up[expert_idx].chunk(2, dim=0)
             base = f"{out_block}.experts.{expert_idx}"
             state_dict[f"{base}.{gate_name}.weight"] = gate_w.contiguous()
             state_dict[f"{base}.{up_name}.weight"] = up_w.contiguous()
+        del state_dict[gate_up_key]
+
+    for down_key in [
+        k for k in list(state_dict) if k.endswith("experts.down_proj")
+    ]:
+        down = state_dict[down_key]
+        if down.dim() != 3:
+            continue
+        out_block = _out_block(down_key[: -len(".down_proj")])
+        for expert_idx in range(down.shape[0]):
+            base = f"{out_block}.experts.{expert_idx}"
             state_dict[f"{base}.{down_name}.weight"] = down[
                 expert_idx
             ].contiguous()
-        del state_dict[gate_up_key]
         del state_dict[down_key]
 
 
@@ -548,6 +549,10 @@ class OffloadEngine(object):
         )
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = SyncGptOssMLP
 
+        _q35_mod = transformers.models.qwen3_5_moe.modeling_qwen3_5_moe
+        _q35_mod._old_qwen3_5_sparse_moe = _q35_mod.Qwen3_5MoeSparseMoeBlock
+        _q35_mod.Qwen3_5MoeSparseMoeBlock = SyncQwen3_5MoeSparseMoeBlock
+
         def from_pretrained_decorator(
             orig_from_pretrained: Callable,
         ) -> Callable:
@@ -573,7 +578,10 @@ class OffloadEngine(object):
                     parse_moe_param(self.config)
                 )
 
-                if "qwen" in model_name.lower():
+                if (
+                    "qwen" in model_name.lower()
+                    and self.config.model_type != "qwen3_5_moe"
+                ):
                     self.prefetch_lib.init_moe_layer(
                         self.num_experts,
                         self.config.num_experts_per_tok,
@@ -818,6 +826,7 @@ class OffloadEngine(object):
                         or isinstance(module, Qwen3MoEBlock)
                         or isinstance(module, SyncDbrxFFNBlock)
                         or isinstance(module, SyncGptOssMLP)
+                        or isinstance(module, SyncQwen3_5MoeSparseMoeBlock)
                         or isinstance(module, SyncOlmoeMoEBlock)
                         or isinstance(module, SyncJambaMoEBlock)
                     ):
@@ -874,6 +883,83 @@ class OffloadEngine(object):
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = (
             transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp
         )
+        _q35_mod = transformers.models.qwen3_5_moe.modeling_qwen3_5_moe
+        if hasattr(_q35_mod, "_old_qwen3_5_sparse_moe"):
+            _q35_mod.Qwen3_5MoeSparseMoeBlock = _q35_mod._old_qwen3_5_sparse_moe
+
+    def _is_shared_expert_param(self, name: str) -> bool:
+        # DeepSeek names shared experts ".shared_experts." (plural); Qwen3.5-MoE
+        # uses singular ".shared_expert." plus ".shared_expert_gate.". The
+        # substring "shared_expert" matches all of them and no routed-expert key.
+        if "shared_expert" in name:
+            return True
+        # Qwen3.5-MoE: keep the small text backbone (embed, hybrid attention,
+        # norms, lm_head) resident and offload ONLY the routed experts. This
+        # avoids the per-module begin/end offload path for the VLM embedding and
+        # the GatedDeltaNet linear-attention layers, which are not compatible
+        # with the native offload engine's begin/end lifecycle.
+        if getattr(self.config, "model_type", "") == "qwen3_5_moe":
+            if "language_model." in name:
+                _, expert_id = parse_expert_id(name, self.config)
+                return expert_id is None
+            if name.endswith("lm_head.weight"):
+                return True
+        return False
+
+    @torch.no_grad()
+    def _load_resident_shared_experts(self, model):
+        # Shared experts run inside the Python MoE block (not the C++ expert
+        # executor) and are used on every MoE layer. The Archer offload path
+        # leaves their live param as a [1] placeholder that is never
+        # materialized before shared_experts(x) runs, so load their real
+        # weights once and keep them resident instead.
+        wanted = {
+            name: param
+            for name, param in model.named_parameters(recurse=True)
+            if self._is_shared_expert_param(name)
+        }
+        if not wanted:
+            return
+
+        remaining = set(wanted)
+        for ckpt in self.ckpt_files:
+            if not remaining:
+                break
+            if ckpt.endswith(".safetensors"):
+                with safe_open(ckpt, framework="pt", device="cpu") as f:
+                    keys = set(f.keys())
+                    for name in list(remaining):
+                        if name not in keys:
+                            continue
+                        param = wanted[name]
+                        param.data = (
+                            f.get_tensor(name)
+                            .to(dtype=param.dtype, device="cpu")
+                            .contiguous()
+                        )
+                        param.requires_grad_(False)
+                        param._moe_infinity_resident = True
+                        remaining.remove(name)
+            else:
+                state = torch.load(ckpt, map_location="cpu")
+                for name in list(remaining):
+                    if name not in state:
+                        continue
+                    param = wanted[name]
+                    param.data = (
+                        state[name]
+                        .to(dtype=param.dtype, device="cpu")
+                        .contiguous()
+                    )
+                    param.requires_grad_(False)
+                    param._moe_infinity_resident = True
+                    remaining.remove(name)
+                del state
+
+        if remaining:
+            raise RuntimeError(
+                f"Missing shared_experts weights: {sorted(remaining)[:5]}"
+            )
 
     def get_topology(self, model):
         name_lst = []
@@ -1503,7 +1589,7 @@ class OffloadEngine(object):
                 if isinstance(output, torch.Tensor):
                     return output.to(target)
 
-                return copy_args_to_device(target, *output)
+                return copy_args_to_device(target, output)
 
         # Pre forward hook
         self.forward_hooks.append(
@@ -1552,3 +1638,6 @@ class OffloadEngine(object):
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = (
             transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp
         )
+        _q35_mod = transformers.models.qwen3_5_moe.modeling_qwen3_5_moe
+        if hasattr(_q35_mod, "_old_qwen3_5_sparse_moe"):
+            _q35_mod.Qwen3_5MoeSparseMoeBlock = _q35_mod._old_qwen3_5_sparse_moe

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -70,6 +70,16 @@ def parse_expert_dtype(config: PretrainedConfig) -> int:
         assert False, "Unknown dtype %s" % dtype
 
 
+def moe_text_config(config: PretrainedConfig) -> PretrainedConfig:
+    # Qwen3.5-MoE is a vision-language wrapper: its MoE fields (num_experts,
+    # num_hidden_layers, ...) live under the nested text sub-config, exposed via
+    # get_text_config() in transformers v5. Flat models return themselves.
+    getter = getattr(config, "get_text_config", None)
+    if callable(getter):
+        return getter()
+    return getattr(config, "text_config", config)
+
+
 def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
     arch = (config.architectures or [""])[0].lower()
 
@@ -85,6 +95,12 @@ def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
         num_decoder_layers = config.num_hidden_layers
         num_layers = config.num_hidden_layers
         num_experts = config.num_local_experts
+    elif "qwen3_5" in arch:
+        text = moe_text_config(config)
+        num_encoder_layers = 0
+        num_decoder_layers = text.num_hidden_layers
+        num_layers = text.num_hidden_layers
+        num_experts = text.num_experts
     elif "qwen3" in arch:
         num_encoder_layers = 0
         num_decoder_layers = config.num_hidden_layers
@@ -150,6 +166,20 @@ def parse_expert_id(
 
         # native key: "layers.1.ffn.experts.0.w1.weight"
         result = re.findall(r"layers\.(\d+)\.ffn\.experts\.(\d+)\.", param_name)
+        if result:
+            layer_id, expert_id = result[0]
+            layer_id = int(layer_id)
+            expert_id = int(expert_id)
+    elif "qwen3_5" in arch:
+        decoder_sparse_step = 1
+        layer_type = "decoder"
+
+        # per-expert keys after the v5 batched-expert expand; anchored on
+        # language_model to exclude MTP (`mtp.*`) and vision (`model.visual.*`).
+        # e.g. "model.language_model.layers.13.mlp.experts.7.gate_proj.weight"
+        result = re.findall(
+            r"language_model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.", param_name
+        )
         if result:
             layer_id, expert_id = result[0]
             layer_id = int(layer_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Root conftest: stub CUDA-only deps so CPU-only CI can collect all tests."""
 
+import importlib.machinery
 import sys
 from unittest.mock import MagicMock
 
@@ -22,7 +23,9 @@ def _stub_if_missing(name: str) -> None:
     try:
         __import__(name)
     except (ImportError, OSError):
-        sys.modules[name] = MagicMock()
+        stub = MagicMock()
+        stub.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+        sys.modules[name] = stub
 
 
 for _mod in _OPTIONAL_CUDA_MODULES:

--- a/tests/python/unit/test_model_registry.py
+++ b/tests/python/unit/test_model_registry.py
@@ -24,6 +24,8 @@ def test_all_models_registered():
     }
     if "deepseekv4" in MODEL_MAPPING_NAMES:
         expected_models.add("deepseekv4")
+    if "qwen3_5" in MODEL_MAPPING_NAMES:
+        expected_models.add("qwen3_5")
     actual_models = set(MODEL_MAPPING_NAMES.keys())
     assert expected_models == actual_models, (
         f"Missing: {expected_models - actual_models}, "

--- a/tests/python/unit/test_qwen3_5_moe.py
+++ b/tests/python/unit/test_qwen3_5_moe.py
@@ -1,0 +1,136 @@
+import warnings
+
+import pytest
+import torch
+from transformers.models.qwen3_5_moe.configuration_qwen3_5_moe import (
+    Qwen3_5MoeConfig,
+    Qwen3_5MoeTextConfig,
+)
+from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
+    Qwen3_5MoeSparseMoeBlock,
+)
+
+from moe_infinity.common.constants import (
+    MODEL_MAPPING_NAMES,
+    MODEL_MAPPING_TYPES,
+    parse_expert_type,
+)
+from moe_infinity.models import SyncQwen3_5MoeSparseMoeBlock
+from moe_infinity.utils.hf_config import parse_expert_id, parse_moe_param
+
+
+def _arch(name):
+    cfg = Qwen3_5MoeConfig()
+    cfg.architectures = [name]
+    return cfg
+
+
+def _tiny_text_config():
+    return Qwen3_5MoeTextConfig(
+        num_experts=8,
+        num_experts_per_tok=2,
+        hidden_size=64,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        num_hidden_layers=2,
+        vocab_size=256,
+        hidden_act="silu",
+    )
+
+
+def test_qwen3_5_registered():
+    assert "qwen3_5" in MODEL_MAPPING_NAMES
+    assert (
+        MODEL_MAPPING_NAMES["qwen3_5"].__name__
+        == "Qwen3_5MoeForConditionalGeneration"
+    )
+    assert MODEL_MAPPING_TYPES["qwen3_5"] == 5
+
+
+@pytest.mark.parametrize(
+    "arch, expected_type",
+    [
+        ("Qwen3_5MoeForConditionalGeneration", 5),
+        ("Qwen3MoeForCausalLM", 5),
+        ("DeepseekV3ForCausalLM", 5),
+        ("MixtralForCausalLM", 4),
+    ],
+)
+def test_arch_resolver_most_specific(arch, expected_type):
+    assert parse_expert_type(_arch(arch)) == expected_type
+
+
+def test_parse_moe_param_reads_nested_text_config():
+    cfg = _arch("Qwen3_5MoeForConditionalGeneration")
+    text = cfg.get_text_config()
+    assert parse_moe_param(cfg) == (
+        text.num_hidden_layers,
+        text.num_experts,
+        0,
+    )
+
+
+@pytest.mark.parametrize(
+    "name, expected",
+    [
+        (
+            "model.language_model.layers.13.mlp.experts.7.gate_proj.weight",
+            (13, 7),
+        ),
+        (
+            "model.language_model.layers.0.mlp.experts.0.down_proj.weight",
+            (0, 0),
+        ),
+        (
+            "model.language_model.layers.39.mlp.experts.255.up_proj.weight",
+            (39, 255),
+        ),
+        (
+            "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight",
+            (None, None),
+        ),
+        ("model.language_model.layers.0.mlp.gate.weight", (None, None)),
+        ("mtp.layers.0.mlp.experts.0.gate_proj.weight", (None, None)),
+        ("model.visual.blocks.0.mlp.linear_fc1.weight", (None, None)),
+    ],
+)
+def test_parse_expert_id_qwen3_5(name, expected):
+    cfg = _arch("Qwen3_5MoeForConditionalGeneration")
+    assert parse_expert_id(name, cfg) == expected
+
+
+def test_sync_block_matches_hf_block():
+    warnings.filterwarnings("ignore")
+    cfg = _tiny_text_config()
+    torch.manual_seed(0)
+
+    hf_block = Qwen3_5MoeSparseMoeBlock(cfg).eval()
+    for p in hf_block.parameters():
+        torch.nn.init.normal_(p, std=0.05)
+
+    sync_block = SyncQwen3_5MoeSparseMoeBlock(cfg).eval()
+    sd = dict(hf_block.state_dict())
+    gate_up = sd.pop("experts.gate_up_proj")
+    down = sd.pop("experts.down_proj")
+    for e in range(cfg.num_experts):
+        gate_w, up_w = gate_up[e].chunk(2, dim=0)
+        sd[f"experts.{e}.gate_proj.weight"] = gate_w.contiguous()
+        sd[f"experts.{e}.up_proj.weight"] = up_w.contiguous()
+        sd[f"experts.{e}.down_proj.weight"] = down[e].contiguous()
+    missing, unexpected = sync_block.load_state_dict(sd, strict=False)
+    assert missing == [], f"missing: {missing}"
+
+    x = torch.randn(2, 6, cfg.hidden_size)
+    with torch.no_grad():
+        out_hf = hf_block(x)
+        out_sync = sync_block(x)
+
+    assert isinstance(out_sync, torch.Tensor)
+    assert out_sync.shape == (2, 6, cfg.hidden_size)
+    assert torch.allclose(out_hf, out_sync, rtol=1e-3, atol=1e-4)
+
+
+def test_sync_block_executor_stays_unset():
+    cfg = _tiny_text_config()
+    block = SyncQwen3_5MoeSparseMoeBlock(cfg)
+    assert block.expert_executor is None


### PR DESCRIPTION
## Qwen3.5-35B-A3B MoE support (text-only, expert offload)

Adds MoE-Infinity support for `Qwen/Qwen3.5-35B-A3B`: a new `SyncQwen3_5MoeSparseMoeBlock`, model-registry + `hf_config` wiring, and a resident-shared-expert / routed-expert-only offload path (keeps the small text backbone resident; offloads only routed experts).

### Provenance
Clean re-cut of **#125** onto the reconciled `main`. Cherry-picked `bfd09af` directly onto current `main`; the follow-up dedup commit `371cd0d` was a **no-op here** (the duplicate `_load_resident_shared_experts` it removed never appeared when applied on main's newer `model_offload.py`, verified: exactly one definition remains).

The transformers-v5 base that #125 carried (`1a8d4c7` pin bump, `1d37321` v5 migration) is **already on `main`** (via #108/#110 + PR #127), so it is intentionally excluded here.

**This supersedes #125**, which was built on a stale (March) base and carried redundant/divergent churn.

### Changes (10 files)
- `moe_infinity/models/qwen3_5_moe.py` (new) — `SyncQwen3_5MoeSparseMoeBlock`
- `moe_infinity/models/__init__.py`, `moe_infinity/common/constants.py`, `moe_infinity/utils/hf_config.py` — registration
- `moe_infinity/runtime/model_offload.py` — resident shared-expert / routed-only offload for `qwen3_5_moe`
- `moe_infinity/entrypoints/big_modeling.py` — block install/restore
- `README.md` — supported-models note
- `tests/python/unit/test_qwen3_5_moe.py` (new), `tests/python/unit/test_model_registry.py`, `tests/conftest.py`

### Verification
- `pytest tests/python/unit/test_qwen3_5_moe.py tests/python/unit/test_model_registry.py` → **19 passed**.
- No LSP diagnostics on new code. Full CPU unit tier runs in CI.
