### PR TITLE
fix(build,ci): link CUDA driver stub so nightly wheels build on driverless runners

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,6 +1,8 @@
 name: Publish Nightly to PyPI
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - main
@@ -121,7 +123,7 @@ jobs:
 
       # Nightly publishes only the sdist to PyPI (see publish.yml for rationale).
       - name: Publish sdist to PyPI
-        if: ${{ matrix.python-version == '3.10' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.python-version == '3.10' }}
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           skip-existing: true

--- a/setup.py
+++ b/setup.py
@@ -239,6 +239,15 @@ _STORE_EXTRA_LINK_ARGS = [
 if TORCH_LIB_DIR:
     _STORE_EXTRA_LINK_ARGS.append(f"-Wl,-rpath,{TORCH_LIB_DIR}")
 
+# libcuda (-lcuda) ships with the GPU driver, not the toolkit, so it is
+# missing on driverless build machines (CI). Link against the toolkit's stub
+# in lib64/stubs; its SONAME (libcuda.so.1) means the real driver is still
+# loaded at runtime on GPUs.
+_CUDA_STUBS_DIR = os.path.join(CUDA_HOME, "lib64", "stubs")
+_STORE_LIBRARY_DIRS = (
+    [_CUDA_STUBS_DIR] if os.path.isdir(_CUDA_STUBS_DIR) else []
+)
+
 # _engine extension: compute kernels (fused_glu + expert_gemm)
 _ENGINE_SOURCES = [
     "core/python/fused_glu_cuda.cu",
@@ -290,6 +299,7 @@ if cuda_available:
             name="moe_infinity._store",
             sources=_STORE_SOURCES,
             include_dirs=COMMON_INCLUDE_PATHS,
+            library_dirs=_STORE_LIBRARY_DIRS,
             extra_compile_args={
                 "cxx": COMMON_CXX_ARGS,
                 "nvcc": COMMON_NVCC_ARGS + _cuda_arch_flags,
@@ -317,6 +327,7 @@ if cuda_available:
             name="moe_infinity._kv_cache",
             sources=_KV_CACHE_SOURCES,
             include_dirs=COMMON_INCLUDE_PATHS,
+            library_dirs=_STORE_LIBRARY_DIRS,
             extra_compile_args={
                 "cxx": COMMON_CXX_ARGS,
                 "nvcc": COMMON_NVCC_ARGS + _cuda_arch_flags,


### PR DESCRIPTION
## Problem

The **Publish Nightly to PyPI** workflow fails on every push to `main` at the wheel link step:

```
/usr/bin/ld: cannot find -lcuda: No such file or directory
collect2: error: ld returned 1 exit status
error: command '/usr/bin/g++' failed with exit code 1
```

`setup.py` links `-lcuda` (the CUDA **driver** library) for the `_store` and `_kv_cache` extensions. Driverless CI runners have the CUDA **toolkit** but no GPU/driver, so `libcuda.so` exists only as a stub at `$CUDA_HOME/lib64/stubs/` — which isn't on the linker's default search path. (Surfaced when #118 made the publish workflows compile the CUDA extensions.)

## Fix

- **`setup.py`** — add `$CUDA_HOME/lib64/stubs` to `library_dirs` for `_store` and `_kv_cache` (existence-guarded; derived from the already-resolved `CUDA_HOME`, so version-agnostic). `-lcuda` is kept. The stub's SONAME is `libcuda.so.1`, so GPU machines still load the real driver at runtime — this only affects the link-time `-L` search path, not the runtime rpath.
- **`.github/workflows/publish-test.yml`** — add `workflow_dispatch`, and harden the PyPI publish step to `github.event_name == 'push' && github.ref == 'refs/heads/main'` so manual/branch runs never publish.

`publish.yml` (release-on-tag) shares the same `setup.py` build path and is fixed automatically — no edit needed.

## Verification

- ✅ **Real CI** — `workflow_dispatch` run [31022400438](https://github.com/EfficientMoE/MoE-Infinity/actions/runs/31022400438) on this branch: all 3 Build Wheel jobs (3.10 / 3.11 / 3.12) **green**, `cannot find -lcuda` count **0**, publish step correctly **skipped**. Pre-fix baseline for comparison: run `31013984382` on `main` (**failure**).
- ✅ **Driverless Docker** (faithful bare-runner emulation, `env -u LIBRARY_PATH`): pre-fix `python -m build` fails with `cannot find -lcuda` at the `_store` link; post-fix builds the wheel with `-L.../lib64/stubs` in the `_store`/`_kv_cache` link lines.
- ✅ **No regression** on GPU machines: link-time `library_dirs` only (not rpath); stub SONAME `libcuda.so.1` ⇒ the loader still resolves the real driver at runtime.

Fixes the "Publish Nightly to PyPI" failure.
