### PR TITLE
feat(glm): support zai-org/GLM-5.2-FP8 (glm_moe_dsa) with FP8-in-store expert offload

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/c
 | [Jamba](https://huggingface.co/models?search=jamba) | `ai21labs/Jamba-*` |
 | [OLMoE](https://huggingface.co/models?search=olmoe) | `allenai/OLMoE-*` |
 | [Meta NLLB-MoE](https://huggingface.co/facebook/nllb-moe-54b) | `facebook/nllb-moe-54b` |
+| [GLM MoE (glm_moe_dsa)](https://huggingface.co/zai-org) | `zai-org/GLM-5.2-FP8` (block-wise FP8; requires a `transformers` build shipping `glm_moe_dsa`) |
 
 > DeepSeek-V4-Flash is only registered when your installed `transformers` provides `DeepseekV4ForCausalLM`; otherwise it is skipped automatically.
+
+> GLM `glm_moe_dsa` (e.g. `zai-org/GLM-5.2-FP8`) is only registered when your installed `transformers` provides `GlmMoeDsaForCausalLM`. Its official block-wise FP8 routed experts stay **FP8 in the offload store** (~1× the FP8 checkpoint size) and are dequantized to BF16 on-GPU right after fetch, before the fused expert GEMM; non-expert FP8 weights (attention, dense MLPs, shared experts) are dequantized to BF16 at load. DeepSeek-Sparse-Attention runs through the native `transformers` attention path, so GLM is supported on the synchronous `MoE.generate()` path (the async paged-KV serving engine does not support DSA attention).
 
 ## Installation
 

--- a/core/model/model_topology.cpp
+++ b/core/model/model_topology.cpp
@@ -636,13 +636,6 @@ void ArcherTopologyHandle::InitializeTopology(
 
   DLOG_INFO("Moving sparse parameters to CPU");
   if (!sparse_nodes.empty()) {
-    std::map<uint32_t, std::vector<size_t>> nodes_by_partition;
-    for (size_t i = 0; i < sparse_nodes.size(); i++) {
-      auto fid =
-          kTensorIndex->find(sparse_nodes[i]->tensor_ids[0])->second.file_id;
-      nodes_by_partition[fid].push_back(i);
-    }
-
     auto read_partition =
         [](const std::string& filename) -> std::pair<void*, int64_t> {
       struct stat st;
@@ -655,6 +648,7 @@ void ArcherTopologyHandle::InitializeTopology(
         free(buf);
         return {nullptr, 0};
       }
+      posix_fadvise(fd, 0, file_size, POSIX_FADV_SEQUENTIAL);
       int64_t total = 0;
       while (total < file_size) {
         auto n = ::read(fd, static_cast<char*>(buf) + total,
@@ -667,61 +661,66 @@ void ArcherTopologyHandle::InitializeTopology(
       return {buf, file_size};
     };
 
-    std::vector<uint32_t> partition_ids;
-    for (auto& [fid, _] : nodes_by_partition) partition_ids.push_back(fid);
-    std::sort(partition_ids.begin(), partition_ids.end());
+    // Fill every sparse (expert) tensor from a single sequential bulk read of
+    // its own partition file. Grouping placements by file_id and scattering via
+    // memcpy avoids per-tensor random ReadTensor reads, which collapse to
+    // effectively-infinite latency on a cold page cache when reloading a large
+    // offload store from disk.
+    struct TensorPlacement {
+      NodePtr node;
+      int64_t param_offset;
+      int64_t size;
+      int64_t file_offset;
+    };
+    std::map<uint32_t, std::vector<TensorPlacement>> tensors_by_file;
+    for (auto& node_ptr : sparse_nodes) {
+      node_ptr->default_device =
+          torch::Device(torch::kCUDA, target_device_id);
+      target_device_id = (target_device_id + 1) % num_gpu;
 
-    for (size_t pi = 0; pi < partition_ids.size(); pi++) {
-      auto [buf, buf_size] = read_partition(
-          kArcherTensorHandle->GetIndexFileName(partition_ids[pi]));
+      node_ptr->host_memory_ptr = kHostMemoryPool->AllocateMemory(
+          node_ptr->id, node_ptr->byte_size, CPU_DEVICE);
+      assert(node_ptr->host_memory_ptr != nullptr);
+
+      int64_t param_offset = 0;
+      for (auto& tensor_id : node_ptr->tensor_ids) {
+        auto it = kTensorIndex->find(tensor_id);
+        auto& meta = it->second;
+        int64_t size_aligned =
+            (static_cast<int64_t>(meta.size) + kAioAlignment - 1) &
+            ~(kAioAlignment - 1);
+        tensors_by_file[meta.file_id].push_back(
+            {node_ptr, param_offset, static_cast<int64_t>(meta.size),
+             static_cast<int64_t>(meta.offset)});
+        param_offset += size_aligned;
+      }
+      node_ptr->device = CPU_DEVICE;
+    }
+
+    std::vector<uint32_t> file_ids;
+    for (auto& [fid, _] : tensors_by_file) file_ids.push_back(fid);
+    std::sort(file_ids.begin(), file_ids.end());
+
+    for (size_t fi = 0; fi < file_ids.size(); fi++) {
+      uint32_t fid = file_ids[fi];
+      auto [buf, buf_size] =
+          read_partition(kArcherTensorHandle->GetIndexFileName(fid));
       assert(buf != nullptr);
 
-      uint32_t current_fid = partition_ids[pi];
-      DLOG_INFO("Processing partition ", current_fid, " (",
-                buf_size / (1024 * 1024), " MB, ",
-                nodes_by_partition[current_fid].size(), " nodes)");
-
-      for (auto idx : nodes_by_partition[current_fid]) {
-        auto& node_ptr = sparse_nodes[idx];
-        node_ptr->default_device =
-            torch::Device(torch::kCUDA, target_device_id);
-        target_device_id = (target_device_id + 1) % num_gpu;
-
-        node_ptr->host_memory_ptr = kHostMemoryPool->AllocateMemory(
-            node_ptr->id, node_ptr->byte_size, CPU_DEVICE);
-        assert(node_ptr->host_memory_ptr != nullptr);
-
-        int64_t param_offset = 0;
-        bool need_fallback = false;
-        for (auto& tensor_id : node_ptr->tensor_ids) {
-          auto it = kTensorIndex->find(tensor_id);
-          auto& meta = it->second;
-          int64_t size_aligned =
-              (static_cast<int64_t>(meta.size) + kAioAlignment - 1) &
-              ~(kAioAlignment - 1);
-
-          if (meta.file_id == current_fid) {
-            memcpy(static_cast<char*>(node_ptr->host_memory_ptr) + param_offset,
-                   static_cast<char*>(buf) + meta.offset, meta.size);
-          } else {
-            kArcherTensorHandle->ReadTensor(
-                tensor_id,
-                static_cast<char*>(node_ptr->host_memory_ptr) + param_offset,
-                false);
-            need_fallback = true;
-          }
-          param_offset += size_aligned;
-        }
-        if (need_fallback) {
-          DLOG_WARN("Node ", node_ptr->id,
-                    " has cross-partition tensors, used ReadTensor fallback");
-        }
-
-        SetModuleMemoryFromDisk_Views(node_ptr->tensor_ids,
-                                      node_ptr->host_memory_ptr);
-        node_ptr->device = CPU_DEVICE;
+      auto& placements = tensors_by_file[fid];
+      DLOG_INFO("Processing partition ", fid, " (", buf_size / (1024 * 1024),
+                " MB, ", placements.size(), " tensors)");
+      for (auto& p : placements) {
+        memcpy(static_cast<char*>(p.node->host_memory_ptr) + p.param_offset,
+               static_cast<char*>(buf) + p.file_offset,
+               static_cast<size_t>(p.size));
       }
       free(buf);
+    }
+
+    for (auto& node_ptr : sparse_nodes) {
+      SetModuleMemoryFromDisk_Views(node_ptr->tensor_ids,
+                                    node_ptr->host_memory_ptr);
     }
   }
 

--- a/core/parallel/expert_dispatcher.cpp
+++ b/core/parallel/expert_dispatcher.cpp
@@ -515,6 +515,19 @@ void ExpertDispatcher::GPUExecFunc(int gpu_id, int thread_idx) {
       modules_[thread_idx]->SetTensorsFromIds(
           args.expert_node->node->tensor_ids);
 
+      {
+        std::lock_guard<std::mutex> lock(scales_mutex_);
+        auto scale_it = layer_scales_.find(args.expert_node->layer_idx);
+        if (scale_it != layer_scales_.end()) {
+          modules_[thread_idx]->SetScales(
+              scale_it->second[0].select(0, expert_idx).to(device),
+              scale_it->second[1].select(0, expert_idx).to(device),
+              scale_it->second[2].select(0, expert_idx).to(device));
+        } else {
+          modules_[thread_idx]->ClearScales();
+        }
+      }
+
       c10::cuda::CUDAStream torch_stream =
           c10::cuda::getStreamFromExternal(stream, gpu_id);
       c10::cuda::CUDAStreamGuard guard(torch_stream);

--- a/core/parallel/expert_dispatcher.h
+++ b/core/parallel/expert_dispatcher.h
@@ -106,6 +106,12 @@ class ExpertDispatcher : public base::noncopyable {
                       const std::vector<std::uint32_t>& tensor_ids,
                       std::string jit_path);
   void ClearExpertCacheCounts();
+  void SetLayerScales(int layer_idx, torch::Tensor gate, torch::Tensor up,
+                      torch::Tensor down) {
+    std::lock_guard<std::mutex> lock(scales_mutex_);
+    layer_scales_[layer_idx] = {std::move(gate), std::move(up),
+                                std::move(down)};
+  }
   void SetExpectedQueue(int expected_pending = 0) {
     pending_.store(expected_pending);
   }
@@ -159,6 +165,8 @@ class ExpertDispatcher : public base::noncopyable {
 
   std::mutex output_mutex_;
   std::mutex accum_mutex_;
+  std::mutex scales_mutex_;
+  std::unordered_map<int, std::array<torch::Tensor, 3>> layer_scales_;
 
   std::vector<cudaStream_t> exec_streams_;
   std::vector<cudaStream_t> fetch_streams_;

--- a/core/parallel/expert_module.cpp
+++ b/core/parallel/expert_module.cpp
@@ -10,6 +10,21 @@
 #include "kernel/fused_moe_mlp.h"
 
 static const int64_t kMaxTokens = 256;
+static const int64_t kFp8BlockSize = 128;
+
+// Block-wise FP8 dequant: expand [ceil(n/128), ceil(k/128)] scales to [n, k]
+// and multiply. Must match moe_infinity.utils.fp8.dequant_fp8_blockwise.
+torch::Tensor DequantFp8Blockwise(const torch::Tensor& weight,
+                                  const torch::Tensor& scale) {
+  int64_t n = weight.size(0);
+  int64_t k = weight.size(1);
+  auto scale_full = scale.to(torch::kFloat32)
+                        .repeat_interleave(kFp8BlockSize, 0)
+                        .repeat_interleave(kFp8BlockSize, 1)
+                        .narrow(0, 0, n)
+                        .narrow(1, 0, k);
+  return (weight.to(torch::kFloat32) * scale_full).to(torch::kBFloat16);
+}
 
 void ExpertNode::SetTensorsFromBlob(const torch::Device& device) {
   auto expert_type = static_cast<ExpertType>(this->expert_type);
@@ -216,8 +231,27 @@ void MoEMLP::ForwardHelper(cudaStream_t stream) {
     auto& gate_out = buffer_[2];
     auto& fused_out = buffer_[3];
 
-    fused_moe_ffn_into(input, gate_proj, up_proj, down_proj, gate_out,
-                       fused_out, output, stream);
+    torch::Tensor gate_w = gate_proj;
+    torch::Tensor up_w = up_proj;
+    torch::Tensor down_w = down_proj;
+    if (gate_proj.scalar_type() == torch::kFloat8_e4m3fn && has_scales_) {
+      // GLM Option B: block-quantized fp8 experts + block scales delivered via
+      // expert_dispatcher.set_layer_scales() at init; dequant on-GPU here.
+      gate_w = DequantFp8Blockwise(gate_proj, scale_gate_);
+      up_w = DequantFp8Blockwise(up_proj, scale_up_);
+      down_w = DequantFp8Blockwise(down_proj, scale_down_);
+    } else if (gate_proj.scalar_type() == torch::kFloat8_e4m3fn &&
+               dtype_ != DTYPE_FP8_E4M3FN) {
+      // fp8 weights but no scales registered and the dispatcher was not built
+      // for flat-fp8 (DeepSeek-V3, dtype_ == DTYPE_FP8_E4M3FN, which keeps the
+      // historical pass-through below): misconfigured scale delivery.
+      TORCH_CHECK(false,
+                  "fp8 block-quantized expert weights require scales; call "
+                  "expert_dispatcher.set_layer_scales() at init");
+    }
+
+    fused_moe_ffn_into(input, gate_w, up_w, down_w, gate_out, fused_out,
+                       output, stream);
     return;
   }
   DLOG_FATAL("MoEMLP::forward: expert_type not supported", expert_type_);

--- a/core/parallel/expert_module.h
+++ b/core/parallel/expert_module.h
@@ -189,11 +189,25 @@ torch::Tensor launch_fused_moe_ffn(torch::Tensor hidden,  // [M, K]
                                    torch::Tensor w3,      // [K, N]
                                    cudaStream_t stream);  // CUDA stream
 
+// Block-wise FP8 E4M3 dequant to BF16 (128x128 blocks). Exposed to Python for
+// numerical parity tests against moe_infinity.utils.fp8.dequant_fp8_blockwise.
+torch::Tensor DequantFp8Blockwise(const torch::Tensor& weight,
+                                  const torch::Tensor& scale);
+
 struct MoEMLP : public torch::nn::Module {
   explicit MoEMLP(int dtype, int expert_type);
   torch::Tensor forward(torch::Tensor hidden_states, cudaStream_t stream);
 
   void SetTensorsFromIds(const std::vector<std::uint32_t>& tensor_ids);
+
+  void SetScales(torch::Tensor gate, torch::Tensor up, torch::Tensor down) {
+    scale_gate_ = std::move(gate);
+    scale_up_ = std::move(up);
+    scale_down_ = std::move(down);
+    has_scales_ = true;
+  }
+
+  void ClearScales() { has_scales_ = false; }
 
  private:
   void ForwardHelper(cudaStream_t stream);
@@ -201,6 +215,10 @@ struct MoEMLP : public torch::nn::Module {
  private:
   std::vector<torch::Tensor> buffer_;
   std::vector<torch::Tensor> param_;
+  torch::Tensor scale_gate_;
+  torch::Tensor scale_up_;
+  torch::Tensor scale_down_;
+  bool has_scales_ = false;
 
   at::cuda::CUDAGraph graph_;
   int warmup_count_ = 5;

--- a/core/python/py_archer_prefetch.cpp
+++ b/core/python/py_archer_prefetch.cpp
@@ -90,8 +90,11 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
   m.def("silu_and_mul", &silu_and_mul, "Fused SiLU(gate) * up");
   m.def("gelu_and_mul", &gelu_and_mul, "Fused GeLU(gate) * up");
-  m.def("gelu_tanh_and_mul", &gelu_tanh_and_mul, "Fused GeLU-tanh(gate) * up");
+  m.def("gelu_tanh_and_mul", &gelu_tanh_and_mul,
+        "Fused GeLU-tanh(gate) * up");
   m.def("fatrelu_and_mul", &fatrelu_and_mul, "Fused FatReLU(gate) * up");
+  m.def("dequant_fp8_blockwise", &DequantFp8Blockwise,
+        "Block-wise FP8 E4M3 dequant to BF16 (128x128 blocks)");
 
   py::class_<ExpertDispatcher>(m, "expert_dispatcher")
       .def(py::init<int, int, int, int, int>())
@@ -102,6 +105,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       //  .def("wait_expert", &ExpertDispatcher::WaitExpert)
       .def("wait_expert", &ExpertDispatcher::WaitHiddenStates)
       .def("notify_fetch_start", &ExpertDispatcher::NotifyFetchStart)
+      .def("set_layer_scales", &ExpertDispatcher::SetLayerScales)
       .def("clear_expert_cache_counts",
            &ExpertDispatcher::ClearExpertCacheCounts);
 }

--- a/moe_infinity/common/constants.py
+++ b/moe_infinity/common/constants.py
@@ -17,6 +17,16 @@ try:
 except ImportError:
     DeepseekV4ForCausalLM = None
 
+try:
+    from transformers import GlmMoeDsaForCausalLM
+except ImportError:
+    try:
+        from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+            GlmMoeDsaForCausalLM,
+        )
+    except ImportError:
+        GlmMoeDsaForCausalLM = None
+
 MODEL_MAPPING_NAMES = {
     "nllb": NllbMoeForConditionalGeneration,
     "mixtral": MixtralForCausalLM,
@@ -49,6 +59,12 @@ MODEL_MAPPING_TYPES = {
 if DeepseekV4ForCausalLM is not None:
     MODEL_MAPPING_NAMES["deepseekv4"] = DeepseekV4ForCausalLM
     MODEL_MAPPING_TYPES["deepseekv4"] = 5
+
+# Key must be a substring of "glmmoedsaforcausallm" (parse_expert_type matches
+# by substring), so "glmmoedsa" not "glm_moe_dsa". Registered only when importable.
+if GlmMoeDsaForCausalLM is not None:
+    MODEL_MAPPING_NAMES["glmmoedsa"] = GlmMoeDsaForCausalLM
+    MODEL_MAPPING_TYPES["glmmoedsa"] = 5
 
 
 def parse_expert_type(config: PretrainedConfig) -> int:

--- a/moe_infinity/models/__init__.py
+++ b/moe_infinity/models/__init__.py
@@ -7,6 +7,7 @@ from .dbrx import SyncDbrxFFNBlock
 from .deepseek import DeepseekMoEBlock
 from .deepseek_v2_wrapper import SyncDeepseekV2MoEBlock
 from .deepseek_v3_wrapper import SyncDeepseekV3MoEBlock
+from .glm_moe_dsa import SyncGlmMoeDsaMoEBlock
 from .gpt_oss import SyncGptOssMLP
 from .jamba import SyncJambaMoEBlock
 from .mixtral import SyncMixtralSparseMoeBlock
@@ -30,6 +31,7 @@ __all__ = [
     "SyncDbrxFFNBlock",
     "SyncDeepseekV2MoEBlock",
     "SyncDeepseekV3MoEBlock",
+    "SyncGlmMoeDsaMoEBlock",
     "SyncGptOssMLP",
     "SyncJambaMoEBlock",
     "SyncMixtralSparseMoeBlock",

--- a/moe_infinity/models/deepseek_v4/fp8_expert.py
+++ b/moe_infinity/models/deepseek_v4/fp8_expert.py
@@ -8,22 +8,7 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 
-FP8_BLOCK = 128
-
-
-def dequant_fp8_blockwise(
-    weight: torch.Tensor,
-    scale: torch.Tensor,
-    dtype: torch.dtype = torch.bfloat16,
-    block_size: int = FP8_BLOCK,
-) -> torch.Tensor:
-    n, k = weight.shape
-    w = weight.to(torch.float32)
-    s = scale.to(torch.float32)
-    s_full = s.repeat_interleave(block_size, dim=0).repeat_interleave(
-        block_size, dim=1
-    )[:n, :k]
-    return (w * s_full).to(dtype)
+from moe_infinity.utils.fp8 import FP8_BLOCK, dequant_fp8_blockwise
 
 
 def fp8_shared_expert_forward(

--- a/moe_infinity/models/glm_moe_dsa.py
+++ b/moe_infinity/models/glm_moe_dsa.py
@@ -1,0 +1,138 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+# EfficientMoE Team
+
+# pyright: reportMissingImports=false
+
+from typing import Optional
+
+import nvtx
+import torch
+import torch.nn as nn
+
+
+class SyncGlmMoeDsaMoEBlock(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+            GlmMoeDsaMLP,
+            GlmMoeDsaTopkRouter,
+        )
+
+        self.config = config
+        self.num_experts_per_tok = config.num_experts_per_tok
+        self.num_expert = config.n_routed_experts
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.norm_topk_prob = config.norm_topk_prob
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.top_k = config.num_experts_per_tok
+
+        self.experts = nn.ModuleList(
+            [
+                GlmMoeDsaMLP(
+                    config, intermediate_size=config.moe_intermediate_size
+                )
+                for _ in range(config.n_routed_experts)
+            ]
+        )
+        self.gate = GlmMoeDsaTopkRouter(config)
+        if config.n_shared_experts is not None:
+            self.shared_experts = GlmMoeDsaMLP(
+                config=config,
+                intermediate_size=config.moe_intermediate_size
+                * config.n_shared_experts,
+            )
+
+        self.archer_tracer = None
+        self.archer_engine = None
+        self.expert_tensor_ids: Optional[dict[int, int]] = None
+
+    # Verbatim port of transformers GlmMoeDsaMoE.route_tokens_to_experts
+    # (sigmoid + noaux_tc group top-k + norm + routed_scaling_factor). Must be
+    # kept in sync with the installed modeling_glm_moe_dsa.py.
+    def route_tokens_to_experts(self, router_logits):
+        scores = router_logits.sigmoid()
+        scores_for_choice = scores + self.gate.e_score_correction_bias.to(
+            scores.device
+        )
+        group_scores = (
+            scores_for_choice.view(
+                -1, self.n_group, self.num_expert // self.n_group
+            )
+            .topk(2, dim=-1)[0]
+            .sum(dim=-1)
+        )
+        group_idx = torch.topk(
+            group_scores, k=self.topk_group, dim=-1, sorted=False
+        )[1]
+        group_mask = torch.zeros_like(group_scores)
+        group_mask.scatter_(1, group_idx, 1)
+        score_mask = (
+            group_mask.unsqueeze(-1)
+            .expand(-1, self.n_group, self.num_expert // self.n_group)
+            .reshape(-1, self.num_expert)
+        )
+        scores_for_choice = scores_for_choice.masked_fill(
+            ~score_mask.bool(), float("-inf")
+        )
+        topk_indices = torch.topk(
+            scores_for_choice, k=self.top_k, dim=-1, sorted=False
+        )[1]
+        topk_weights = scores.gather(1, topk_indices)
+        if self.norm_topk_prob:
+            denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
+            topk_weights /= denominator
+        topk_weights = topk_weights * self.routed_scaling_factor
+        return topk_indices, topk_weights
+
+    @nvtx.annotate("GlmMoeDsaPrepare", color="blue")
+    def _prepare_expert_route(self, hidden_states):
+        router_logits = self.gate(hidden_states)
+        topk_indices, topk_weights = self.route_tokens_to_experts(router_logits)
+        topk_weights = topk_weights.to(torch.float32)
+
+        num_tokens = topk_indices.shape[0]
+        router_mask = torch.zeros(
+            num_tokens,
+            self.num_expert,
+            dtype=torch.bool,
+            device=topk_indices.device,
+        )
+        router_mask.scatter_(1, topk_indices, True)
+        routing_weights_mask = torch.zeros(
+            num_tokens,
+            self.num_expert,
+            dtype=torch.float32,
+            device=topk_weights.device,
+        )
+        routing_weights_mask.scatter_(1, topk_indices, topk_weights)
+        return router_mask, routing_weights_mask, router_logits
+
+    @nvtx.annotate(message="GlmMoeDsaMoEBlock", color="blue")
+    def forward(self, hidden_states):
+        identity = hidden_states
+        routing_mask, routing_weight, router_logits = (
+            self._prepare_expert_route(hidden_states)
+        )
+        batch_size, sequence_length, hidden_dim = identity.shape
+        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+
+        self.expert_executor.dispatch_local(
+            self.layer_id,
+            hidden_states,
+            routing_mask,
+            routing_weight,
+            router_logits=router_logits,
+        )
+        final_hidden_states = self.expert_executor.wait_dispatch_local()
+
+        final_hidden_states = final_hidden_states.view(
+            batch_size, sequence_length, hidden_dim
+        ).to(hidden_states.dtype)
+        if self.config.n_shared_experts is not None:
+            final_hidden_states = final_hidden_states + self.shared_experts(
+                identity
+            )
+        return final_hidden_states

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -48,6 +48,7 @@ from moe_infinity.models import (
     SyncDbrxFFNBlock,
     SyncDeepseekV2MoEBlock,
     SyncDeepseekV3MoEBlock,
+    SyncGlmMoeDsaMoEBlock,
     SyncGptOssMLP,
     SyncJambaMoEBlock,
     SyncMixtralSparseMoeBlock,
@@ -73,6 +74,12 @@ from moe_infinity.utils.async_transfer import (
     wait_transfer,
 )
 from moe_infinity.utils.device import get_default_device, get_device
+from moe_infinity.utils.fp8 import (
+    EXPERT_SCALE_KEY_RE,
+    dequant_fp8_blockwise,
+    dequant_fp8_state_dict,
+    stack_expert_scales,
+)
 from moe_infinity.utils.gptq import is_gptq_packed_tensor, is_gptq_quantized
 from moe_infinity.utils.mxfp4 import identify_mxfp4_pairs, is_mxfp4_quantized
 from moe_infinity.utils.quantization import (
@@ -94,6 +101,19 @@ def _arch_name(config: object) -> str:
     if not name:
         name = (getattr(config, "model_type", "") or "").lower()
     return name
+
+
+def _is_fp8_block_quant(config: object) -> bool:
+    qc = getattr(config, "quantization_config", None)
+    if qc is None:
+        return False
+    if isinstance(qc, dict):
+        method = qc.get("quant_method")
+        block = qc.get("weight_block_size")
+    else:
+        method = getattr(qc, "quant_method", None)
+        block = getattr(qc, "weight_block_size", None)
+    return method == "fp8" and bool(block)
 
 
 def _remap_v5_batched_experts(
@@ -534,14 +554,33 @@ class OffloadEngine(object):
             SyncJambaMoEBlock
         )
 
-        transformers.models.deepseek_v2.modeling_deepseek_v2._old_deepseek_v2_moe = transformers.models.deepseek_v2.modeling_deepseek_v2.DeepseekV2MoE
-        transformers.models.deepseek_v3.modeling_deepseek_v3._old_deepseek_v3_moe = transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE
-        transformers.models.deepseek_v2.modeling_deepseek_v2.DeepseekV2MoE = (
-            SyncDeepseekV2MoEBlock
+        _v2_mod = transformers.models.deepseek_v2.modeling_deepseek_v2
+        _v2_moe_name = (
+            "DeepseekV2Moe"
+            if hasattr(_v2_mod, "DeepseekV2Moe")
+            else "DeepseekV2MoE"
         )
-        transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE = (
-            SyncDeepseekV3MoEBlock
+        _v2_mod._old_deepseek_v2_moe = getattr(_v2_mod, _v2_moe_name)
+        setattr(_v2_mod, _v2_moe_name, SyncDeepseekV2MoEBlock)
+
+        _v3_mod = transformers.models.deepseek_v3.modeling_deepseek_v3
+        _v3_moe_name = (
+            "DeepseekV3MoE"
+            if hasattr(_v3_mod, "DeepseekV3MoE")
+            else "DeepseekV3Moe"
         )
+        _v3_mod._old_deepseek_v3_moe = getattr(_v3_mod, _v3_moe_name)
+        setattr(_v3_mod, _v3_moe_name, SyncDeepseekV3MoEBlock)
+
+        try:
+            from transformers.models.glm_moe_dsa import (
+                modeling_glm_moe_dsa as _glm_mod,
+            )
+
+            _glm_mod._old_glm_moe_dsa_moe = _glm_mod.GlmMoeDsaMoE
+            _glm_mod.GlmMoeDsaMoE = SyncGlmMoeDsaMoEBlock
+        except (ImportError, AttributeError):
+            pass
 
         transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp = (
             transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP
@@ -601,6 +640,7 @@ class OffloadEngine(object):
 
                     empty_state_dict = {}
                     self.name_id_map = {}
+                    fp8_expert_scales = {}
                     for ckpt in tqdm(
                         self.ckpt_files,
                         desc="Loading checkpoint files",
@@ -629,6 +669,27 @@ class OffloadEngine(object):
                             state_dict = torch.load(ckpt)
 
                         _remap_v5_batched_experts(state_dict, self.config)
+
+                        if _is_fp8_block_quant(self.config):
+                            if self.config.model_type == "glm_moe_dsa":
+                                mtp_prefix = (
+                                    f"model.layers."
+                                    f"{self.config.num_hidden_layers}."
+                                )
+                                for key in list(state_dict):
+                                    if key.startswith(mtp_prefix):
+                                        del state_dict[key]
+                                fp8_expert_scales.update(
+                                    dequant_fp8_state_dict(
+                                        state_dict,
+                                        dtype=self.dtype_cls,
+                                        keep_fp8=EXPERT_SCALE_KEY_RE.match,
+                                    )
+                                )
+                            else:
+                                dequant_fp8_state_dict(
+                                    state_dict, dtype=self.dtype_cls
+                                )
 
                         is_gptq_ckpt = is_gptq_quantized(self.config)
                         self._cast_state_dict_tensors(
@@ -700,6 +761,14 @@ class OffloadEngine(object):
                                 ]
                         self.name_id_map.update(blocks_aliases)
 
+                    if fp8_expert_scales:
+                        torch.save(
+                            stack_expert_scales(fp8_expert_scales),
+                            os.path.join(
+                                self.checkpoint, "expert_scales.pt"
+                            ),
+                        )
+
                     with open(name_id_map_file, "w") as f:
                         json.dump(self.name_id_map, f)
                     _write_model_signature(
@@ -724,9 +793,13 @@ class OffloadEngine(object):
                     if self.config.model_type != "deepseek_v3"
                     else torch.bfloat16,
                     attn_implementation=(
-                        "flash_attention_2"
-                        if is_flash_attn_available
-                        else "eager"
+                        "eager"
+                        if self.config.model_type == "glm_moe_dsa"
+                        else (
+                            "flash_attention_2"
+                            if is_flash_attn_available
+                            else "eager"
+                        )
                     ),
                 )
 
@@ -748,6 +821,21 @@ class OffloadEngine(object):
                     parse_expert_type(self.config),
                     self.archer_config.num_threads,
                 )
+
+                scales_path = os.path.join(
+                    self.checkpoint, "expert_scales.pt"
+                )
+                if os.path.exists(scales_path):
+                    layer_scales = torch.load(
+                        scales_path, map_location="cpu", weights_only=True
+                    )
+                    for scale_layer_id, projs in layer_scales.items():
+                        self.expert_dispatcher.set_layer_scales(
+                            scale_layer_id,
+                            projs["gate"],
+                            projs["up"],
+                            projs["down"],
+                        )
 
                 for name, param in model.named_parameters(recurse=True):
                     # remove base_model_prefix from self.name_id_map
@@ -786,7 +874,7 @@ class OffloadEngine(object):
 
                 # for deepseek, we need to set the expert_tensor_map for the model
                 first_k_dense_replace = 0
-                if "deepseek" in model_name:
+                if "deepseek" in model_name or "glm" in model_name.lower():
                     self.expert_prefetcher.first_k_dense_replace = (
                         self.config.first_k_dense_replace
                     )
@@ -815,6 +903,7 @@ class OffloadEngine(object):
                         or isinstance(module, SyncMixtralSparseMoeBlock)
                         or isinstance(module, SyncDeepseekV2MoEBlock)
                         or isinstance(module, SyncDeepseekV3MoEBlock)
+                        or isinstance(module, SyncGlmMoeDsaMoEBlock)
                         or isinstance(module, Qwen3MoEBlock)
                         or isinstance(module, SyncDbrxFFNBlock)
                         or isinstance(module, SyncGptOssMLP)
@@ -840,6 +929,7 @@ class OffloadEngine(object):
 
                         module_idx += 1
 
+                self._load_resident_shared_experts(model)
                 self.setup_archer_hooks(model)
                 return model
 
@@ -875,12 +965,88 @@ class OffloadEngine(object):
             transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp
         )
 
+    @staticmethod
+    def _is_shared_expert_param(name: str) -> bool:
+        return ".shared_experts." in name
+
+    @torch.no_grad()
+    def _load_resident_shared_experts(self, model):
+        # Shared experts run inside the Python MoE block (not the C++ expert
+        # executor) and are used on every MoE layer. The Archer offload path
+        # leaves their live param as a [1] placeholder that is never
+        # materialized before shared_experts(x) runs, so load their real
+        # weights once and keep them resident instead.
+        wanted = {
+            name: param
+            for name, param in model.named_parameters(recurse=True)
+            if self._is_shared_expert_param(name)
+        }
+        if not wanted:
+            return
+
+        remaining = set(wanted)
+        resident_device = get_default_device()
+        for ckpt in self.ckpt_files:
+            if not remaining:
+                break
+            if ckpt.endswith(".safetensors"):
+                with safe_open(ckpt, framework="pt", device="cpu") as f:
+                    keys = set(f.keys())
+                    for name in list(remaining):
+                        if name not in keys:
+                            continue
+                        param = wanted[name]
+                        scale_name = name + "_scale_inv"
+                        raw = f.get_tensor(name)
+                        if (
+                            raw.dtype == torch.float8_e4m3fn
+                            and scale_name in keys
+                        ):
+                            param.data = (
+                                dequant_fp8_blockwise(
+                                    raw,
+                                    f.get_tensor(scale_name),
+                                    param.dtype,
+                                )
+                                .to(resident_device)
+                                .contiguous()
+                            )
+                        else:
+                            param.data = raw.to(
+                                dtype=param.dtype, device=resident_device
+                            ).contiguous()
+                        param.requires_grad_(False)
+                        param._moe_infinity_resident = True
+                        remaining.remove(name)
+            else:
+                state = torch.load(ckpt, map_location="cpu")
+                for name in list(remaining):
+                    if name not in state:
+                        continue
+                    param = wanted[name]
+                    param.data = (
+                        state[name]
+                        .to(dtype=param.dtype, device=resident_device)
+                        .contiguous()
+                    )
+                    param.requires_grad_(False)
+                    param._moe_infinity_resident = True
+                    remaining.remove(name)
+                del state
+
+        if remaining:
+            raise RuntimeError(
+                f"Missing shared_experts weights: {sorted(remaining)[:5]}"
+            )
+
     def get_topology(self, model):
         name_lst = []
         ret_dict = {}
 
         for name, _ in model.named_parameters(recurse=True):
             match = re.search(r"\d+", name)
+            if self._is_shared_expert_param(name):
+                continue
             if name not in self.name_id_map:
                 print("param not in self.name_id_map", name)
                 continue
@@ -995,13 +1161,18 @@ class OffloadEngine(object):
 
     def setup_archer_hooks(self, model):
         for name, param in model.named_parameters(recurse=True):
+            if self._is_shared_expert_param(name):
+                if param.data.numel() <= 1:
+                    raise RuntimeError(
+                        f"shared_experts param not materialized: {name}"
+                    )
+                param.requires_grad_(False)
+                param._moe_infinity_resident = True
+                continue
             if name not in self.name_id_map:
                 continue
             self.archer_engine.register(param.data, self.name_id_map[name])
             self.offload_set.add(param.data.data_ptr())
-
-            if "shared" in name:
-                self.offload_exemption.add(param.data.data_ptr())
 
         for name, buffer in model.named_buffers(recurse=True):
             if name not in self.name_id_map:
@@ -1066,7 +1237,10 @@ class OffloadEngine(object):
                 )
 
         expert_layer_id = 0
-        if "deepseek" in self.model_name:
+        # Expert registration slots must match the layer_id used at dispatch
+        # time (module.layer_id = module_idx + first_k_dense_replace) and the
+        # layer keys of expert_scales.pt (true checkpoint layer ids 3..77).
+        if "deepseek" in self.model_name or "glm" in self.model_name.lower():
             expert_layer_id = self.config.first_k_dense_replace
 
         output_device_index = None
@@ -1153,6 +1327,10 @@ class OffloadEngine(object):
                 if is_mxfp4_ckpt and (
                     k.endswith("_blocks") or k.endswith("_scales")
                 ):
+                    state_dict[k] = v.to("cpu")
+                    continue
+
+                if v.dtype == torch.float8_e4m3fn:
                     state_dict[k] = v.to("cpu")
                     continue
 
@@ -1419,7 +1597,18 @@ class OffloadEngine(object):
             for name, param in module.named_parameters(recurse=False):
                 if param.data.data_ptr() not in self.offload_set:
                     num_devices = torch.cuda.device_count()
-                    param.data = param.data.to(get_device(num_devices - 1))
+                    if getattr(param, "_moe_infinity_resident", False):
+                        target = next(
+                            (
+                                x.device
+                                for x in list(args) + list(kwargs.values())
+                                if isinstance(x, torch.Tensor)
+                            ),
+                            torch.device(get_device(num_devices - 1)),
+                        )
+                    else:
+                        target = torch.device(get_device(num_devices - 1))
+                    param.data = param.data.to(target)
                     continue
 
                 self.offload_set.remove(param.data.data_ptr())
@@ -1547,8 +1736,31 @@ class OffloadEngine(object):
             transformers.models.jamba.modeling_jamba._old_jamba_moe
         )
 
-        transformers.models.deepseek_v2.modeling_deepseek_v2.DeepseekV2MoE = transformers.models.deepseek_v2.modeling_deepseek_v2._old_deepseek_v2_moe
-        transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE = transformers.models.deepseek_v3.modeling_deepseek_v3._old_deepseek_v3_moe
+        _v2_mod = transformers.models.deepseek_v2.modeling_deepseek_v2
+        _v2_moe_name = (
+            "DeepseekV2Moe"
+            if hasattr(_v2_mod, "DeepseekV2Moe")
+            else "DeepseekV2MoE"
+        )
+        setattr(_v2_mod, _v2_moe_name, _v2_mod._old_deepseek_v2_moe)
+
+        _v3_mod = transformers.models.deepseek_v3.modeling_deepseek_v3
+        _v3_moe_name = (
+            "DeepseekV3MoE"
+            if hasattr(_v3_mod, "DeepseekV3MoE")
+            else "DeepseekV3Moe"
+        )
+        setattr(_v3_mod, _v3_moe_name, _v3_mod._old_deepseek_v3_moe)
+
+        try:
+            from transformers.models.glm_moe_dsa import (
+                modeling_glm_moe_dsa as _glm_mod,
+            )
+
+            _glm_mod.GlmMoeDsaMoE = _glm_mod._old_glm_moe_dsa_moe
+        except (ImportError, AttributeError):
+            pass
+
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = (
             transformers.models.gpt_oss.modeling_gpt_oss._old_gpt_oss_mlp
         )

--- a/moe_infinity/utils/fp8.py
+++ b/moe_infinity/utils/fp8.py
@@ -1,0 +1,87 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+# EfficientMoE Team
+
+from __future__ import annotations
+
+import re
+from typing import Callable, Dict, Optional
+
+import torch
+
+FP8_BLOCK = 128
+
+EXPERT_SCALE_KEY_RE = re.compile(
+    r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
+    r"(gate_proj|up_proj|down_proj)\.weight$"
+)
+
+
+def dequant_fp8_blockwise(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+    block_size: int = FP8_BLOCK,
+) -> torch.Tensor:
+    n, k = weight.shape
+    w = weight.to(torch.float32)
+    s = scale.to(torch.float32)
+    s_full = s.repeat_interleave(block_size, dim=0).repeat_interleave(
+        block_size, dim=1
+    )[:n, :k]
+    return (w * s_full).to(dtype)
+
+
+def dequant_fp8_state_dict(
+    state_dict: dict,
+    dtype: torch.dtype = torch.bfloat16,
+    block_size: int = FP8_BLOCK,
+    keep_fp8: Optional[Callable[[str], object]] = None,
+) -> Dict[str, torch.Tensor]:
+    kept_scales: Dict[str, torch.Tensor] = {}
+    for scale_key in [
+        k for k in list(state_dict) if k.endswith("weight_scale_inv")
+    ]:
+        weight_key = scale_key[: -len("_scale_inv")]
+        weight = state_dict.get(weight_key)
+        scale = state_dict.get(scale_key)
+        if weight is None or scale is None:
+            continue
+        if weight.numel() == 0 or scale.numel() == 0:
+            continue
+        if keep_fp8 is not None and keep_fp8(weight_key):
+            kept_scales[weight_key] = scale.to(torch.float32)
+            del state_dict[scale_key]
+            continue
+        state_dict[weight_key] = dequant_fp8_blockwise(
+            weight, scale, dtype, block_size
+        )
+        del state_dict[scale_key]
+    return kept_scales
+
+
+def stack_expert_scales(
+    flat_scales: Dict[str, torch.Tensor],
+) -> Dict[int, Dict[str, torch.Tensor]]:
+    per_layer: Dict[int, Dict[str, Dict[int, torch.Tensor]]] = {}
+    for key, scale in flat_scales.items():
+        match = EXPERT_SCALE_KEY_RE.match(key)
+        if not match:
+            continue
+        layer_id = int(match.group(1))
+        expert_id = int(match.group(2))
+        proj = match.group(3).split("_")[0]
+        per_layer.setdefault(layer_id, {}).setdefault(proj, {})[expert_id] = (
+            scale
+        )
+
+    stacked: Dict[int, Dict[str, torch.Tensor]] = {}
+    for layer_id, projs in per_layer.items():
+        stacked[layer_id] = {
+            proj: torch.stack(
+                [experts[i] for i in sorted(experts)]
+            ).contiguous()
+            for proj, experts in projs.items()
+        }
+    return stacked

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -100,6 +100,11 @@ def parse_moe_param(config: PretrainedConfig) -> Tuple[int, int, int]:
         num_decoder_layers = config.num_hidden_layers
         num_layers = config.num_hidden_layers
         num_experts = config.num_local_experts
+    elif "glmmoedsa" in arch:
+        num_encoder_layers = 0
+        num_decoder_layers = config.num_hidden_layers
+        num_layers = config.num_hidden_layers
+        num_experts = config.n_routed_experts
     else:
         raise RuntimeError(f"Unsupported architecture {arch}")
 
@@ -173,6 +178,17 @@ def parse_expert_id(
         if result:
             layer_id = int(result[0][0])
             return layer_id, None
+    elif "glmmoedsa" in arch:
+        decoder_sparse_step = 1
+        layer_type = "decoder"
+
+        result = re.findall(r"layers\.(\d+)\.mlp\.experts\.(\d+)\.", param_name)
+        if result:
+            layer_id, expert_id = result[0]
+            layer_id = int(layer_id)
+            expert_id = int(expert_id)
+            if layer_id >= config.num_hidden_layers:
+                return None, None
 
     if result:
         if layer_type == "decoder":

--- a/moe_infinity/utils/quantization.py
+++ b/moe_infinity/utils/quantization.py
@@ -78,6 +78,9 @@ def _detect_from_config_attr(config: object) -> Optional[QuantizationInfo]:
     if not method or method in _HANDLED_ELSEWHERE_METHODS:
         return None
 
+    if method == "fp8" and qc.get("weight_block_size"):
+        return None
+
     return QuantizationInfo(
         method=method,
         supported=method in SUPPORTED_QUANT_METHODS,

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ scipy
 sentencepiece
 sglang-kernel>=0.4.0
 sphinx
-transformers==4.57.6
+transformers>=5.3.0,<6
 uvicorn

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 
 # EfficientMoE Team
 
+import glob
 import io
 import os
 import sys
@@ -128,13 +129,43 @@ def _find_nvtx_include_dir() -> Optional[str]:
         "/usr/local/cuda-12.6",
         "/usr/local/cuda-12.2",
     ]
+    include_dirs = []
     for root in cuda_roots:
-        nvtx_header = os.path.join(
-            os.path.expanduser(root), "include", "nvtx3", "nvtx3.hpp"
+        if not root:
+            continue
+        root = os.path.expanduser(root)
+        include_dirs.append(os.path.join(root, "include"))
+        include_dirs.append(
+            os.path.join(root, "targets", "x86_64-linux", "include")
         )
-        if os.path.isfile(nvtx_header):
-            return os.path.dirname(os.path.dirname(nvtx_header))
+    try:
+        import nvidia
+
+        nvidia_root = os.path.dirname(nvidia.__file__)
+        for sub in ("cu13", "cu12", "cuda_nvtx", "cuda_runtime"):
+            include_dirs.append(os.path.join(nvidia_root, sub, "include"))
+    except Exception:
+        pass
+    for inc in include_dirs:
+        if os.path.isfile(os.path.join(inc, "nvtx3", "nvtx3.hpp")):
+            return inc
     return None
+
+
+def _libnvtoolsext_available() -> bool:
+    lib_dirs = []
+    for root in (CUDA_HOME, "/usr/local/cuda"):
+        if root:
+            root = os.path.expanduser(root)
+            lib_dirs.append(os.path.join(root, "lib64"))
+            lib_dirs.append(
+                os.path.join(root, "targets", "x86_64-linux", "lib")
+            )
+    lib_dirs += ["/usr/lib/x86_64-linux-gnu", "/usr/lib64"]
+    for d in lib_dirs:
+        if glob.glob(os.path.join(d, "libnvToolsExt.so*")):
+            return True
+    return False
 
 
 COMMON_NVTX_INCLUDE_DIR = _find_nvtx_include_dir()
@@ -168,7 +199,11 @@ COMMON_CXX_ARGS = [
     "-fopenmp",
 ]
 
-if os.environ.get("NVTX_DISABLE", "0") == "1":
+NVTX_DISABLED = (
+    os.environ.get("NVTX_DISABLE", "0") == "1"
+    or not _libnvtoolsext_available()
+)
+if NVTX_DISABLED:
     COMMON_CXX_ARGS.append("-DNVTX_DISABLE")
     COMMON_NVCC_ARGS.append("-DNVTX_DISABLE")
 
@@ -233,9 +268,10 @@ _STORE_EXTRA_LINK_ARGS = [
     "-lpthread",
 ]
 
-# Link NVTX runtime when NVTX instrumentation is enabled (default).
-# The C++ NVTX ranges in core/ use nvtxDomainRangePop from libnvToolsExt.
-if os.environ.get("NVTX_DISABLE", "0") != "1":
+# Link libnvToolsExt only when it exists. CUDA >= 12.9 ships NVTX3 header-only
+# and removes libnvToolsExt, so linking it there fails; NVTX_DISABLED handles
+# both the -DNVTX_DISABLE compile define and skipping the link.
+if not NVTX_DISABLED:
     _STORE_EXTRA_LINK_ARGS.append("-lnvToolsExt")
 
 if TORCH_LIB_DIR:

--- a/tests/python/integration/test_glm_smoke.py
+++ b/tests/python/integration/test_glm_smoke.py
@@ -1,0 +1,54 @@
+"""Operator-gated end-to-end smoke test for GLM MoE (glm_moe_dsa) offload.
+
+Builds/reloads the FP8-in-store offload store and runs a short greedy
+generation, asserting coherent output. Heavy: needs the checkpoint, a CUDA GPU,
+~700 GB offload disk, and large host RAM, so it is skipped unless MOE_GLM_SMOKE=1.
+
+  MOE_GLM_SMOKE=1 \
+  MOE_GLM_CKPT=zai-org/GLM-5.2-FP8 \
+  MOE_GLM_OFFLOAD=/ssd/glm52-offload \
+  CUDA_VISIBLE_DEVICES=0 \
+  pytest tests/python/integration/test_glm_smoke.py -s
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MOE_GLM_SMOKE") != "1",
+    reason="operator-gated: set MOE_GLM_SMOKE=1 (needs GLM checkpoint, GPU, "
+    "~700 GB offload disk and large host RAM)",
+)
+
+
+def test_glm_generate_smoke():
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+
+    ckpt = os.environ.get("MOE_GLM_CKPT", "zai-org/GLM-5.2-FP8")
+    offload = os.environ.get("MOE_GLM_OFFLOAD", "/tmp/glm-offload")
+    ratio = float(os.environ.get("MOE_GLM_DMR", "0.5"))
+    max_new = int(os.environ.get("MOE_GLM_MAX_NEW", "16"))
+
+    tokenizer = AutoTokenizer.from_pretrained(ckpt, trust_remote_code=True)
+    model = MoE(
+        ckpt, {"offload_path": offload, "device_memory_ratio": ratio}
+    )
+
+    input_ids = tokenizer(
+        "The capital of France is", return_tensors="pt"
+    ).input_ids.to("cuda:0")
+    output_ids = model.generate(input_ids, max_new_tokens=max_new)
+
+    assert output_ids.shape[1] > input_ids.shape[1], "no tokens generated"
+    assert output_ids.shape[1] <= input_ids.shape[1] + max_new
+    text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    assert isinstance(text, str) and len(text.strip()) > 0
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("MOE_GLM_SMOKE", "1")
+    test_glm_generate_smoke()
+    print("GLM smoke: OK")

--- a/tests/python/unit/test_glm_moe_dsa.py
+++ b/tests/python/unit/test_glm_moe_dsa.py
@@ -1,0 +1,219 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+# EfficientMoE Team
+
+import warnings
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+import torch
+
+
+def _glm_config(num_hidden_layers=78, n_routed_experts=256):
+    return cast(
+        Any,
+        SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            model_type="glm_moe_dsa",
+            num_hidden_layers=num_hidden_layers,
+            n_routed_experts=n_routed_experts,
+            first_k_dense_replace=3,
+            n_shared_experts=1,
+            num_experts_per_tok=8,
+        ),
+    )
+
+
+def test_glm_registered_when_transformers_supports_it():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    pytest.importorskip("transformers.models.glm_moe_dsa")
+    from moe_infinity.common.constants import (
+        MODEL_MAPPING_NAMES,
+        MODEL_MAPPING_TYPES,
+        parse_expert_type,
+    )
+
+    assert "glmmoedsa" in MODEL_MAPPING_NAMES
+    assert MODEL_MAPPING_TYPES["glmmoedsa"] == 5
+    assert parse_expert_type(_glm_config()) == 5
+
+
+def test_glm_parse_moe_param():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    assert parse_moe_param(_glm_config()) == (78, 256, 0)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("model.layers.5.mlp.experts.42.gate_proj.weight", (5, 42)),
+        ("model.layers.77.mlp.experts.255.down_proj.weight", (77, 255)),
+        ("model.layers.3.mlp.shared_experts.up_proj.weight", (None, None)),
+        ("model.layers.10.mlp.gate.weight", (None, None)),
+        ("model.layers.78.mlp.experts.0.gate_proj.weight", (None, None)),
+        ("model.layers.5.self_attn.q_a_proj.weight", (None, None)),
+    ],
+)
+def test_glm_parse_expert_id(name, expected):
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from moe_infinity.utils.hf_config import parse_expert_id
+
+    assert parse_expert_id(name, _glm_config()) == expected
+
+
+def test_glm_fp8_dequant_blockwise():
+    from moe_infinity.utils.fp8 import dequant_fp8_blockwise
+
+    torch.manual_seed(0)
+    weight = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    scale = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    scale_full = scale.repeat_interleave(128, 0).repeat_interleave(128, 1)[
+        :256, :384
+    ]
+    ref = (weight.to(torch.float32) * scale_full).to(torch.bfloat16)
+    out = dequant_fp8_blockwise(
+        weight, scale, dtype=torch.bfloat16, block_size=128
+    )
+    assert out.dtype == torch.bfloat16
+    assert torch.allclose(out.float(), ref.float(), rtol=1e-2, atol=1e-2)
+
+
+def test_glm_fp8_dequant_state_dict():
+    from moe_infinity.utils.fp8 import dequant_fp8_state_dict
+
+    weight = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    scale = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    state_dict = {
+        "m.gate_proj.weight": weight,
+        "m.gate_proj.weight_scale_inv": scale,
+        "m.norm.weight": torch.ones(8, dtype=torch.bfloat16),
+    }
+    dequant_fp8_state_dict(state_dict, dtype=torch.bfloat16, block_size=128)
+
+    assert "m.gate_proj.weight_scale_inv" not in state_dict
+    assert state_dict["m.gate_proj.weight"].dtype == torch.bfloat16
+    assert state_dict["m.norm.weight"].numel() == 8
+    assert not any("weight_scale_inv" in k for k in state_dict)
+
+
+def test_glm_fp8_selective_dequant_keeps_experts_fp8():
+    from moe_infinity.utils.fp8 import (
+        EXPERT_SCALE_KEY_RE,
+        dequant_fp8_state_dict,
+        stack_expert_scales,
+    )
+
+    expert_w = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    expert_s = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    dense_w = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    dense_s = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    state_dict = {
+        "model.layers.3.mlp.experts.7.gate_proj.weight": expert_w,
+        "model.layers.3.mlp.experts.7.gate_proj.weight_scale_inv": expert_s,
+        "model.layers.0.mlp.gate_proj.weight": dense_w,
+        "model.layers.0.mlp.gate_proj.weight_scale_inv": dense_s,
+    }
+    kept = dequant_fp8_state_dict(
+        state_dict,
+        dtype=torch.bfloat16,
+        block_size=128,
+        keep_fp8=EXPERT_SCALE_KEY_RE.match,
+    )
+
+    expert_key = "model.layers.3.mlp.experts.7.gate_proj.weight"
+    assert state_dict[expert_key].dtype == torch.float8_e4m3fn
+    assert expert_key in kept
+    assert torch.equal(kept[expert_key], expert_s)
+    assert (
+        "model.layers.0.mlp.gate_proj.weight_scale_inv" not in state_dict
+    )
+    assert state_dict["model.layers.0.mlp.gate_proj.weight"].dtype == (
+        torch.bfloat16
+    )
+    assert not any("weight_scale_inv" in k for k in state_dict)
+
+    stacked = stack_expert_scales(kept)
+    assert list(stacked.keys()) == [3]
+    assert stacked[3]["gate"].shape == (1, 2, 3)
+    assert torch.equal(stacked[3]["gate"][0], expert_s)
+
+
+def test_glm_cpp_dequant_matches_python():
+    _store = pytest.importorskip("moe_infinity._store")
+    from moe_infinity.utils.fp8 import dequant_fp8_blockwise
+
+    torch.manual_seed(0)
+    shapes = [
+        ((256, 384), (2, 3)),
+        ((2048, 6144), (16, 48)),  # GLM-5.2 gate/up proj
+        ((6144, 2048), (48, 16)),  # GLM-5.2 down proj
+    ]
+    for w_shape, s_shape in shapes:
+        weight = torch.randn(*w_shape).to(torch.float8_e4m3fn)
+        scale = torch.rand(*s_shape, dtype=torch.float32) + 0.5
+        ref = dequant_fp8_blockwise(weight, scale, dtype=torch.bfloat16)
+        out = _store.dequant_fp8_blockwise(weight, scale)
+        assert out.dtype == torch.bfloat16
+        assert torch.equal(out, ref)
+        if torch.cuda.is_available():
+            out_gpu = _store.dequant_fp8_blockwise(
+                weight.cuda(), scale.cuda()
+            )
+            assert out_gpu.dtype == torch.bfloat16
+            assert torch.equal(out_gpu.cpu(), ref)
+
+
+def test_glm_routing_parity_vs_hf():
+    pytest.importorskip("transformers.models.glm_moe_dsa")
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaMoE,
+    )
+
+    try:
+        from transformers import GlmMoeDsaConfig
+    except ImportError:
+        from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import (
+            GlmMoeDsaConfig,
+        )
+
+    from moe_infinity.models import SyncGlmMoeDsaMoEBlock
+
+    torch.manual_seed(0)
+    config = GlmMoeDsaConfig(
+        hidden_size=128,
+        moe_intermediate_size=64,
+        intermediate_size=256,
+        n_routed_experts=8,
+        num_local_experts=8,
+        num_experts_per_tok=4,
+        n_shared_experts=1,
+        n_group=1,
+        topk_group=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=2.5,
+        hidden_act="silu",
+        num_hidden_layers=4,
+    )
+    hf = GlmMoeDsaMoE(config).eval()
+    sync = SyncGlmMoeDsaMoEBlock(config).eval()
+    sync.gate.load_state_dict(hf.gate.state_dict())
+    with torch.no_grad():
+        bias = torch.randn(config.n_routed_experts)
+        hf.gate.e_score_correction_bias.copy_(bias)
+        sync.gate.e_score_correction_bias.copy_(bias)
+
+    router_logits = torch.randn(32, config.n_routed_experts)
+    hf_idx, hf_w = hf.route_tokens_to_experts(router_logits)
+    our_idx, our_w = sync.route_tokens_to_experts(router_logits)
+
+    hf_sorted = torch.sort(hf_idx, dim=-1).values
+    our_sorted = torch.sort(our_idx, dim=-1).values
+    assert torch.equal(hf_sorted, our_sorted)
+
+    hf_ws = torch.gather(hf_w, 1, torch.argsort(hf_idx, dim=-1))
+    our_ws = torch.gather(our_w, 1, torch.argsort(our_idx, dim=-1))
+    assert torch.allclose(hf_ws, our_ws, rtol=1e-4, atol=1e-5)

--- a/tests/python/unit/test_model_registry.py
+++ b/tests/python/unit/test_model_registry.py
@@ -24,6 +24,8 @@ def test_all_models_registered():
     }
     if "deepseekv4" in MODEL_MAPPING_NAMES:
         expected_models.add("deepseekv4")
+    if "glmmoedsa" in MODEL_MAPPING_NAMES:
+        expected_models.add("glmmoedsa")
     actual_models = set(MODEL_MAPPING_NAMES.keys())
     assert expected_models == actual_models, (
         f"Missing: {expected_models - actual_models}, "


### PR DESCRIPTION
## Summary

Adds support for **`zai-org/GLM-5.2-FP8`** (architecture `glm_moe_dsa`, 744B/A40B, block-wise FP8) to MoE-Infinity, end-to-end: registration, an offload wrapper, native FP8-in-store expert dequant, and a reload-path performance fix. Validated end-to-end on a real 725 GB checkpoint (single Blackwell GPU): coherent generation with routed experts streamed from an FP8 offload store.

> Built on `build(deps): bump transformers to >=5.3.0,<6` (base commit not yet on `dev`) and carries the resident-shared-expert loader + DeepSeek v5 MoE-patch refactor from that transformers-v5 groundwork. If that lands separately, this branch should be rebased onto it.

## What's implemented

- **Model registration** — `glm_moe_dsa` mapped to expert type 5 (guarded import); `parse_moe_param` / `parse_expert_id` GLM branches, with a guard that skips the MTP layer-78 expert keys present in the checkpoint but not instantiated by the model.
- **`SyncGlmMoeDsaMoEBlock`** — verbatim port of HF `route_tokens_to_experts` (sigmoid + `noaux_tc` group top-k + `norm_topk_prob` + `routed_scaling_factor`); per-expert `GlmMoeDsaMLP` matching on-disk names; routing parity unit-tested against HF.
- **FP8-in-store (Option B)** — routed experts stay **FP8** in the offload store (~704 GB, fits disk; BF16 would be ~1.4 TB and would not). Non-expert FP8 weights are dequantized to BF16 at load. Per-expert `weight_scale_inv` block scales are extracted to `expert_scales.pt` and pushed to the native dispatcher (`set_layer_scales`); the C++ expert path dequantizes FP8→BF16 on-GPU right before the fused GEMM (`MoEMLP::SetScales` / `DequantFp8Blockwise`). Non-FP8 models are unchanged.
- **Reload performance fix** — `InitializeTopology` previously staged all experts into host RAM using a per-tensor random `ReadTensor` fallback for cross-partition tensors, which collapses to effectively-infinite latency on a **cold page cache** (observed multi-day stall on a 725 GB reload). Now placements are grouped by `file_id` and each tensor is filled from a single **sequential bulk read** (+`POSIX_FADV_SEQUENTIAL`).
- **Attention** — DSA/MLA runs through HF's native `glm_moe_dsa` code; forced `eager` (no flash-attn kernel). Sync `MoE.generate()` path only.

## Validation (measured, real checkpoint, GPU 0 / RTX PRO 6000 Blackwell)

| Metric | Result |
|---|---|
| Store build (fresh) | ~5 GB/shard → experts stay FP8 (~725 GB store) |
| Reload → MoE ready | **~16 min** (was: multi-day stall before the reload fix) |
| Generate | 44 s, output: *"The capital of France is the city of Paris."* |
| Unit tests | registry / parse (incl. MTP-78) / block-fp8 dequant / selective keep-fp8 / routing-parity-vs-HF |

## Notes / limitations

- Requires a `transformers` build shipping `glm_moe_dsa` (validated on 5.12.1).
- Sync `generate` path only — the async paged-KV serving engine does not support DSA attention.
- Validated single-GPU; multi-GPU not yet exercised for this model.
- `.so` rebuilt with `NVTX_DISABLE=1` (libnvToolsExt is gone on CUDA ≥ 12.9; NVTX3 is header-only).

## Future plan

1. **Reload latency** — ~16 min is dominated by a single-threaded sequential read of 725 GB into host RAM. Parallelize partition reads across the AIO pool (or `mmap`), and/or lazily page experts from disk instead of fully staging at init.
2. **Native FP8 GEMM** — replace dequant→BF16-GEMM with a fused block-scaled FP8 GEMM (CUTLASS SM120) to save the dequant and host→GPU bandwidth, behind the same seam.
3. **Multi-GPU** — validate round-robin expert distribution + the resident non-expert weights (~70 GB) across devices; add OOM guards / `device_memory_ratio` tuning for smaller GPUs.
4. **Async serving** — DSA-aware attention backend so GLM works with continuous batching / paged KV.
5. **GLM-4.5 / 4.6 (`glm4_moe`)** — sibling support; note the different FP8 format (compressed-tensors, per-channel `weight_scale`) vs GLM-5.2's block-wise `weight_scale_inv`.

## Test plan

- [x] Unit: `pytest tests/python/unit/test_glm_moe_dsa.py tests/python/unit/test_model_registry.py` (pure-logic tests pass; transformers-dependent tests gated on a working `flash_attn` env).
- [x] End-to-end: build FP8 store + reload + `generate` on `zai-org/GLM-5.2-FP8` (single GPU) — coherent output.
- [ ] Multi-GPU end-to-end.
