### PR TITLE
feat(dflash): native gpt-oss DFlash speculative decoding (engine-integrated, greedy, resident)

### DIFF
--- a/docs/dflash.md
+++ b/docs/dflash.md
@@ -1,0 +1,63 @@
+# DFlash Speculative Decoding (gpt-oss-120b)
+
+MoE-Infinity ships a **native** DFlash (block-diffusion) speculative-decoding
+path for gpt-oss. A greedy, batch-1 `MoE.generate(..., speculative_draft=...)`
+routes through the engine's `spec_strategy` seam and runs the native
+draft → verify → rollback loop in `moe_infinity/spec_decode/dflash.py`.
+
+## Usage
+
+```python
+from moe_infinity import MoE
+from moe_infinity.spec_decode import DFlashSpeculator
+
+model = MoE("openai/gpt-oss-120b", {"offload_path": "/ssd/moe-infinity/gpt-oss-120b"})
+speculator = DFlashSpeculator(model, "z-lab/gpt-oss-120b-DFlash")  # trust_remote_code
+
+output_ids = model.generate(
+    input_ids,
+    max_new_tokens=64,
+    do_sample=False,          # greedy → routes through the native DFlash strategy
+    speculative_draft=speculator,
+)
+```
+
+Omit `speculative_draft` (or pass a non-greedy sampling config / batch > 1) and
+`generate` uses the standard autoregressive path, **byte-identical** to before.
+
+## v1 scope
+
+- **Greedy only** (`do_sample=False`); sampled speculative decoding is deferred.
+- **Resident by default.** Expert offload is a tunable knob (`device_memory_ratio`);
+  v1 does not couple expert prefetch to the speculative loop.
+- **Sync path only** — the async serving path is not spec-enabled.
+- **batch == 1.**
+
+## How it works
+
+Per step: prefill the target for an anchor; build a `block_size=10` block
+`[anchor, MASK×9]`; the non-causal drafter (reusing the target `embed_tokens` /
+`lm_head`, with a 5-layer target feature at layers `[1, 9, 17, 25, 33]` injected
+into every drafter layer) fills the 9 masks; the target verifies the whole block
+in **one full-logits forward**; the leading drafts the target's argmax agrees with
+are accepted, plus a bonus token (emitted but not cached); both KV caches roll
+back to the committed prefix.
+
+gpt-oss uses **sliding-window attention**, so the target rollback snapshots each
+sliding layer *before* the verify forward and rebuilds it from the committed
+prefix — a plain `DynamicCache.crop()` is invalid once the window is saturated
+(the layer has already evicted the tokens a partial accept must restore).
+
+## Testing
+
+- **Autonomous (CPU, tiny model)** — no GPU / no checkpoints:
+  `pytest tests/python/dflash -q`. The losslessness gates are
+  `test_native_e2e.py` (native DFlash == plain greedy, token-identical) and
+  `test_spec_off_regression.py` (spec-off byte-identical to the pre-integration
+  baseline).
+- **GPU-gated (120B)**:
+  `MOE_DFLASH_GPU=1 pytest tests/python/dflash/test_gpu_120b.py -q`
+  with `openai/gpt-oss-120b` + `z-lab/gpt-oss-120b-DFlash` cached; resident, TP=2
+  on SM120. Reports token agreement-rate vs plain-decode self-consistency, the
+  acceptance-length histogram, and decode tok/s (DFlash vs no-spec). Skips
+  cleanly when the flag is unset or the checkpoints/GPU are unavailable.

--- a/examples/dflash_gpt_oss_example.py
+++ b/examples/dflash_gpt_oss_example.py
@@ -1,3 +1,31 @@
+"""Native DFlash speculative decoding for gpt-oss-120b (v1: greedy, resident).
+
+Drives the **native** DFlash draft->verify->rollback loop through the
+MoE-Infinity engine: a greedy, batch-1 ``model.generate(..., speculative_draft=...)``
+routes through ``GenerationEngine.spec_strategy`` (the native loop in
+``moe_infinity/spec_decode/dflash.py``). The drafter (``z-lab/gpt-oss-120b-DFlash``)
+loads via ``trust_remote_code=True`` and reuses the target's ``embed_tokens`` +
+``lm_head``. Omit ``speculative_draft`` (or use a non-greedy config / batch>1) and
+``generate`` uses the standard autoregressive path, byte-identical to before.
+
+v1 scope (everything else is deferred):
+  * Greedy only (``do_sample=False``); sampled speculative decoding is deferred.
+  * Resident by default. Expert offload is a tunable knob (``device_memory_ratio``);
+    v1 does not couple expert prefetch to the speculative loop.
+  * Sync path only; the async serving path is not spec-enabled.
+  * batch == 1.
+
+Hardware: gpt-oss-120b is validated resident with TP=2 on Blackwell/SM120
+(RTX PRO 6000). Correctness is proven autonomously on a tiny CPU model
+(``tests/python/dflash/test_native_e2e.py``: native == plain greedy,
+token-identical); the 120B agreement-rate / acceptance-length / tok-s harness is
+GPU-gated (``tests/python/dflash/test_gpu_120b.py``, enabled via ``MOE_DFLASH_GPU=1``
+with the checkpoints cached). See ``docs/dflash.md``.
+
+Run:
+    python examples/dflash_gpt_oss_example.py --offload_dir /ssd/moe-infinity/gpt-oss-120b
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/examples/dflash_gpt_oss_example.py
+++ b/examples/dflash_gpt_oss_example.py
@@ -39,9 +39,14 @@ def main() -> None:
 
     input_ids = tokenizer(args.prompt, return_tensors="pt").input_ids
 
+    # Engine path: greedy batch-1 generate with a drafter routes through
+    # GenerationEngine.spec_strategy (the native DFlash loop).
     start = time.time()
-    output_ids = speculator.generate(
-        input_ids, max_new_tokens=args.max_new_tokens, temperature=0.0
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        speculative_draft=speculator,
     )
     elapsed = time.time() - start
 

--- a/moe_infinity/engine/generation_loop.py
+++ b/moe_infinity/engine/generation_loop.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Callable, Optional, Protocol
 
 import torch
 import torch.nn.functional as F
@@ -28,6 +28,18 @@ class GenerationResult:
     finish_reason: SequenceStatus
 
 
+class SpecDecodeStrategy(Protocol):
+    def run(
+        self,
+        *,
+        engine: GenerationEngine,
+        prompt_token_ids: list[int],
+        sampling_params: SamplingParams,
+        request_id: Optional[str] = None,
+    ) -> list[int]:
+        ...
+
+
 class GenerationEngine:
     kv_mgr: KVCacheManager
     kv_spec: KVCacheSpec
@@ -38,6 +50,7 @@ class GenerationEngine:
         Callable[[list[int], AttentionMetadata], torch.Tensor]
     ]
     max_seq_length: Optional[int]
+    spec_strategy: Optional[SpecDecodeStrategy]
 
     def __init__(
         self,
@@ -50,6 +63,7 @@ class GenerationEngine:
         ] = None,
         eos_token_id: int = 2,
         max_seq_length: Optional[int] = None,
+        spec_strategy: Optional[SpecDecodeStrategy] = None,
     ) -> None:
         self.kv_mgr = kv_cache_manager
         self.kv_spec = kv_spec
@@ -58,6 +72,7 @@ class GenerationEngine:
         self.eos_token_id = eos_token_id
         self._model_forward = model_forward_fn
         self.max_seq_length = max_seq_length
+        self.spec_strategy = spec_strategy
 
     def generate(
         self,
@@ -68,8 +83,56 @@ class GenerationEngine:
         if not prompt_token_ids:
             raise ValueError("prompt_token_ids must not be empty")
 
-        rid = request_id or str(uuid.uuid4())
         sp = sampling_params or SamplingParams()
+
+        if self._spec_strategy_applies(sp, batch_size=1):
+            assert self.spec_strategy is not None
+            rid = request_id or str(uuid.uuid4())
+            generated_ids = list(
+                self.spec_strategy.run(
+                    engine=self,
+                    prompt_token_ids=prompt_token_ids,
+                    sampling_params=sp,
+                    request_id=rid,
+                )
+            )
+            finish_reason = (
+                SequenceStatus.FINISHED_STOPPED
+                if generated_ids and generated_ids[-1] == self.eos_token_id
+                else SequenceStatus.FINISHED_LENGTH
+            )
+            return GenerationResult(
+                request_id=rid,
+                prompt_token_ids=prompt_token_ids,
+                output_token_ids=generated_ids,
+                finish_reason=finish_reason,
+            )
+
+        return self._generate_standard(prompt_token_ids, sp, request_id)
+
+    def _spec_strategy_applies(
+        self, sp: SamplingParams, batch_size: int
+    ) -> bool:
+        if self.spec_strategy is None:
+            return False
+        if batch_size != 1:
+            return False
+        if (
+            sp.temperature > 0
+            or sp.top_p < 1.0
+            or sp.top_k > 0
+            or getattr(sp, "do_sample", False)
+        ):
+            return False
+        return True
+
+    def _generate_standard(
+        self,
+        prompt_token_ids: list[int],
+        sp: SamplingParams,
+        request_id: Optional[str] = None,
+    ) -> GenerationResult:
+        rid = request_id or str(uuid.uuid4())
 
         num_prompt_tokens = len(prompt_token_ids)
         if (
@@ -235,4 +298,5 @@ __all__ = [
     "GenerationResult",
     "KVCacheAllocationError",
     "PromptTooLongError",
+    "SpecDecodeStrategy",
 ]

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -11,6 +11,37 @@ import moe_infinity
 warnings.filterwarnings("ignore")
 
 
+def extract_context_feature(hidden_states, layer_ids=(1, 9, 17, 25, 33)):
+    """Concatenate post-layer hidden states for DFlash drafter conditioning.
+
+    Args:
+        hidden_states: Per-layer hidden states from an HF forward with
+            ``output_hidden_states=True``. Index 0 is the embedding output, so
+            decoder layer ``layer_id``'s output lives at ``layer_id + 1``.
+        layer_ids: Decoder layers to concatenate; defaults to the gpt-oss-120b
+            DFlash contract ``(1, 9, 17, 25, 33)``.
+
+    Returns:
+        Tensor ``[batch, seq_len, len(layer_ids) * hidden_size]`` on the same
+        device/dtype as the inputs (e.g. ``[B, L, 14400]`` for 120B).
+    """
+    if hidden_states is None or len(hidden_states) == 0:
+        raise ValueError(
+            "hidden_states must be a non-empty tuple; "
+            "run the forward with output_hidden_states=True"
+        )
+    selected = []
+    for layer_id in layer_ids:
+        idx = int(layer_id) + 1
+        if idx >= len(hidden_states):
+            raise ValueError(
+                f"layer_id {layer_id} maps to hidden_states[{idx}], but only "
+                f"{len(hidden_states)} entries were returned"
+            )
+        selected.append(hidden_states[idx])
+    return torch.cat(selected, dim=-1)
+
+
 class MoE:
     """
     Loads a (potentially sharded) checkpoint inside a model, potentially sending weights to a given device as they are
@@ -537,6 +568,106 @@ class MoE:
         if logits.ndim == 2:
             return logits.detach().to("cpu")
         raise RuntimeError(f"unexpected logits shape: {tuple(logits.shape)}")
+
+    def _native_model_forward_rich(
+        self,
+        token_ids: list[int],
+        _attention_metadata: object = None,
+        logits_to_keep: int = 0,
+    ) -> tuple[torch.Tensor, tuple, object]:
+        """On-device forward for speculative decoding: hidden-state capture.
+
+        Single HF forward with ``output_hidden_states=True`` returning
+        ``(logits, hidden_states, past_key_values)`` on the model device —
+        unlike `_native_model_forward`, nothing is detached to CPU. The cache
+        contract mirrors the baseline (non-paged path reads/writes
+        ``self._cached_past_key_values``) so callers can roll the returned
+        ``DynamicCache`` back via ``crop()``.
+
+        ``logits_to_keep`` passthrough: ``1`` for the anchor/prefill step
+        (last-position logits only); ``0`` (the default) keeps full logits and
+        MUST be used for the verify step. Experts flow through the exact same
+        ``self.model(...)`` call as the baseline path, so the standard
+        ExpertExecutor dispatch (and its ``speculative_prefetch`` hook) is
+        preserved — nothing here bypasses expert dispatch.
+        """
+        input_tensor = torch.tensor([token_ids], dtype=torch.long)
+        if torch.cuda.is_available():
+            input_tensor = input_tensor.to("cuda:0")
+        else:
+            model_device = getattr(self.model, "device", None)
+            if isinstance(
+                model_device, torch.device
+            ) and model_device.type not in ("meta", "cpu"):
+                input_tensor = input_tensor.to(model_device)
+
+        is_prefill = True
+        if _attention_metadata is not None:
+            is_prefill = bool(getattr(_attention_metadata, "is_prefill", True))
+
+        paged_attention_classes = self._get_paged_attention_classes()
+        use_paged_context = bool(
+            paged_attention_classes
+            and _attention_metadata is not None
+            and getattr(self, "_native_attention_backend", None) is not None
+        )
+
+        extra_kwargs: dict = {"output_hidden_states": True}
+        if logits_to_keep:
+            extra_kwargs["logits_to_keep"] = int(logits_to_keep)
+
+        if not use_paged_context:
+            # Same HF KV-cache contract as the baseline: prefill captures
+            # past_key_values; decode steps consume the cached KV.
+            extra_kwargs["use_cache"] = True
+            if not is_prefill:
+                cached_kv = getattr(self, "_cached_past_key_values", None)
+                if cached_kv is not None:
+                    extra_kwargs["past_key_values"] = cached_kv
+        else:
+            if not is_prefill and _attention_metadata is not None:
+                seq_lens = getattr(_attention_metadata, "seq_lens", None)
+                if seq_lens is not None and seq_lens.numel() > 0:
+                    current_pos = int(seq_lens[0].item()) - 1
+                    extra_kwargs["position_ids"] = torch.tensor(
+                        [[current_pos]], device=input_tensor.device
+                    )
+
+        with torch.no_grad():
+            if not use_paged_context:
+                outputs = self.model(input_tensor, **extra_kwargs)
+            else:
+                backend = self._native_attention_backend
+                for attn_cls in paged_attention_classes:
+                    attn_cls.set_paged_context(backend, _attention_metadata)
+                try:
+                    outputs = self.model(input_tensor, **extra_kwargs)
+                finally:
+                    for attn_cls in paged_attention_classes:
+                        attn_cls.clear_paged_context()
+
+        if not use_paged_context:
+            past_kv = getattr(outputs, "past_key_values", None)
+            if past_kv is not None:
+                self._cached_past_key_values = past_kv
+
+        logits = getattr(outputs, "logits", None)
+        if logits is None and isinstance(outputs, tuple) and outputs:
+            logits = outputs[0]
+        if logits is None:
+            raise RuntimeError("model forward did not return logits")
+        if not isinstance(logits, torch.Tensor):
+            raise RuntimeError("model logits must be a torch.Tensor")
+
+        hidden_states = getattr(outputs, "hidden_states", None)
+        if hidden_states is None:
+            raise RuntimeError(
+                "model forward did not return hidden_states; "
+                "output_hidden_states=True is required"
+            )
+
+        past_key_values = getattr(outputs, "past_key_values", None)
+        return logits, hidden_states, past_key_values
 
     def _get_paged_attention_classes(self) -> list[type[Any]]:
         paged_class_names = {

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -713,6 +713,39 @@ class MoE:
         for module in self.engine.expert_layer_modules:
             module.seq_id_list = self.seq_id_list
 
+    def _resolve_spec_strategy(self, speculative_draft):
+        """Attach/detach the DFlash speculator on the native engine per call.
+
+        ``speculative_draft`` may be a drafter checkpoint path (loaded via
+        ``DFlashSpeculator``), an already-built ``DFlashSpeculator``, or an
+        instantiated draft module (wrapped via ``from_models``). Construction
+        is memoized by the passed value; ``None``/``False`` detaches so the
+        standard path runs, without discarding the memoized speculator.
+        """
+        engine = self._native_generation_engine
+        if not speculative_draft:
+            engine.spec_strategy = None
+            return
+        cached = getattr(self, "_dflash_speculator", None)
+        source = getattr(self, "_dflash_speculator_source", None)
+        same = source is speculative_draft or (
+            isinstance(source, str)
+            and isinstance(speculative_draft, (str, os.PathLike))
+            and source == str(speculative_draft)
+        )
+        if cached is None or not same:
+            from moe_infinity.spec_decode import DFlashSpeculator
+
+            if isinstance(speculative_draft, DFlashSpeculator):
+                cached = speculative_draft
+            elif isinstance(speculative_draft, (str, os.PathLike)):
+                cached = DFlashSpeculator(self, str(speculative_draft))
+            else:
+                cached = DFlashSpeculator.from_models(self, speculative_draft)
+            self._dflash_speculator = cached
+            self._dflash_speculator_source = speculative_draft
+        engine.spec_strategy = cached
+
     def generate(self, input_ids: torch.LongTensor, **kwargs) -> Any:
         """
         Generates sequences for models with a language modeling head. The method currently supports greedy decoding,
@@ -722,6 +755,11 @@ class MoE:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 The sequence used as a prompt for the generation. If `past` is used, only `bos_token_id` is used as
                 prompt.
+            speculative_draft: optional DFlash drafter (checkpoint path,
+                `DFlashSpeculator`, or draft module). When given, greedy
+                batch-1 decoding routes through the native speculative
+                strategy on the engine; omitted/`None`/`False` uses the
+                standard path (per-call, never sticky).
             **kwargs: Additional arguments for the generation method. Check the HuggingFace documentation of the model's
                 `generate` method for the supported arguments.
 
@@ -739,12 +777,24 @@ class MoE:
                 stacklevel=2,
             )
 
+        speculative_draft = kwargs.pop("speculative_draft", None)
+
         if (
             not self.use_native_engine
             or self._native_generation_engine is None
             or input_ids.ndim != 2
             or input_ids.shape[0] != 1
         ):
+            if speculative_draft:
+                if input_ids.ndim == 2 and input_ids.shape[0] != 1:
+                    raise NotImplementedError(
+                        "speculative_draft (DFlash) v1 supports batch==1 "
+                        f"only; got batch size {input_ids.shape[0]}"
+                    )
+                raise ValueError(
+                    "speculative_draft (DFlash) requires the MoE-Infinity "
+                    "native engine (use_native_engine=True)"
+                )
             self._configure_hook(input_ids)
             self.model.eval()
             with torch.no_grad():
@@ -752,6 +802,7 @@ class MoE:
 
         from moe_infinity.engine.types import SamplingParams
 
+        self._resolve_spec_strategy(speculative_draft)
         self._configure_hook(input_ids)
         self._cached_past_key_values = None
         self.model.eval()

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -39,6 +39,11 @@ def extract_context_feature(hidden_states, layer_ids=(1, 9, 17, 25, 33)):
                 f"{len(hidden_states)} entries were returned"
             )
         selected.append(hidden_states[idx])
+    # Multi-GPU (TP>1): the target's layers can span devices, so the selected
+    # per-layer states may live on different GPUs. Gather them onto one device
+    # before concatenating (no-op on a single device).
+    gather_device = selected[0].device
+    selected = [state.to(gather_device) for state in selected]
     return torch.cat(selected, dim=-1)
 
 

--- a/moe_infinity/spec_decode/_dflash_ops.py
+++ b/moe_infinity/spec_decode/_dflash_ops.py
@@ -1,0 +1,70 @@
+"""Pure, CPU-friendly tensor ops for the DFlash accept rule and block build.
+
+No model loading, no KV cache, no state machine -- just the deterministic
+argmax-domain math from RFC 1.2 (batch==1 in v1). The native draft->verify->
+rollback loop (Task 6) composes these; the emitted-vs-cached split lives in
+``Committed`` because conflating the two is the plan's #1 losslessness risk.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple, Union
+
+import torch
+
+AnchorLike = Union[int, torch.Tensor]
+
+
+class Committed(NamedTuple):
+    emitted: torch.Tensor  # [B, accept+1] accepted drafts ++ bonus; appended to output
+    block_prefix: torch.Tensor  # [B, accept+1] anchor ++ accepted drafts; KV kept (start += accept+1)
+    bonus: torch.Tensor  # [B, 1] posterior[:, accept]; emitted-but-NOT-cached, next anchor
+
+
+def build_block(anchor: AnchorLike, mask_token_id: int, block_size: int) -> torch.Tensor:
+    """Return ``[anchor, MASK x (block_size - 1)]`` as an int64 ``[B, block_size]``."""
+    if not torch.is_tensor(anchor):
+        anchor = torch.tensor(anchor)
+    anchor = anchor.to(torch.long).reshape(-1, 1)
+    masks = torch.full(
+        (anchor.shape[0], block_size - 1),
+        int(mask_token_id),
+        dtype=anchor.dtype,
+        device=anchor.device,
+    )
+    return torch.cat([anchor, masks], dim=1)
+
+
+def acceptance_length(candidates: torch.Tensor, target_predict: torch.Tensor) -> int:
+    """Number of leading draft tokens the target agrees with (RFC 1.2).
+
+    ``accept = cumprod(candidates[:, 1:] == target_predict[:, :-1]).sum()`` --
+    ``cumprod`` zeroes out everything past the first mismatch, so the sum is the
+    count of accepted tokens in ``[0, block_size - 1]``.
+    """
+    matches = (candidates[:, 1:] == target_predict[:, :-1]).long()
+    return int(matches.cumprod(dim=1).sum().item())
+
+
+def committed_tokens(
+    block: torch.Tensor, posterior: torch.Tensor, accept: int
+) -> Committed:
+    """Split one verify step into emitted / cached / bonus tensors.
+
+    ``emitted`` = the ``accept`` accepted drafts followed by the bonus token
+    ``posterior[:, accept]`` (the anchor at ``block[:, 0]`` is already in the
+    running sequence, so it is not re-emitted). ``block_prefix`` = the KV-retained
+    slice ``block[:, :accept+1]`` (advances ``start`` by ``accept+1``); the bonus
+    is deliberately excluded from it -- emitted-but-not-cached.
+    """
+    accept = int(accept)
+    accepted_drafts = block[:, 1 : accept + 1]
+    bonus = posterior[:, accept : accept + 1]
+    return Committed(
+        emitted=torch.cat([accepted_drafts, bonus], dim=1),
+        block_prefix=block[:, : accept + 1],
+        bonus=bonus,
+    )
+
+
+__all__ = ["Committed", "build_block", "acceptance_length", "committed_tokens"]

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, List, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
 
 import torch
 
@@ -13,6 +13,10 @@ from moe_infinity.spec_decode._dflash_ops import (
     build_block,
     committed_tokens,
 )
+
+if TYPE_CHECKING:
+    from moe_infinity.engine.generation_loop import GenerationEngine
+    from moe_infinity.engine.types import SamplingParams
 
 
 @dataclass
@@ -578,6 +582,39 @@ class DFlashSpeculator:
             [emitted[:max_new_tokens]], dtype=torch.long, device=input_ids.device
         )
         return torch.cat([input_ids, new_ids], dim=1)
+
+    def run(
+        self,
+        *,
+        engine: GenerationEngine,
+        prompt_token_ids: List[int],
+        sampling_params: SamplingParams,
+        request_id: Optional[str] = None,
+    ) -> List[int]:
+        """``SpecDecodeStrategy`` adapter: engine list contract -> native loop.
+
+        The engine calls this only after its greedy gate applied (batch==1,
+        temperature==0, top_p==1, top_k==0). Target forwards route through
+        this speculator's OWN ``self.moe`` rich helper -- never through
+        ``engine`` -- so the standard expert dispatch is preserved.
+        ``max_new_tokens`` comes from ``sampling_params.max_tokens`` and the
+        stop ids from ``engine.eos_token_id`` (the native loop falls back to
+        the target config's eos when the engine has none). Returns ONLY the
+        newly generated token ids (prompt stripped); the engine wraps them in
+        a ``GenerationResult`` and ``MoE.generate`` re-prepends the prompt.
+        """
+        del request_id  # protocol-conformance parameter; the loop is stateless
+        input_ids = torch.tensor([list(prompt_token_ids)], dtype=torch.long)
+        max_new_tokens = int(getattr(sampling_params, "max_tokens", 256))
+        eos = getattr(engine, "eos_token_id", None)
+        stop_ids = [int(eos)] if isinstance(eos, int) and eos >= 0 else None
+        output = self.generate(
+            input_ids,
+            max_new_tokens=max_new_tokens,
+            temperature=0.0,
+            stop_token_ids=stop_ids,
+        )
+        return [int(t) for t in output[0, len(prompt_token_ids) :].tolist()]
 
 
 __all__ = [

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -468,7 +468,9 @@ class DFlashSpeculator:
             input_ids, past_key_values=None, logits_to_keep=1
         )
         anchor = int(logits[:, -1, :].argmax(dim=-1).item())
-        context_feature = extract_context_feature(hidden_states, layer_ids)
+        context_feature = extract_context_feature(hidden_states, layer_ids).to(
+            self.device
+        )
 
         stop_ids = set(_resolve_stop_ids(self.target, stop_token_ids))
 
@@ -513,7 +515,7 @@ class DFlashSpeculator:
             logits, hidden_states, target_kv = self._forward_target(
                 block, past_key_values=target_kv, logits_to_keep=0
             )
-            posterior = logits.argmax(dim=-1)
+            posterior = logits.argmax(dim=-1).to(self.device)
 
             accept = acceptance_length(block, posterior)
             committed = committed_tokens(block, posterior, accept)
@@ -565,9 +567,9 @@ class DFlashSpeculator:
             if stop:
                 break
 
-            suffix = extract_context_feature(hidden_states, layer_ids)[
-                :, : accept + 1, :
-            ]
+            suffix = extract_context_feature(hidden_states, layer_ids).to(
+                self.device
+            )[:, : accept + 1, :]
             if self._drafter_has_kv_cache:
                 context_feature = suffix
             else:

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -47,6 +47,10 @@ def read_dflash_config(draft_hf_config: Any) -> DFlashConfig:
     )
 
 
+DFLASH_BLOCK_SIZE = 10
+DFLASH_TARGET_LAYER_IDS = [1, 9, 17, 25, 33]
+
+
 def validate_pairing(draft_cfg: DFlashConfig, target_hf_config: Any) -> None:
     target_text = _get(target_hf_config, "text_config", target_hf_config)
     t_hidden = int(_get(target_text, "hidden_size"))
@@ -57,9 +61,21 @@ def validate_pairing(draft_cfg: DFlashConfig, target_hf_config: Any) -> None:
         raise ValueError(
             f"DFlash drafter hidden_size {draft_cfg.hidden_size} != target hidden_size {t_hidden}"
         )
+    if draft_cfg.vocab_size != t_vocab:
+        raise ValueError(
+            f"DFlash drafter vocab_size {draft_cfg.vocab_size} != target vocab_size {t_vocab}"
+        )
     if draft_cfg.mask_token_id >= t_vocab:
         raise ValueError(
             f"DFlash mask_token_id {draft_cfg.mask_token_id} is outside target vocab_size {t_vocab}"
+        )
+    if draft_cfg.block_size != DFLASH_BLOCK_SIZE:
+        raise ValueError(
+            f"DFlash block_size {draft_cfg.block_size} != expected {DFLASH_BLOCK_SIZE}"
+        )
+    if draft_cfg.target_layer_ids != DFLASH_TARGET_LAYER_IDS:
+        raise ValueError(
+            f"DFlash target_layer_ids {draft_cfg.target_layer_ids} != expected {DFLASH_TARGET_LAYER_IDS}"
         )
     highest_capture = max(draft_cfg.target_layer_ids) + 1
     if highest_capture > t_layers:
@@ -67,6 +83,71 @@ def validate_pairing(draft_cfg: DFlashConfig, target_hf_config: Any) -> None:
             f"DFlash target_layer_ids reference target layer {max(draft_cfg.target_layer_ids)} "
             f"(capture index {highest_capture}) but target has only {t_layers} layers"
         )
+
+
+def validate_drafter_module(draft_model: Any, draft_cfg: DFlashConfig) -> None:
+    fc = _get(draft_model, "fc")
+    if fc is None:
+        raise ValueError(
+            "DFlash drafter is missing the required `fc` projection layer "
+            "(expected a Linear consuming the concatenated 5-layer hidden feature)"
+        )
+    in_features = _get(fc, "in_features")
+    expected = len(draft_cfg.target_layer_ids) * draft_cfg.hidden_size
+    if in_features != expected:
+        raise ValueError(
+            f"DFlash drafter fc.in_features {in_features} != expected {expected} "
+            f"({len(draft_cfg.target_layer_ids)} * hidden_size {draft_cfg.hidden_size})"
+        )
+
+
+def validate_drafter(
+    draft_model: Any,
+    target_hf_config: Any,
+    draft_cfg: Optional[DFlashConfig] = None,
+) -> DFlashConfig:
+    if draft_cfg is None:
+        draft_cfg = read_dflash_config(_get(draft_model, "config"))
+    validate_pairing(draft_cfg, target_hf_config)
+    validate_drafter_module(draft_model, draft_cfg)
+    return draft_cfg
+
+
+def _resolve_input_embeddings(target: Any) -> Any:
+    getter = getattr(target, "get_input_embeddings", None)
+    if callable(getter):
+        emb = getter()
+        if emb is not None:
+            return emb
+    inner = getattr(target, "model", target)
+    emb = getattr(inner, "embed_tokens", None)
+    if emb is not None:
+        return emb
+    raise ValueError(
+        "could not resolve target embed_tokens for DFlash drafter weight sharing"
+    )
+
+
+def _resolve_output_embeddings(target: Any) -> Any:
+    getter = getattr(target, "get_output_embeddings", None)
+    if callable(getter):
+        head = getter()
+        if head is not None:
+            return head
+    head = getattr(target, "lm_head", None)
+    if head is not None:
+        return head
+    raise ValueError(
+        "could not resolve target lm_head for DFlash drafter weight sharing"
+    )
+
+
+def bind_shared_weights(draft_model: Any, target: Any) -> tuple[Any, Any]:
+    embed_tokens = _resolve_input_embeddings(target)
+    lm_head = _resolve_output_embeddings(target)
+    draft_model.embed_tokens = embed_tokens
+    draft_model.lm_head = lm_head
+    return embed_tokens, lm_head
 
 
 def _infer_cuda_device(model: Any) -> str:
@@ -121,7 +202,8 @@ class DFlashSpeculator:
             )
 
         self.config = read_dflash_config(self.draft.config)
-        validate_pairing(self.config, self.target.config)
+        validate_drafter(self.draft, self.target.config, draft_cfg=self.config)
+        self.embed_tokens, self.lm_head = bind_shared_weights(self.draft, self.target)
 
     def _configure_target_hooks(self, input_ids: torch.Tensor) -> None:
         configure = getattr(self.moe, "_configure_hook", None)
@@ -162,4 +244,7 @@ __all__ = [
     "DFlashSpeculator",
     "read_dflash_config",
     "validate_pairing",
+    "validate_drafter",
+    "validate_drafter_module",
+    "bind_shared_weights",
 ]

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+import inspect
 from dataclasses import dataclass
-from typing import Any, List, Optional
+from types import SimpleNamespace
+from typing import Any, List, NamedTuple, Optional
 
 import torch
+
+from moe_infinity.entrypoints.big_modeling import extract_context_feature
+from moe_infinity.spec_decode._dflash_ops import (
+    acceptance_length,
+    build_block,
+    committed_tokens,
+)
 
 
 @dataclass
@@ -174,6 +183,62 @@ def _resolve_stop_ids(target: Any, stop_token_ids: Optional[List[int]]) -> List[
     return [int(x) for x in eos]
 
 
+def rollback_target_cache(
+    target_kv: Any,
+    sliding_snaps: dict[int, tuple[torch.Tensor, torch.Tensor, int]],
+    prev_start: int,
+    committed: int,
+    block_size: int,
+) -> None:
+    """Roll the target KV cache back to ``prev_start + committed`` in place.
+
+    Slice-only rollback (``DynamicCache.crop``) is WRONG for sliding-window
+    layers: ``DynamicSlidingWindowLayer.update`` retains only the last
+    ``sliding_window - 1`` tokens, so the verify forward evicts prefix tokens
+    that a partial accept must restore (and ``crop`` itself raises once the
+    cumulative length reaches the window). Instead the sliding layers are
+    snapshotted before the verify forward (see ``generate``) and rebuilt here
+    as ``snapshot prefix ++ kept block tokens``, re-truncated to the window;
+    full-attention layers retain every token and crop cleanly. ``kv_offset``
+    is recomputed from ``cumulative_length``, so only ``keys`` / ``values`` /
+    ``cumulative_length`` are touched.
+    """
+    from transformers.cache_utils import DynamicSlidingWindowLayer
+
+    new_len = prev_start + committed
+    for i, layer in enumerate(target_kv.layers):
+        if isinstance(layer, DynamicSlidingWindowLayer):
+            old_k, old_v, old_len = sliding_snaps[i]
+            assert old_len == prev_start
+            block_k = layer.keys[:, :, -block_size:, :]
+            block_v = layer.values[:, :, -block_size:, :]
+            keep_k = block_k[:, :, :committed, :]
+            keep_v = block_v[:, :, :committed, :]
+            full_k = torch.cat([old_k, keep_k], dim=-2)
+            full_v = torch.cat([old_v, keep_v], dim=-2)
+            layer.keys = full_k[:, :, -layer.sliding_window + 1 :, :]
+            layer.values = full_v[:, :, -layer.sliding_window + 1 :, :]
+            layer.cumulative_length = new_len
+        else:
+            layer.crop(new_len)
+
+
+class NativeStepTrace(NamedTuple):
+    """Per-step state accounting for the native DFlash loop (diagnostics).
+
+    The bonus token is emitted but NOT cached, so after every step the target
+    cache length equals ``start`` while the absolute emitted length is exactly
+    one ahead -- conflating the two is the bonus-token trap (oracle ruling #3).
+    """
+
+    prev_start: int  # cached_len at step entry
+    accept: int  # accepted draft count, in [0, block_size - 1]
+    start: int  # cached_len after commit == prev_start + accept + 1
+    emitted_len: int  # generated tokens emitted so far (accepted drafts + bonus)
+    target_cache_len: int  # target_kv.get_seq_length() after crop
+    draft_cache_len: Optional[int]  # context-KV length after crop (KV drafter only)
+
+
 class DFlashSpeculator:
     def __init__(
         self,
@@ -195,15 +260,73 @@ class DFlashSpeculator:
             .to(self.device)
             .eval()
         )
-        if not hasattr(self.draft, "spec_generate"):
-            raise TypeError(
-                f"loaded draft model {type(self.draft).__name__} has no spec_generate; "
-                "expected a DFlash drafter checkpoint (e.g. z-lab/gpt-oss-120b-DFlash)"
-            )
 
         self.config = read_dflash_config(self.draft.config)
         validate_drafter(self.draft, self.target.config, draft_cfg=self.config)
         self.embed_tokens, self.lm_head = bind_shared_weights(self.draft, self.target)
+        self._init_native_runtime()
+
+    @classmethod
+    def from_models(
+        cls,
+        moe: Any,
+        draft_model: Any,
+        config: Optional[DFlashConfig] = None,
+        device: Optional[str] = None,
+    ) -> "DFlashSpeculator":
+        """Build a speculator from already-instantiated models (no checkpoint load).
+
+        ``moe`` may be the MoE wrapper -- every target forward then routes
+        through ``moe._native_model_forward_rich`` so experts stay on the
+        standard ExpertExecutor dispatch -- or a bare HF causal LM, which is
+        called directly with ``output_hidden_states=True``. The 120B pairing
+        constants are not applied here; the module-level ``fc`` contract is.
+        """
+        self = cls.__new__(cls)
+        self.moe = moe
+        on_moe_engine = callable(getattr(moe, "_native_model_forward_rich", None))
+        self.target = moe.model if on_moe_engine else moe
+        if device is None:
+            if on_moe_engine:
+                device = _infer_cuda_device(self.target)
+            else:
+                dev = getattr(self.target, "device", None)
+                device = (
+                    str(dev)
+                    if isinstance(dev, torch.device)
+                    else str(next(self.target.parameters()).device)
+                )
+        self.device = device
+        self.draft = draft_model
+        if config is None:
+            config = read_dflash_config(_get(self.draft, "config"))
+        self.config = config
+        validate_drafter_module(self.draft, self.config)
+        self.embed_tokens, self.lm_head = bind_shared_weights(self.draft, self.target)
+        self._init_native_runtime()
+        return self
+
+    def _init_native_runtime(self) -> None:
+        # The reference DFlashDraftModel.forward takes ``noise_embedding`` and
+        # maintains a DynamicCache of projected context KV; stateless drafters
+        # (tiny fixtures) take ``(block_ids, context_feature)`` instead.
+        self._drafter_has_kv_cache = (
+            "noise_embedding" in inspect.signature(self.draft.forward).parameters
+        )
+        # Sliding-window targets retain only the last ``sliding_window - 1``
+        # tokens per cache update; the verify block must fit in that span or
+        # the snapshot/rebuild rollback cannot recover the block's K/V.
+        sliding_window = getattr(
+            getattr(self.target, "config", None), "sliding_window", None
+        )
+        if sliding_window:
+            assert int(self.config.block_size) <= int(sliding_window) - 1, (
+                f"DFlash block_size {self.config.block_size} must be <= "
+                f"target sliding_window - 1 ({int(sliding_window) - 1})"
+            )
+        self.step_trace: List[NativeStepTrace] = []
+        self.last_target_cache: Any = None
+        self.last_draft_cache: Any = None
 
     def _configure_target_hooks(self, input_ids: torch.Tensor) -> None:
         configure = getattr(self.moe, "_configure_hook", None)
@@ -213,6 +336,72 @@ class DFlashSpeculator:
         if callable(eval_fn):
             eval_fn()
 
+    def _forward_target(
+        self,
+        input_ids: torch.Tensor,
+        past_key_values: Any = None,
+        logits_to_keep: int = 0,
+    ) -> tuple[torch.Tensor, Any, Any]:
+        """Rich target forward -> on-device (logits, hidden_states, past_key_values).
+
+        ``logits_to_keep=1`` slices to the last position and is for the
+        prefill/anchor step only; the verify step MUST pass ``0`` (full
+        logits) or the acceptance rule breaks.
+        """
+        rich = getattr(self.moe, "_native_model_forward_rich", None)
+        if callable(rich):
+            metadata = (
+                None
+                if past_key_values is None
+                else SimpleNamespace(is_prefill=False)
+            )
+            token_ids = [int(t) for t in input_ids[0].tolist()]
+            return rich(token_ids, metadata, logits_to_keep=logits_to_keep)
+        kwargs: dict[str, Any] = {
+            "past_key_values": past_key_values,
+            "use_cache": True,
+            "output_hidden_states": True,
+        }
+        if logits_to_keep:
+            kwargs["logits_to_keep"] = int(logits_to_keep)
+        outputs = self.target(input_ids, **kwargs)
+        return outputs.logits, outputs.hidden_states, outputs.past_key_values
+
+    def _run_drafter(
+        self,
+        block: torch.Tensor,
+        context_feature: torch.Tensor,
+        start: int,
+        draft_kv: Any,
+    ) -> torch.Tensor:
+        """One non-causal drafter pass over ``block`` -> hidden [1, block_size, H].
+
+        Both drafter contracts KV-inject the 5-layer target feature into
+        EVERY drafter layer internally. The KV drafter is fed suffix-only
+        features and its cache is cropped back to ``start`` after the pass:
+        the cache accumulates projected context KV only, so this block's
+        noise KV is discarded (mirrors the reference ``spec_generate``).
+        """
+        if self._drafter_has_kv_cache:
+            noise_embedding = self.embed_tokens(block)
+            position_ids = torch.arange(
+                draft_kv.get_seq_length(),
+                start + block.shape[1],
+                device=block.device,
+                dtype=torch.long,
+            ).unsqueeze(0)
+            drafter_out = self.draft(
+                target_hidden=context_feature,
+                noise_embedding=noise_embedding,
+                position_ids=position_ids,
+                past_key_values=draft_kv,
+                use_cache=True,
+                is_causal=False,
+            )
+            draft_kv.crop(start)
+            return drafter_out
+        return self.draft(block, context_feature)
+
     @torch.inference_mode()
     def generate(
         self,
@@ -221,22 +410,123 @@ class DFlashSpeculator:
         temperature: float = 0.0,
         stop_token_ids: Optional[List[int]] = None,
     ) -> torch.Tensor:
+        """Native greedy DFlash draft->verify->rollback loop (RFC 1.2).
+
+        Per step: draft a block of ``block_size`` candidates with the
+        non-causal drafter, verify the whole block in ONE target forward with
+        full logits, accept the leading drafts the target's argmax agrees
+        with, emit the accepted drafts plus the target's bonus token, and roll
+        both KV caches back to the committed prefix. The bonus token is
+        emitted but NOT cached -- it becomes the next step's anchor, so
+        ``cached_len`` (``start``) always trails the emitted count by one.
+        """
         if input_ids.ndim != 2 or input_ids.shape[0] != 1:
             raise ValueError(
                 f"DFlashSpeculator.generate expects input_ids of shape [1, seq], got {tuple(input_ids.shape)}"
             )
+        if float(temperature) > 0:
+            raise ValueError(
+                "DFlashSpeculator v1 is greedy-only (temperature=0.0); "
+                "sampled speculative decoding is out of scope"
+            )
+        if stop_token_ids is not None:
+            raise NotImplementedError(
+                "stop_token_ids / EOS-mid-block handling is Task 7 scope; "
+                "the native loop currently decodes to max_new_tokens"
+            )
+
+        from transformers import DynamicCache
+        from transformers.cache_utils import DynamicSlidingWindowLayer
 
         input_ids = input_ids.to(self.device)
-        stops = _resolve_stop_ids(self.target, stop_token_ids)
         self._configure_target_hooks(input_ids)
 
-        return self.draft.spec_generate(
-            target=self.target,
-            input_ids=input_ids,
-            max_new_tokens=int(max_new_tokens),
-            stop_token_ids=stops,
-            temperature=float(temperature),
+        num_prompt_tokens = int(input_ids.shape[1])
+        block_size = int(self.config.block_size)
+        layer_ids = list(self.config.target_layer_ids)
+        max_new_tokens = int(max_new_tokens)
+
+        logits, hidden_states, target_kv = self._forward_target(
+            input_ids, past_key_values=None, logits_to_keep=1
         )
+        anchor = int(logits[:, -1, :].argmax(dim=-1).item())
+        context_feature = extract_context_feature(hidden_states, layer_ids)
+
+        emitted: List[int] = [anchor]
+        start = num_prompt_tokens
+        draft_kv = DynamicCache() if self._drafter_has_kv_cache else None
+
+        self.step_trace = []
+        while len(emitted) < max_new_tokens:
+            prev_start = start
+            block = build_block(anchor, self.config.mask_token_id, block_size).to(
+                self.device
+            )
+
+            drafter_out = self._run_drafter(block, context_feature, start, draft_kv)
+            draft_logits = self.lm_head(drafter_out)[:, -(block_size - 1) :, :]
+            block[:, 1:] = draft_logits.argmax(dim=-1)
+
+            # Snapshot sliding layers BEFORE the verify forward: its update
+            # evicts all but the last ``sliding_window - 1`` tokens, so the
+            # prefix must be captured here to rebuild after a partial accept.
+            sliding_snaps: dict[int, tuple[torch.Tensor, torch.Tensor, int]] = {}
+            for i, layer in enumerate(target_kv.layers):
+                if isinstance(layer, DynamicSlidingWindowLayer):
+                    sliding_snaps[i] = (
+                        layer.keys.clone(),
+                        layer.values.clone(),
+                        int(layer.cumulative_length),
+                    )
+
+            logits, hidden_states, target_kv = self._forward_target(
+                block, past_key_values=target_kv, logits_to_keep=0
+            )
+            posterior = logits.argmax(dim=-1)
+
+            accept = acceptance_length(block, posterior)
+            committed = committed_tokens(block, posterior, accept)
+
+            emitted.extend(int(t) for t in committed.emitted[0].tolist())
+            start = prev_start + accept + 1
+            rollback_target_cache(
+                target_kv,
+                sliding_snaps,
+                prev_start=prev_start,
+                committed=accept + 1,
+                block_size=block_size,
+            )
+            assert int(target_kv.get_seq_length()) == start
+
+            suffix = extract_context_feature(hidden_states, layer_ids)[
+                :, : accept + 1, :
+            ]
+            if self._drafter_has_kv_cache:
+                context_feature = suffix
+            else:
+                context_feature = torch.cat([context_feature, suffix], dim=1)
+
+            anchor = int(committed.bonus[0, 0].item())
+            self.step_trace.append(
+                NativeStepTrace(
+                    prev_start=prev_start,
+                    accept=accept,
+                    start=start,
+                    emitted_len=len(emitted),
+                    target_cache_len=int(target_kv.get_seq_length()),
+                    draft_cache_len=(
+                        int(draft_kv.get_seq_length()) if draft_kv is not None else None
+                    ),
+                )
+            )
+
+        self.last_target_cache = target_kv
+        self.last_draft_cache = draft_kv
+
+        new_ids = torch.tensor(
+            [emitted[:max_new_tokens]], dtype=torch.long, device=input_ids.device
+        )
+        return torch.cat([input_ids, new_ids], dim=1)
 
 
 __all__ = [

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -232,7 +232,11 @@ class NativeStepTrace(NamedTuple):
     """
 
     prev_start: int  # cached_len at step entry
-    accept: int  # accepted draft count, in [0, block_size - 1]
+    # accepted drafts actually committed this step, in [0, block_size - 1];
+    # smaller than the accept-rule result when the step is truncated by a
+    # stop token or the max_new_tokens budget (drafts beyond the cut are
+    # dropped), so ``start == prev_start + accept + 1`` holds in every branch
+    accept: int
     start: int  # cached_len after commit == prev_start + accept + 1
     emitted_len: int  # generated tokens emitted so far (accepted drafts + bonus)
     target_cache_len: int  # target_kv.get_seq_length() after crop
@@ -419,20 +423,30 @@ class DFlashSpeculator:
         both KV caches back to the committed prefix. The bonus token is
         emitted but NOT cached -- it becomes the next step's anchor, so
         ``cached_len`` (``start``) always trails the emitted count by one.
+
+        Stop handling: ``stop_token_ids`` (falling back to the target
+        config's ``eos_token_id``) truncates the emitted output at the first
+        stop id, inclusive, and ends the loop; ``max_new_tokens`` truncates a
+        block that would overshoot the remaining budget. Neither cache is
+        allowed past the last kept token: keeping ``k`` of a step's
+        ``accept + 1`` emitted tokens (``k - 1`` is the stop index) commits
+        ``min(k, accept) + 1`` cached tokens -- the anchor plus the first
+        ``min(k, accept)`` drafts -- because the verify forward only
+        produced KV for block tokens, never for the bonus.
         """
-        if input_ids.ndim != 2 or input_ids.shape[0] != 1:
+        if input_ids.ndim != 2:
             raise ValueError(
                 f"DFlashSpeculator.generate expects input_ids of shape [1, seq], got {tuple(input_ids.shape)}"
+            )
+        if input_ids.shape[0] != 1:
+            raise NotImplementedError(
+                "DFlashSpeculator v1 supports batch==1 only; got input_ids "
+                f"with batch size {input_ids.shape[0]}"
             )
         if float(temperature) > 0:
             raise ValueError(
                 "DFlashSpeculator v1 is greedy-only (temperature=0.0); "
                 "sampled speculative decoding is out of scope"
-            )
-        if stop_token_ids is not None:
-            raise NotImplementedError(
-                "stop_token_ids / EOS-mid-block handling is Task 7 scope; "
-                "the native loop currently decodes to max_new_tokens"
             )
 
         from transformers import DynamicCache
@@ -452,11 +466,24 @@ class DFlashSpeculator:
         anchor = int(logits[:, -1, :].argmax(dim=-1).item())
         context_feature = extract_context_feature(hidden_states, layer_ids)
 
+        stop_ids = set(_resolve_stop_ids(self.target, stop_token_ids))
+
         emitted: List[int] = [anchor]
         start = num_prompt_tokens
         draft_kv = DynamicCache() if self._drafter_has_kv_cache else None
 
         self.step_trace = []
+        if stop_ids and anchor in stop_ids and max_new_tokens >= 1:
+            # The prefill anchor is itself a stop token: emit it and halt
+            # before any block is drafted (nothing past EOS may be emitted
+            # or cached; the anchor/bonus is never cached).
+            self.last_target_cache = target_kv
+            self.last_draft_cache = draft_kv
+            new_ids = torch.tensor(
+                [emitted], dtype=torch.long, device=input_ids.device
+            )
+            return torch.cat([input_ids, new_ids], dim=1)
+
         while len(emitted) < max_new_tokens:
             prev_start = start
             block = build_block(anchor, self.config.mask_token_id, block_size).to(
@@ -487,16 +514,52 @@ class DFlashSpeculator:
             accept = acceptance_length(block, posterior)
             committed = committed_tokens(block, posterior, accept)
 
-            emitted.extend(int(t) for t in committed.emitted[0].tolist())
-            start = prev_start + accept + 1
+            # This step's emitted tokens are [d_1 .. d_accept, bonus]; the
+            # verify forward produced KV only for [anchor, d_1 .. d_accept].
+            # Keeping k emitted tokens (stop index k - 1) therefore commits
+            # min(k, accept) + 1 cached tokens: the anchor plus the first
+            # min(k, accept) drafts. The bonus is never cached, so a cut at
+            # the bonus still commits the full accept + 1 block prefix.
+            step_tokens = [int(t) for t in committed.emitted[0].tolist()]
+            keep = accept + 1
+            stop = False
+            if stop_ids:
+                for j, tok in enumerate(step_tokens):
+                    if tok in stop_ids:
+                        keep = j + 1
+                        stop = True
+                        break
+            remaining = max_new_tokens - len(emitted)
+            if keep > remaining:
+                keep = remaining
+                stop = True
+
+            emitted.extend(step_tokens[:keep])
+            cache_committed = min(keep, accept) + 1
+            start = prev_start + cache_committed
             rollback_target_cache(
                 target_kv,
                 sliding_snaps,
                 prev_start=prev_start,
-                committed=accept + 1,
+                committed=cache_committed,
                 block_size=block_size,
             )
             assert int(target_kv.get_seq_length()) == start
+
+            self.step_trace.append(
+                NativeStepTrace(
+                    prev_start=prev_start,
+                    accept=cache_committed - 1,
+                    start=start,
+                    emitted_len=len(emitted),
+                    target_cache_len=int(target_kv.get_seq_length()),
+                    draft_cache_len=(
+                        int(draft_kv.get_seq_length()) if draft_kv is not None else None
+                    ),
+                )
+            )
+            if stop:
+                break
 
             suffix = extract_context_feature(hidden_states, layer_ids)[
                 :, : accept + 1, :
@@ -507,18 +570,6 @@ class DFlashSpeculator:
                 context_feature = torch.cat([context_feature, suffix], dim=1)
 
             anchor = int(committed.bonus[0, 0].item())
-            self.step_trace.append(
-                NativeStepTrace(
-                    prev_start=prev_start,
-                    accept=accept,
-                    start=start,
-                    emitted_len=len(emitted),
-                    target_cache_len=int(target_kv.get_seq_length()),
-                    draft_cache_len=(
-                        int(draft_kv.get_seq_length()) if draft_kv is not None else None
-                    ),
-                )
-            )
 
         self.last_target_cache = target_kv
         self.last_draft_cache = draft_kv

--- a/tests/python/dflash/compare_greedy.py
+++ b/tests/python/dflash/compare_greedy.py
@@ -32,7 +32,6 @@ def main() -> None:
     parser.add_argument("--out", default="dflash_agreement.json")
     args = parser.parse_args()
 
-    import torch
     from transformers import AutoTokenizer
 
     from moe_infinity import MoE
@@ -54,15 +53,17 @@ def main() -> None:
         input_ids = tokenizer(prompt, return_tensors="pt").input_ids
         n_prompt = input_ids.shape[1]
 
+        # Both sides go through the native engine: plain greedy (no drafter)
+        # vs the DFlash strategy attached via speculative_draft (per-call).
         baseline = moe.generate(
             input_ids, max_new_tokens=args.max_new_tokens, do_sample=False
         )[0].tolist()
-        with torch.inference_mode():
-            speculative = speculator.generate(
-                input_ids,
-                max_new_tokens=args.max_new_tokens,
-                temperature=0.0,
-            )[0].tolist()
+        speculative = moe.generate(
+            input_ids,
+            max_new_tokens=args.max_new_tokens,
+            do_sample=False,
+            speculative_draft=speculator,
+        )[0].tolist()
 
         agreement = token_agreement_rate(
             baseline[n_prompt:], speculative[n_prompt:]

--- a/tests/python/dflash/fixtures_tiny.py
+++ b/tests/python/dflash/fixtures_tiny.py
@@ -69,7 +69,7 @@ def make_tiny_target_config(
         num_local_experts=4,
         num_experts_per_tok=2,
         max_position_embeddings=64,
-        sliding_window=8,
+        sliding_window=128,
         attn_implementation="eager",
         tie_word_embeddings=False,
         rope_scaling={"rope_type": "default"},

--- a/tests/python/dflash/fixtures_tiny.py
+++ b/tests/python/dflash/fixtures_tiny.py
@@ -1,0 +1,287 @@
+"""Tiny, CPU-deterministic gpt-oss target + DFlash drafter doubles.
+
+Public fixture module for the DFlash autonomous test suite. It provides:
+
+* ``build_tiny_target`` — a real (but tiny) ``GptOssForCausalLM`` in fp32 on CPU,
+  faithful to the target contract downstream tasks rely on: ``output_hidden_states``
+  (``num_hidden_layers + 1`` states), ``logits_to_keep``, ``embed_tokens`` /
+  ``lm_head``, and a ``DynamicCache`` past that supports ``.crop()``.
+* ``TinyDFlashDrafter`` / ``build_tiny_drafter`` — a matching drafter stand-in that
+  mirrors the RFC §1.2 forward contract: reuses the target ``embed_tokens`` +
+  ``lm_head``, projects the concatenated 5-layer context feature (``fc``: 5H→H,
+  then RMSNorm) and KV-injects it into every layer with NON-causal attention.
+* ``plain_greedy_decode`` — the ground-truth greedy generator.
+* ``set_determinism`` / ``context_feature_from_hidden_states`` helpers.
+
+By design this module contains NO DFlash acceptance / verify / rollback logic;
+that state machine is the code under test in Task 6.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from types import SimpleNamespace
+from typing import Any, Optional, Sequence
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from moe_infinity.spec_decode import read_dflash_config
+
+TINY_HIDDEN = 32
+TINY_VOCAB = 64
+TINY_NUM_LAYERS = 6
+TINY_TARGET_LAYER_IDS = (1, 2, 3, 4, 5)
+TINY_BLOCK_SIZE = 10
+TINY_MASK_TOKEN_ID = TINY_VOCAB - 1
+
+_TARGET_HEADS = 4
+_TARGET_KV_HEADS = 2
+_TARGET_HEAD_DIM = 8
+_DRAFTER_LAYERS = 2
+_DRAFTER_HEADS = 4
+
+
+def set_determinism(seed: int = 0) -> None:
+    torch.manual_seed(seed)
+    torch.use_deterministic_algorithms(True, warn_only=True)
+    torch.set_num_threads(1)
+
+
+def make_tiny_target_config(
+    *,
+    num_hidden_layers: int = TINY_NUM_LAYERS,
+    hidden_size: int = TINY_HIDDEN,
+    vocab_size: int = TINY_VOCAB,
+) -> Any:
+    from transformers import GptOssConfig
+
+    return GptOssConfig(
+        vocab_size=vocab_size,
+        hidden_size=hidden_size,
+        intermediate_size=hidden_size,
+        num_hidden_layers=num_hidden_layers,
+        num_attention_heads=_TARGET_HEADS,
+        num_key_value_heads=_TARGET_KV_HEADS,
+        head_dim=_TARGET_HEAD_DIM,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=64,
+        sliding_window=8,
+        attn_implementation="eager",
+        tie_word_embeddings=False,
+        rope_scaling={"rope_type": "default"},
+    )
+
+
+def build_tiny_target(seed: int = 0, **config_kwargs: Any) -> Any:
+    from transformers import GptOssForCausalLM
+
+    set_determinism(seed)
+    config = make_tiny_target_config(**config_kwargs)
+    torch.manual_seed(seed)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        model = GptOssForCausalLM(config)
+    return model.to(torch.float32).eval()
+
+
+def make_tiny_drafter_config(
+    target_config: Any = None,
+    *,
+    block_size: int = TINY_BLOCK_SIZE,
+    target_layer_ids: Sequence[int] = TINY_TARGET_LAYER_IDS,
+    mask_token_id: int = TINY_MASK_TOKEN_ID,
+    hidden_size: Optional[int] = None,
+    vocab_size: Optional[int] = None,
+    num_target_layers: Optional[int] = None,
+) -> SimpleNamespace:
+    if target_config is not None:
+        if hidden_size is None:
+            hidden_size = int(target_config.hidden_size)
+        if vocab_size is None:
+            vocab_size = int(target_config.vocab_size)
+        if num_target_layers is None:
+            num_target_layers = int(target_config.num_hidden_layers)
+    return SimpleNamespace(
+        block_size=block_size,
+        hidden_size=hidden_size if hidden_size is not None else TINY_HIDDEN,
+        vocab_size=vocab_size if vocab_size is not None else TINY_VOCAB,
+        num_target_layers=(
+            num_target_layers if num_target_layers is not None else TINY_NUM_LAYERS
+        ),
+        dflash_config={
+            "mask_token_id": mask_token_id,
+            "target_layer_ids": list(target_layer_ids),
+        },
+    )
+
+
+def context_feature_from_hidden_states(
+    hidden_states: Sequence[torch.Tensor],
+    target_layer_ids: Sequence[int] = TINY_TARGET_LAYER_IDS,
+) -> torch.Tensor:
+    return torch.cat([hidden_states[i + 1] for i in target_layer_ids], dim=-1)
+
+
+class _RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        variance = x.pow(2).mean(-1, keepdim=True)
+        return self.weight * (x * torch.rsqrt(variance + self.eps))
+
+
+class _NonCausalBlock(nn.Module):
+    def __init__(self, hidden_size: int, num_heads: int) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = hidden_size // num_heads
+        self.q_proj = nn.Linear(hidden_size, hidden_size, bias=True)
+        self.k_proj = nn.Linear(hidden_size, hidden_size, bias=True)
+        self.v_proj = nn.Linear(hidden_size, hidden_size, bias=True)
+        self.o_proj = nn.Linear(hidden_size, hidden_size, bias=True)
+        self.attn_norm = _RMSNorm(hidden_size)
+        self.mlp_norm = _RMSNorm(hidden_size)
+        self.gate_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.down_proj = nn.Linear(hidden_size, hidden_size, bias=False)
+
+    def _heads(self, x: torch.Tensor, batch: int, length: int) -> torch.Tensor:
+        return x.view(batch, length, self.num_heads, self.head_dim).transpose(1, 2)
+
+    def forward(self, noise: torch.Tensor, ctx: torch.Tensor) -> torch.Tensor:
+        batch, block, hidden = noise.shape
+        ctx_len = ctx.shape[1]
+        normed = self.attn_norm(noise)
+        # KV spans the injected context followed by the block; every query
+        # attends over all of it (non-causal) — the core DFlash injection.
+        kv_source = torch.cat([ctx, normed], dim=1)
+        q = self._heads(self.q_proj(normed), batch, block)
+        k = self._heads(self.k_proj(kv_source), batch, ctx_len + block)
+        v = self._heads(self.v_proj(kv_source), batch, ctx_len + block)
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(self.head_dim)
+        weights = torch.softmax(scores, dim=-1)
+        attended = torch.matmul(weights, v).transpose(1, 2).reshape(batch, block, hidden)
+        noise = noise + self.o_proj(attended)
+        gated = self.down_proj(F.silu(self.gate_proj(self.mlp_norm(noise))) * self.up_proj(self.mlp_norm(noise)))
+        return noise + gated
+
+
+class TinyDFlashDrafter(nn.Module):
+    is_causal = False
+
+    def __init__(
+        self,
+        config: Any,
+        embed_tokens: nn.Module,
+        lm_head: nn.Module,
+        *,
+        num_layers: int = _DRAFTER_LAYERS,
+        num_heads: int = _DRAFTER_HEADS,
+    ) -> None:
+        super().__init__()
+        hidden = int(config.hidden_size)
+        self.block_size = int(config.block_size)
+        self.mask_token_id = int(config.mask_token_id)
+        self.target_layer_ids = list(config.target_layer_ids)
+        # Reuse the target modules by reference without registering them as
+        # drafter submodules (they belong to, and are placed by, the target).
+        object.__setattr__(self, "embed_tokens", embed_tokens)
+        object.__setattr__(self, "lm_head", lm_head)
+        self.fc = nn.Linear(len(self.target_layer_ids) * hidden, hidden, bias=False)
+        self.hidden_norm = _RMSNorm(hidden)
+        self.layers = nn.ModuleList(
+            [_NonCausalBlock(hidden, num_heads) for _ in range(num_layers)]
+        )
+        self.norm = _RMSNorm(hidden)
+
+    def forward(
+        self, block_ids: torch.Tensor, context_feature: torch.Tensor
+    ) -> torch.Tensor:
+        noise = self.embed_tokens(block_ids)
+        ctx = self.hidden_norm(self.fc(context_feature))
+        hidden = noise
+        for layer in self.layers:
+            hidden = layer(hidden, ctx)
+        return self.norm(hidden)
+
+
+def build_tiny_drafter(
+    target: Any,
+    seed: int = 1,
+    *,
+    block_size: int = TINY_BLOCK_SIZE,
+    target_layer_ids: Sequence[int] = TINY_TARGET_LAYER_IDS,
+    num_layers: int = _DRAFTER_LAYERS,
+    num_heads: int = _DRAFTER_HEADS,
+) -> TinyDFlashDrafter:
+    draft_config_ns = make_tiny_drafter_config(
+        target.config, block_size=block_size, target_layer_ids=target_layer_ids
+    )
+    config = read_dflash_config(draft_config_ns)
+    if max(config.target_layer_ids) + 1 > int(target.config.num_hidden_layers):
+        raise ValueError(
+            f"tiny drafter target_layer_ids {config.target_layer_ids} exceed target "
+            f"depth {target.config.num_hidden_layers}"
+        )
+
+    embed_tokens = target.get_input_embeddings()
+    lm_head = target.get_output_embeddings()
+    if lm_head is None:
+        lm_head = target.lm_head
+
+    set_determinism(seed)
+    drafter = TinyDFlashDrafter(
+        config, embed_tokens, lm_head, num_layers=num_layers, num_heads=num_heads
+    )
+    return drafter.to(torch.float32).eval()
+
+
+@torch.no_grad()
+def plain_greedy_decode(
+    model: Any,
+    input_ids: torch.Tensor,
+    max_new_tokens: int,
+    eos_token_id: Optional[int] = None,
+) -> torch.Tensor:
+    model.eval()
+    generated = input_ids.clone()
+
+    output = model(generated, use_cache=True)
+    past = output.past_key_values
+    next_token = output.logits[:, -1, :].argmax(dim=-1, keepdim=True)
+    generated = torch.cat([generated, next_token], dim=1)
+
+    for _ in range(max_new_tokens - 1):
+        if eos_token_id is not None and int(next_token.item()) == int(eos_token_id):
+            break
+        output = model(next_token, past_key_values=past, use_cache=True)
+        past = output.past_key_values
+        next_token = output.logits[:, -1, :].argmax(dim=-1, keepdim=True)
+        generated = torch.cat([generated, next_token], dim=1)
+
+    return generated
+
+
+__all__ = [
+    "TINY_BLOCK_SIZE",
+    "TINY_HIDDEN",
+    "TINY_MASK_TOKEN_ID",
+    "TINY_NUM_LAYERS",
+    "TINY_TARGET_LAYER_IDS",
+    "TINY_VOCAB",
+    "TinyDFlashDrafter",
+    "build_tiny_drafter",
+    "build_tiny_target",
+    "context_feature_from_hidden_states",
+    "make_tiny_drafter_config",
+    "make_tiny_target_config",
+    "plain_greedy_decode",
+    "set_determinism",
+]

--- a/tests/python/dflash/test_accept_rule.py
+++ b/tests/python/dflash/test_accept_rule.py
@@ -1,0 +1,182 @@
+"""Hand-checked unit tests for the DFlash accept-rule + block-build pure ops.
+
+Autonomous correctness gate for Task 3 of
+``.sisyphus/plans/gpt-oss-dflash-native-integration.md``. Pure, CPU-only tensor
+helpers only -- no model loading, no KV/state-machine logic.
+
+Accept rule (RFC 1.2), for ``block_size = 10`` (1 anchor + 9 masks):
+
+    block     = [anchor, d1, ..., d9]                       # drafter candidates
+    posterior = [p0, ..., p9]                               # argmax of the verify
+    accept    = cumprod(block[:, 1:] == posterior[:, :-1]).sum()
+
+``cumprod`` stops at the first mismatch, so ``accept`` counts leading matches
+(0..block_size-1). The step then emits the ``accept`` accepted drafts plus one
+bonus token ``posterior[:, accept]`` (the target's correction / next anchor).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from moe_infinity.spec_decode._dflash_ops import (
+    acceptance_length,
+    build_block,
+    committed_tokens,
+)
+
+BLOCK_SIZE = 10
+MASK = 200000
+ANCHOR = 100
+DRAFTS = [10 + i for i in range(1, BLOCK_SIZE)]  # d1..d9 = 11..19
+
+
+def _row(values) -> torch.Tensor:
+    return torch.tensor([list(values)], dtype=torch.long)
+
+
+def _make_case(k: int):
+    """Return ``(block, posterior, expected_accept=k)`` for a hand-checked case.
+
+    Posterior is laid out so that ``acceptance_length`` is exactly ``k``:
+    positions ``0..k-1`` equal ``d_{i+1}`` (match); position ``k`` (if ``k<9``)
+    is ``900+k`` (forced mismatch); positions ``k+1..8`` are arbitrary
+    (post-cumprod, irrelevant); position 9 is ``999``. Hence the bonus token
+    ``posterior[:, k]`` is ``900+k`` for ``k<9`` and ``999`` for ``k==9``.
+    """
+    assert 0 <= k <= BLOCK_SIZE - 1
+    block = [ANCHOR] + DRAFTS[:]
+
+    posterior = [0] * BLOCK_SIZE
+    for i in range(k):
+        posterior[i] = DRAFTS[i]
+    if k < BLOCK_SIZE - 1:
+        posterior[k] = 900 + k
+        for i in range(k + 1, BLOCK_SIZE - 1):
+            posterior[i] = 800 + i
+    posterior[BLOCK_SIZE - 1] = 999
+
+    return _row(block), _row(posterior), k
+
+
+def test_build_block_shape_and_contents():
+    block = build_block(_row([ANCHOR]), MASK, BLOCK_SIZE)
+    assert block.shape == (1, BLOCK_SIZE)
+    assert block.dtype == torch.long
+    assert block[0, 0].item() == ANCHOR
+    assert block[0, 1:].tolist() == [MASK] * (BLOCK_SIZE - 1)
+
+
+def test_build_block_mask_count_is_block_size_minus_one():
+    block = build_block(_row([ANCHOR]), MASK, BLOCK_SIZE)
+    assert (block[0] == MASK).sum().item() == BLOCK_SIZE - 1
+
+
+@pytest.mark.parametrize("anchor", [ANCHOR, _row([ANCHOR]), torch.tensor([[ANCHOR]])])
+def test_build_block_accepts_int_and_tensor_anchor(anchor):
+    block = build_block(anchor, MASK, BLOCK_SIZE)
+    assert block.shape == (1, BLOCK_SIZE)
+    assert block[0, 0].item() == ANCHOR
+    assert block[0, 1:].tolist() == [MASK] * (BLOCK_SIZE - 1)
+
+
+def test_build_block_preserves_device_of_tensor_anchor():
+    anchor = _row([ANCHOR])
+    assert build_block(anchor, MASK, BLOCK_SIZE).device == anchor.device
+
+
+def test_acceptance_full_accept_equals_block_size_minus_one():
+    block, posterior, _ = _make_case(BLOCK_SIZE - 1)
+    assert acceptance_length(block, posterior) == BLOCK_SIZE - 1 == 9
+
+
+def test_acceptance_first_mismatch_at_k():
+    k = 4
+    block, posterior, _ = _make_case(k)
+    assert acceptance_length(block, posterior) == k
+
+
+def test_acceptance_none_immediate_mismatch():
+    block, posterior, _ = _make_case(0)
+    assert acceptance_length(block, posterior) == 0
+
+
+@pytest.mark.parametrize("k", list(range(BLOCK_SIZE)))
+def test_acceptance_length_matches_expected_for_every_k(k):
+    block, posterior, expected = _make_case(k)
+    assert acceptance_length(block, posterior) == expected
+
+
+def test_acceptance_length_returns_python_int():
+    block, posterior, _ = _make_case(3)
+    assert isinstance(acceptance_length(block, posterior), int)
+
+
+def test_acceptance_explicit_handchecked_vector():
+    #   block[:, 1:]      = [11, 12, 13, 14, 15, 16, 17, 18, 19]
+    #   posterior[:, :-1] = [11, 12, 13, 77, 55,  0,  0,  0,  0]
+    #   matches           = [ T,  T,  T,  F,  F,  F,  F,  F,  F]  => cumprod sum = 3
+    block = _row([100, 11, 12, 13, 14, 15, 16, 17, 18, 19])
+    posterior = _row([11, 12, 13, 77, 55, 0, 0, 0, 0, 999])
+    assert acceptance_length(block, posterior) == 3
+
+
+def test_committed_accept0_emits_single_bonus_token():
+    # QA task-3-bonus-token: accept==0 => 1 emitted token == posterior[:, 0].
+    block, posterior, _ = _make_case(0)
+    res = committed_tokens(block, posterior, accept=0)
+    assert res.emitted.shape == (1, 1)
+    assert res.emitted[0, 0].item() == posterior[0, 0].item()
+
+
+def test_committed_accept9_emits_ten_tokens_last_is_bonus():
+    # QA task-3-bonus-token: accept==9 => 10 emitted tokens, last == posterior[:, 9].
+    block, posterior, _ = _make_case(BLOCK_SIZE - 1)
+    res = committed_tokens(block, posterior, accept=BLOCK_SIZE - 1)
+    assert res.emitted.shape == (1, BLOCK_SIZE)
+    assert res.emitted[0, -1].item() == posterior[0, BLOCK_SIZE - 1].item()
+
+
+@pytest.mark.parametrize("k", list(range(BLOCK_SIZE)))
+def test_committed_emitted_is_accepted_drafts_then_bonus(k):
+    block, posterior, _ = _make_case(k)
+    res = committed_tokens(block, posterior, accept=k)
+    assert res.emitted.shape == (1, k + 1)
+    if k > 0:
+        assert res.emitted[0, :k].tolist() == block[0, 1 : k + 1].tolist()
+    assert res.bonus.shape == (1, 1)
+    assert res.bonus[0, 0].item() == posterior[0, k].item()
+    assert res.emitted[0, -1].item() == posterior[0, k].item()
+
+
+@pytest.mark.parametrize("k", list(range(BLOCK_SIZE)))
+def test_committed_block_prefix_is_anchor_plus_accepted_drafts(k):
+    # block_prefix = block[:, :accept+1] (anchor + accepted drafts): the KV-retained
+    # slice (start += accept+1). The bonus is excluded -- emitted-but-not-cached.
+    block, posterior, _ = _make_case(k)
+    res = committed_tokens(block, posterior, accept=k)
+    assert res.block_prefix.shape == (1, k + 1)
+    assert res.block_prefix[0].tolist() == block[0, : k + 1].tolist()
+    assert res.block_prefix[0, 0].item() == ANCHOR
+
+
+def test_committed_bonus_absent_from_cached_prefix_on_partial_accept():
+    block, posterior, _ = _make_case(4)
+    res = committed_tokens(block, posterior, accept=4)
+    assert res.bonus[0, 0].item() == posterior[0, 4].item()
+    assert res.bonus[0, 0].item() not in res.block_prefix[0].tolist()
+
+
+def test_build_then_accept_then_commit_full_pipeline():
+    block = build_block(_row([ANCHOR]), MASK, BLOCK_SIZE)
+    block[0, 1:] = _row(DRAFTS)
+    posterior = _row(DRAFTS + [999])
+
+    accept = acceptance_length(block, posterior)
+    assert accept == BLOCK_SIZE - 1
+
+    res = committed_tokens(block, posterior, accept=accept)
+    assert res.emitted[0].tolist() == DRAFTS + [999]
+    assert res.block_prefix[0].tolist() == [ANCHOR] + DRAFTS
+    assert res.bonus[0, 0].item() == 999

--- a/tests/python/dflash/test_capture.py
+++ b/tests/python/dflash/test_capture.py
@@ -1,0 +1,184 @@
+"""Task 2: rich on-device forward helper + 5-layer hidden-state capture.
+
+Covers `_native_model_forward_rich` and `extract_context_feature` in
+`moe_infinity/entrypoints/big_modeling.py`:
+
+1. Capture returns the 5-layer concat with last dim == 5 * hidden, on the
+   model device (NOT the CPU-detach path of `_native_model_forward`), with
+   the model dtype.
+2. Capture-on greedy decode is byte-identical to capture-off greedy decode
+   (the capture must not perturb the forward).
+
+The tiny gpt-oss-like target is built INLINE here (no T5-fixture imports —
+those are owned by a parallel task) and runs on CPU or GPU, fp32, seeded.
+"""
+
+from types import SimpleNamespace
+
+import torch
+from transformers.models.gpt_oss import GptOssConfig, GptOssForCausalLM
+
+from moe_infinity.entrypoints.big_modeling import (
+    MoE,
+    extract_context_feature,
+)
+
+TINY_HIDDEN = 64
+TINY_LAYERS = 6
+# Scaled stand-in for the real gpt-oss-120b DFlash ids (1, 9, 17, 25, 33).
+TINY_LAYER_IDS = (0, 1, 2, 3, 4)
+DEVICE = (
+    torch.device("cuda:0") if torch.cuda.is_available() else torch.device("cpu")
+)
+
+PROMPT = [3, 1, 4, 1, 5, 9, 2, 6]
+
+
+def _tiny_config() -> GptOssConfig:
+    return GptOssConfig(
+        vocab_size=512,
+        hidden_size=TINY_HIDDEN,
+        intermediate_size=128,
+        num_hidden_layers=TINY_LAYERS,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        sliding_window=128,
+        max_position_embeddings=512,
+        rope_parameters={
+            "rope_type": "yarn",
+            "factor": 1.0,
+            "original_max_position_embeddings": 512,
+            "rope_theta": 150000.0,
+        },
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_model(seed: int = 0) -> GptOssForCausalLM:
+    torch.manual_seed(seed)
+    return GptOssForCausalLM(_tiny_config()).to(DEVICE).eval()
+
+
+def _moe_shell(model: GptOssForCausalLM) -> MoE:
+    """Bare MoE instance (no checkpoint load) exposing the forward helpers."""
+    shell = MoE.__new__(MoE)
+    shell.model = model
+    shell._cached_past_key_values = None
+    shell._native_attention_backend = None
+    return shell
+
+
+def _greedy_ids(shell: MoE, rich: bool, n_tokens: int) -> list[int]:
+    shell._cached_past_key_values = None
+    generated: list[int] = []
+    step_ids = list(PROMPT)
+    for step in range(n_tokens):
+        meta = None if step == 0 else SimpleNamespace(is_prefill=False)
+        if rich:
+            logits, _, _ = shell._native_model_forward_rich(
+                step_ids, meta, logits_to_keep=1
+            )
+            next_id = int(logits[0, -1].argmax().item())
+        else:
+            logits = shell._native_model_forward(step_ids, meta)
+            next_id = int(logits[-1].argmax().item())
+        generated.append(next_id)
+        step_ids = [next_id]
+    return generated
+
+
+def test_rich_forward_capture_shape_device_dtype():
+    model = _tiny_model()
+    shell = _moe_shell(model)
+    param = next(model.parameters())
+
+    logits, hidden_states, past_kv = shell._native_model_forward_rich(
+        PROMPT, None, logits_to_keep=1
+    )
+
+    vocab = model.config.vocab_size
+    assert isinstance(logits, torch.Tensor)
+    assert logits.shape == (1, 1, vocab)
+    # On-device: same device/dtype as the model weights (the baseline helper
+    # would have detached to CPU here).
+    assert logits.device == param.device
+    assert logits.dtype == param.dtype
+    if param.device.type == "cuda":
+        assert logits.device.type == "cuda"
+
+    assert isinstance(hidden_states, tuple)
+    assert len(hidden_states) == TINY_LAYERS + 1  # embeddings + layers
+    assert hidden_states[0].shape == (1, len(PROMPT), TINY_HIDDEN)
+
+    feat = extract_context_feature(hidden_states, layer_ids=TINY_LAYER_IDS)
+    assert feat.shape == (1, len(PROMPT), 5 * TINY_HIDDEN)
+    assert feat.device == param.device
+    assert feat.dtype == param.dtype
+
+    assert past_kv is not None
+    assert past_kv.get_seq_length() == len(PROMPT)
+
+
+def test_extract_context_feature_default_layer_ids_mapping():
+    # 35 entries (embeddings + 34 layers) so the real default ids index in.
+    width = 8
+    hidden_states = tuple(
+        torch.full((1, 3, width), float(i)) for i in range(35)
+    )
+    feat = extract_context_feature(hidden_states)
+    assert feat.shape == (1, 3, 5 * width)
+    # Default ids (1, 9, 17, 25, 33) map to tuple indices id + 1.
+    for slot, src_idx in enumerate((2, 10, 18, 26, 34)):
+        block = feat[0, :, slot * width : (slot + 1) * width]
+        assert torch.all(block == float(src_idx))
+
+
+def test_extract_context_feature_out_of_range_raises():
+    hidden_states = tuple(torch.zeros(1, 2, 4) for _ in range(3))
+    try:
+        extract_context_feature(hidden_states, layer_ids=(5,))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for out-of-range layer id")
+
+
+def test_logits_to_keep_passthrough():
+    model = _tiny_model()
+    shell = _moe_shell(model)
+
+    full_logits, hidden_states, _ = shell._native_model_forward_rich(
+        PROMPT, None, logits_to_keep=0
+    )
+    assert full_logits.shape == (1, len(PROMPT), model.config.vocab_size)
+    # Hidden-state capture is full-length even when logits are kept in full.
+    assert hidden_states[-1].shape[1] == len(PROMPT)
+
+    shell._cached_past_key_values = None
+    kept_logits, _, _ = shell._native_model_forward_rich(
+        PROMPT, None, logits_to_keep=1
+    )
+    assert kept_logits.shape == (1, 1, model.config.vocab_size)
+    # The kept row is the last row of the full-logits forward. GEMM-shape
+    # differences allow low-bit FP wobble on GPU, so the contract is
+    # argmax-identical (the DFlash losslessness rule) + numerically tight.
+    assert torch.allclose(
+        full_logits[:, -1:, :], kept_logits, rtol=1e-4, atol=1e-5
+    )
+    assert int(full_logits[0, -1].argmax().item()) == int(
+        kept_logits[0, -1].argmax().item()
+    )
+
+
+def test_capture_on_off_greedy_byte_identical():
+    model = _tiny_model()
+    shell = _moe_shell(model)
+
+    baseline_ids = _greedy_ids(shell, rich=False, n_tokens=16)
+    capture_ids = _greedy_ids(shell, rich=True, n_tokens=16)
+
+    assert len(baseline_ids) == 16
+    assert capture_ids == baseline_ids

--- a/tests/python/dflash/test_drafter_load.py
+++ b/tests/python/dflash/test_drafter_load.py
@@ -1,0 +1,150 @@
+"""Contract-assert tests for the hardened DFlash drafter loader (Task 4).
+
+Uses FAKE config/model objects only (no network, no checkpoint download, no
+GPU). ``DFlashSpeculator.__init__`` calls the same helpers on the
+``AutoModel.from_pretrained(..., trust_remote_code=True)`` drafter.
+
+Enforced contract (z-lab/gpt-oss-120b-DFlash):
+    hidden_size == target.hidden_size
+    fc.in_features == 5 * hidden_size            (== 14400)
+    mask_token_id (200000) < vocab_size
+    block_size == 10
+    target_layer_ids == [1, 9, 17, 25, 33]
+    vocab_size == target.vocab_size
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from moe_infinity.spec_decode.dflash import (
+    bind_shared_weights,
+    read_dflash_config,
+    validate_drafter,
+    validate_pairing,
+)
+
+
+def _fake_draft_config(
+    *,
+    block_size=10,
+    hidden_size=2880,
+    vocab_size=201088,
+    mask_token_id=200000,
+    target_layer_ids=None,
+    num_target_layers=36,
+):
+    return SimpleNamespace(
+        block_size=block_size,
+        hidden_size=hidden_size,
+        vocab_size=vocab_size,
+        num_target_layers=num_target_layers,
+        dflash_config={
+            "mask_token_id": mask_token_id,
+            "target_layer_ids": list(target_layer_ids or [1, 9, 17, 25, 33]),
+        },
+    )
+
+
+def _fake_drafter(*, fc_in_features=14400, **cfg_kwargs):
+    return SimpleNamespace(
+        config=_fake_draft_config(**cfg_kwargs),
+        fc=SimpleNamespace(in_features=fc_in_features),
+    )
+
+
+def _fake_target_config(*, hidden_size=2880, vocab_size=201088, num_hidden_layers=36):
+    return SimpleNamespace(
+        hidden_size=hidden_size,
+        vocab_size=vocab_size,
+        num_hidden_layers=num_hidden_layers,
+    )
+
+
+def test_validate_drafter_accepts_matching_contract():
+    validate_drafter(_fake_drafter(), _fake_target_config())
+
+
+def test_validate_drafter_accepts_when_config_precomputed():
+    drafter = _fake_drafter()
+    cfg = read_dflash_config(drafter.config)
+    validate_drafter(drafter, _fake_target_config(), draft_cfg=cfg)
+
+
+def test_validate_drafter_rejects_fc_in_features_mismatch():
+    with pytest.raises(ValueError, match="in_features"):
+        validate_drafter(_fake_drafter(fc_in_features=9999), _fake_target_config())
+
+
+def test_validate_drafter_requires_fc_projection():
+    drafter = SimpleNamespace(config=_fake_draft_config())
+    with pytest.raises(ValueError, match="fc"):
+        validate_drafter(drafter, _fake_target_config())
+
+
+def test_validate_pairing_rejects_hidden_mismatch():
+    cfg = read_dflash_config(_fake_draft_config(hidden_size=2880))
+    with pytest.raises(ValueError, match="hidden_size"):
+        validate_pairing(cfg, _fake_target_config(hidden_size=4096))
+
+
+def test_validate_pairing_rejects_mask_ge_vocab():
+    cfg = read_dflash_config(_fake_draft_config(mask_token_id=201088))
+    with pytest.raises(ValueError, match="mask_token_id"):
+        validate_pairing(cfg, _fake_target_config())
+
+
+def test_validate_pairing_rejects_block_size_mismatch():
+    cfg = read_dflash_config(_fake_draft_config(block_size=8))
+    with pytest.raises(ValueError, match="block_size"):
+        validate_pairing(cfg, _fake_target_config())
+
+
+def test_validate_pairing_rejects_target_layer_ids_mismatch():
+    cfg = read_dflash_config(_fake_draft_config(target_layer_ids=[1, 9, 17, 25, 34]))
+    with pytest.raises(ValueError, match="target_layer_ids"):
+        validate_pairing(cfg, _fake_target_config())
+
+
+def test_validate_pairing_rejects_vocab_mismatch():
+    cfg = read_dflash_config(_fake_draft_config(vocab_size=201088))
+    with pytest.raises(ValueError, match="vocab_size"):
+        validate_pairing(cfg, _fake_target_config(vocab_size=201000))
+
+
+def test_bind_shared_weights_uses_target_references():
+    embed = SimpleNamespace(tag="embed")
+    lm_head = SimpleNamespace(tag="lm_head")
+    target = SimpleNamespace(
+        get_input_embeddings=lambda: embed,
+        get_output_embeddings=lambda: lm_head,
+    )
+    drafter = SimpleNamespace()
+
+    embed_ref, lm_head_ref = bind_shared_weights(drafter, target)
+
+    assert drafter.embed_tokens is embed
+    assert drafter.lm_head is lm_head
+    assert embed_ref is embed
+    assert lm_head_ref is lm_head
+
+
+def test_bind_shared_weights_falls_back_to_attributes():
+    embed = SimpleNamespace(tag="embed")
+    lm_head = SimpleNamespace(tag="lm_head")
+    target = SimpleNamespace(
+        model=SimpleNamespace(embed_tokens=embed),
+        lm_head=lm_head,
+    )
+    drafter = SimpleNamespace()
+
+    bind_shared_weights(drafter, target)
+
+    assert drafter.embed_tokens is embed
+    assert drafter.lm_head is lm_head
+
+
+def test_bind_shared_weights_raises_when_embeddings_unresolvable():
+    target = SimpleNamespace()
+    with pytest.raises(ValueError, match="embed"):
+        bind_shared_weights(SimpleNamespace(), target)

--- a/tests/python/dflash/test_edge_cases.py
+++ b/tests/python/dflash/test_edge_cases.py
@@ -1,0 +1,335 @@
+"""Task 7: edge-case handling in the native DFlash loop.
+
+Pins the six Task-7 edge cases on the tiny CPU fixtures (T5), with forced
+accept lengths / EOS placements via a scripted drafter head and targeted
+target-argmax overrides:
+
+(a) first step — the anchor comes from the prefill forward over the prompt.
+(b) full-accept (``accept == block_size - 1 == 9``) — commit 10, continue.
+(c) full-reject (``accept == 0``) — commit exactly 1 (the bonus becomes the
+    next anchor); start advances by 1.
+(d) EOS inside a block — emitted is truncated at the first stop id
+    (inclusive), the loop stops, and neither cache extends past the last
+    kept token. Covered for an EOS as an *accepted draft* (block position 3;
+    cached, since it went through the verify forward) and as the *bonus*
+    (emitted but not cached, so the cache trails the emitted sequence by
+    one), plus EOS as the prefill anchor (stop before the first block).
+(e) ``max_new_tokens`` crossing a block boundary — the step that would
+    overshoot is truncated to the remaining budget and the loop stops; the
+    return is exactly ``max_new_tokens`` new tokens and the cache is cropped
+    to the truncated ``start``.
+(f) batch > 1 — raises ``NotImplementedError`` naming the batch==1
+    constraint (v1 is single-sequence).
+
+State accounting: ``committed.emitted = [d_1 .. d_accept, bonus]`` while the
+verify-forward KV covers ``[anchor, d_1 .. d_accept]`` only. Keeping ``k``
+emitted tokens therefore commits ``min(k, accept) + 1`` cached tokens
+(anchor + min(k, accept) drafts); the bonus is never cached. The step trace
+records the *effective* accept (drafts actually committed), so the Task-6
+invariant ``start == prev_start + accept + 1`` holds in every branch.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    TINY_BLOCK_SIZE,
+    TINY_HIDDEN,
+    TINY_VOCAB,
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+)
+
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+
+PROMPT = torch.tensor([[3, 7, 11, 2, 5]])
+PROMPT_LEN = int(PROMPT.shape[1])
+EOS_ID = 62  # absent from the tiny target's greedy continuation for PROMPT
+
+_TARGET = None
+_DRAFTER = None
+
+
+def _tiny_spec():
+    """Fresh speculator per test (cheap ``from_models``) over shared models."""
+    global _TARGET, _DRAFTER
+    if _TARGET is None:
+        _TARGET = build_tiny_target(seed=0)
+        _DRAFTER = build_tiny_drafter(_TARGET, seed=1)
+    config = read_dflash_config(make_tiny_drafter_config(_TARGET.config))
+    spec = DFlashSpeculator.from_models(_TARGET, _DRAFTER, config=config, device="cpu")
+    return spec, _TARGET
+
+
+def _greedy_full(target, n_new: int) -> list[int]:
+    """Absolute ids (prompt ++ greedy continuation) for indexing drafts."""
+    return plain_greedy_decode(target, PROMPT, max_new_tokens=n_new)[0].tolist()
+
+
+class _ScriptedHead:
+    """Fake ``lm_head`` programming the drafter's per-position draft argmax.
+
+    ``draft_fn(call_index)`` must return the ``block_size - 1`` draft ids for
+    that drafter pass; the returned logits make the loop's
+    ``lm_head(drafter_out)[:, -(block_size-1):].argmax`` pick exactly them.
+    """
+
+    def __init__(self, draft_fn) -> None:
+        self.draft_fn = draft_fn
+        self.calls = 0
+
+    def __call__(self, hidden: torch.Tensor) -> torch.Tensor:
+        drafts = [int(t) for t in self.draft_fn(self.calls)]
+        self.calls += 1
+        assert len(drafts) == TINY_BLOCK_SIZE - 1
+        length = hidden.shape[1]
+        logits = torch.zeros(
+            1, length, TINY_VOCAB, dtype=hidden.dtype, device=hidden.device
+        )
+        for i, tok in enumerate(drafts):
+            logits[0, length - (TINY_BLOCK_SIZE - 1) + i, tok] = 1.0
+        return logits
+
+
+def _install_scripted_drafter(monkeypatch, spec, draft_fn) -> None:
+    """Bypass drafter compute; feed scripted draft ids into the accept rule.
+
+    The verify forward stays REAL (the genuine target), so acceptance is
+    exercised for real against the scripted drafts.
+    """
+    monkeypatch.setattr(
+        spec,
+        "_run_drafter",
+        lambda block, context_feature, start, draft_kv: torch.zeros(
+            1, TINY_BLOCK_SIZE, TINY_HIDDEN
+        ),
+    )
+    monkeypatch.setattr(spec, "lm_head", _ScriptedHead(draft_fn))
+
+
+def _force_target_argmax(monkeypatch, spec, *, prefill=None, verify=None):
+    """Override the target's argmax at chosen rows of the rich forward.
+
+    ``prefill``/``verify`` map ``row -> token_id``; the row's logits are
+    replaced by a one-hot so ``argmax`` yields ``token_id``. KV/hidden are
+    untouched, so the override only steers the discrete accept/emission
+    path (which is exactly what these tests pin).
+    """
+    orig = spec._forward_target
+
+    def wrapped(input_ids, past_key_values=None, logits_to_keep=0):
+        logits, hidden, kv = orig(
+            input_ids, past_key_values=past_key_values, logits_to_keep=logits_to_keep
+        )
+        rows = prefill if int(logits_to_keep) == 1 else verify
+        if rows:
+            logits = logits.clone()
+            for row, tok in rows.items():
+                logits[0, row, :] = -1e9
+                logits[0, row, int(tok)] = 1e9
+        return logits, hidden, kv
+
+    monkeypatch.setattr(spec, "_forward_target", wrapped)
+
+
+def _assert_trace_invariants(spec) -> None:
+    for rec in spec.step_trace:
+        assert rec.start == rec.prev_start + rec.accept + 1
+        assert rec.target_cache_len == rec.start
+
+
+# (a) first step: anchor from the prefill forward over the prompt only
+def test_first_step_anchor_from_prefill():
+    spec, target = _tiny_spec()
+
+    out = spec.generate(PROMPT, max_new_tokens=2)
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=2)
+
+    assert len(spec.step_trace) == 1
+    rec = spec.step_trace[0]
+    assert rec.prev_start == PROMPT_LEN
+    assert int(out[0, PROMPT_LEN].item()) == int(plain[0, PROMPT_LEN].item())
+    assert torch.equal(out, plain)
+
+
+# (b) full-accept: accept == block_size - 1 == 9 -> commit 10, continue
+def test_full_accept_commits_whole_block_and_continues(monkeypatch):
+    spec, target = _tiny_spec()
+    full = _greedy_full(target, 25)
+
+    # Drafts == true greedy continuation => every position accepted.
+    def draft_fn(step: int):
+        anchor_idx = PROMPT_LEN + TINY_BLOCK_SIZE * step
+        return full[anchor_idx + 1 : anchor_idx + TINY_BLOCK_SIZE]
+
+    _install_scripted_drafter(monkeypatch, spec, draft_fn)
+
+    max_new = 2 * TINY_BLOCK_SIZE + 1  # two exact full-accept steps
+    out = spec.generate(PROMPT, max_new_tokens=max_new)
+
+    assert len(spec.step_trace) == 2
+    for i, rec in enumerate(spec.step_trace):
+        assert rec.accept == TINY_BLOCK_SIZE - 1
+        assert rec.start == PROMPT_LEN + TINY_BLOCK_SIZE * (i + 1)
+    _assert_trace_invariants(spec)
+
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=max_new)
+    assert torch.equal(out, plain)
+
+
+# (c) full-reject: accept == 0 -> commit 1 (bonus becomes next anchor)
+def test_full_reject_commits_bonus_only(monkeypatch):
+    spec, target = _tiny_spec()
+    full = _greedy_full(target, 8)
+
+    # First draft mismatches the target's argmax => accept == 0 every step;
+    # the committed token is the bonus (true greedy token), the next anchor.
+    def draft_fn(step: int):
+        wrong = (full[PROMPT_LEN + step + 1] + 1) % TINY_VOCAB
+        return [wrong] * (TINY_BLOCK_SIZE - 1)
+
+    _install_scripted_drafter(monkeypatch, spec, draft_fn)
+
+    max_new = 5
+    out = spec.generate(PROMPT, max_new_tokens=max_new)
+
+    assert len(spec.step_trace) == max_new - 1  # one token per step
+    for i, rec in enumerate(spec.step_trace):
+        assert rec.accept == 0
+        assert rec.start == PROMPT_LEN + (i + 1)
+    _assert_trace_invariants(spec)
+
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=max_new)
+    assert torch.equal(out, plain)
+
+
+# (d) EOS inside a block
+def test_eos_mid_block_accepted_draft_truncates_and_stops(monkeypatch):
+    """QA headline: EOS at block position 3 (an accepted draft)."""
+    spec, target = _tiny_spec()
+    full = _greedy_full(target, 16)
+
+    other = 40  # forced posterior at the position after EOS (never emitted)
+    # d1, d2 = greedy (accepted); d3 = EOS (accepted via forced posterior);
+    # d4 forced to mismatch so accept == 3.
+    drafts = [full[PROMPT_LEN + 1], full[PROMPT_LEN + 2], EOS_ID, (other + 1) % TINY_VOCAB]
+    drafts += [0] * (TINY_BLOCK_SIZE - 1 - len(drafts))
+    _install_scripted_drafter(monkeypatch, spec, lambda step: drafts)
+    _force_target_argmax(monkeypatch, spec, verify={2: EOS_ID, 3: other})
+
+    out = spec.generate(PROMPT, max_new_tokens=40, stop_token_ids=[EOS_ID])
+
+    # One step only (loop stopped); the accept rule saw 3 accepted drafts.
+    assert len(spec.step_trace) == 1
+    rec = spec.step_trace[0]
+    assert rec.accept == 3
+
+    # Emitted ends exactly at EOS: the forced bonus and further blocks are
+    # never emitted despite the large max_new_tokens budget.
+    new_ids = out[0, PROMPT_LEN:].tolist()
+    assert new_ids == [full[PROMPT_LEN], full[PROMPT_LEN + 1], full[PROMPT_LEN + 2], EOS_ID]
+    assert other not in new_ids
+
+    # cache length == start_at_EOS: anchor + 3 drafts (the EOS draft DID go
+    # through the verify forward, so its KV stays).
+    assert rec.start == PROMPT_LEN + 4
+    assert rec.target_cache_len == PROMPT_LEN + 4
+    assert int(spec.last_target_cache.get_seq_length()) == PROMPT_LEN + 4
+    _assert_trace_invariants(spec)
+
+
+def test_eos_bonus_token_truncates_and_stops(monkeypatch):
+    """EOS as the bonus (emitted but NOT cached): cache trails emitted by 1."""
+    spec, target = _tiny_spec()
+    full = _greedy_full(target, 16)
+
+    # All drafts greedy; posterior row 2 forced to EOS => accept == 2 and
+    # the bonus token itself IS the EOS.
+    def draft_fn(step: int):
+        return full[PROMPT_LEN + 1 : PROMPT_LEN + TINY_BLOCK_SIZE]
+
+    _install_scripted_drafter(monkeypatch, spec, draft_fn)
+    _force_target_argmax(monkeypatch, spec, verify={2: EOS_ID})
+
+    out = spec.generate(PROMPT, max_new_tokens=40, stop_token_ids=[EOS_ID])
+
+    assert len(spec.step_trace) == 1
+    rec = spec.step_trace[0]
+    assert rec.accept == 2
+
+    new_ids = out[0, PROMPT_LEN:].tolist()
+    assert new_ids == [full[PROMPT_LEN], full[PROMPT_LEN + 1], full[PROMPT_LEN + 2], EOS_ID]
+
+    # The bonus is never forwarded, so the cache covers anchor + 2 accepted
+    # drafts only: exactly one behind the emitted sequence.
+    assert rec.start == PROMPT_LEN + 3
+    assert rec.target_cache_len == PROMPT_LEN + 3
+    assert int(spec.last_target_cache.get_seq_length()) == PROMPT_LEN + 3
+    assert (PROMPT_LEN + len(new_ids)) - rec.target_cache_len == 1
+    _assert_trace_invariants(spec)
+
+
+def test_eos_prefill_anchor_stops_before_first_block(monkeypatch):
+    """The prefill anchor itself is a stop id: emit it, run no block step."""
+    spec, _ = _tiny_spec()
+
+    _force_target_argmax(monkeypatch, spec, prefill={-1: EOS_ID}, verify={})
+    out = spec.generate(PROMPT, max_new_tokens=16, stop_token_ids=[EOS_ID])
+
+    assert out[0, PROMPT_LEN:].tolist() == [EOS_ID]
+    assert tuple(out.shape) == (1, PROMPT_LEN + 1)
+    assert spec.step_trace == []
+    assert int(spec.last_target_cache.get_seq_length()) == PROMPT_LEN
+
+
+# (e) max_new_tokens crossing a block boundary
+def test_max_new_tokens_truncates_at_block_boundary(monkeypatch):
+    spec, target = _tiny_spec()
+    full = _greedy_full(target, 25)
+
+    def draft_fn(step: int):
+        anchor_idx = PROMPT_LEN + TINY_BLOCK_SIZE * step
+        return full[anchor_idx + 1 : anchor_idx + TINY_BLOCK_SIZE]
+
+    _install_scripted_drafter(monkeypatch, spec, draft_fn)
+
+    max_new = TINY_BLOCK_SIZE + 5  # one full 10-token step + a 4-token step
+    out = spec.generate(PROMPT, max_new_tokens=max_new)
+
+    # Step 2 would have committed 10 but is truncated to the remaining
+    # budget of 4; the loop stops (no third step).
+    assert len(spec.step_trace) == 2
+    first, last = spec.step_trace
+    assert first.accept == TINY_BLOCK_SIZE - 1
+    assert first.start == PROMPT_LEN + TINY_BLOCK_SIZE
+    assert last.accept == 4  # effective accept: drafts actually committed
+    assert last.start == PROMPT_LEN + max_new
+    _assert_trace_invariants(spec)
+
+    # Exactly max_new_tokens new tokens, token-identical to plain greedy;
+    # the cache is cropped to the truncated start.
+    assert tuple(out.shape) == (1, PROMPT_LEN + max_new)
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=max_new)
+    assert torch.equal(out, plain)
+    assert int(spec.last_target_cache.get_seq_length()) == PROMPT_LEN + max_new
+
+
+# (f) batch > 1 guard
+def test_batch_greater_than_one_raises_not_implemented():
+    spec, _ = _tiny_spec()
+    batched = torch.cat([PROMPT, PROMPT], dim=0)
+    assert batched.shape[0] == 2
+    with pytest.raises(NotImplementedError, match="batch==1"):
+        spec.generate(batched, max_new_tokens=4)

--- a/tests/python/dflash/test_engine_wire.py
+++ b/tests/python/dflash/test_engine_wire.py
@@ -1,0 +1,272 @@
+"""Task 8: wire the native DFlash speculator as ``GenerationEngine.spec_strategy``.
+
+Pins the two Task-8 QA scenarios on the tiny CPU fixtures (T5), driving the
+REAL sync path end to end: ``MoE.generate(..., speculative_draft=...)`` ->
+``GenerationEngine.generate`` -> ``spec_strategy.run`` ->
+``DFlashSpeculator.generate`` (via ``MoE._native_model_forward_rich``).
+
+(a) happy: a greedy, batch==1 ``generate`` with a drafter configured routes
+    through the native strategy -- ``strategy.run`` is invoked exactly once and
+    the emitted ids are non-empty and identical to the standalone native loop.
+(b) negative: no drafter configured -> the ``_generate_standard`` path is used
+    and the output is byte-identical to the plain-engine baseline.
+
+Also pinned: omitting the kwarg detaches a previously attached strategy (the
+kwarg is per-call, never sticky), non-greedy params with a drafter configured
+still use the standard path (T1 gate), and batch>1 with a drafter fails loudly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+    set_determinism,
+)
+
+from moe_infinity.engine.generation_loop import GenerationEngine  # noqa: E402
+from moe_infinity.engine.types import SamplingParams  # noqa: E402
+from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
+from moe_infinity.memory.kv_cache_manager import KVCacheManager  # noqa: E402
+from moe_infinity.runtime.attention_types import KVCacheSpec  # noqa: E402
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+from moe_infinity.spec_decode.dflash import _resolve_stop_ids  # noqa: E402
+
+PROMPT = [3, 7, 11, 2, 5]
+MAX_NEW_TOKENS = 16
+DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def _tiny_moe_shell(seed: int = 0):
+    """An MoE instance shell around the tiny target with a real engine.
+
+    Mirrors the production wiring of ``_build_native_components`` (engine
+    holds ``model_forward_fn=shell._native_model_forward``) without the
+    offload runtime; ``_configure_hook`` is a no-op like in
+    ``test_native_step.py``.
+    """
+    set_determinism(seed)
+    target = build_tiny_target(seed=seed).to(DEVICE)
+    shell = MoE.__new__(MoE)
+    shell.model = target
+    shell.use_native_engine = True
+    shell.max_seq_length = 64
+    shell._cached_past_key_values = None
+    shell._native_attention_backend = None
+    shell._configure_hook = lambda input_ids: None
+
+    stop_ids = _resolve_stop_ids(target, None)
+    eos_token_id = stop_ids[0] if stop_ids else -1
+
+    engine = GenerationEngine(
+        kv_cache_manager=KVCacheManager(
+            num_gpu_blocks=64, num_cpu_blocks=16, block_size=4
+        ),
+        kv_spec=KVCacheSpec(
+            num_kv_heads=2, head_dim=8, dtype=torch.float32, block_size=4
+        ),
+        num_layers=int(target.config.num_hidden_layers),
+        vocab_size=int(target.config.vocab_size),
+        model_forward_fn=shell._native_model_forward,
+        eos_token_id=eos_token_id,
+        max_seq_length=64,
+    )
+    shell._native_generation_engine = engine
+    return shell, target
+
+
+def _tiny_speculator(shell, target):
+    drafter = build_tiny_drafter(target, seed=1).to(DEVICE)
+    config = read_dflash_config(make_tiny_drafter_config(target.config))
+    return DFlashSpeculator.from_models(
+        shell, drafter, config=config, device=DEVICE
+    )
+
+
+def _spy_on_run(spec: DFlashSpeculator):
+    calls = []
+    orig_run = spec.run
+
+    def run_spy(*, engine, prompt_token_ids, sampling_params, request_id=None):
+        calls.append(
+            {
+                "engine": engine,
+                "prompt_token_ids": list(prompt_token_ids),
+                "sampling_params": sampling_params,
+                "request_id": request_id,
+            }
+        )
+        return orig_run(
+            engine=engine,
+            prompt_token_ids=prompt_token_ids,
+            sampling_params=sampling_params,
+            request_id=request_id,
+        )
+
+    spec.run = run_spy
+    return calls
+
+
+def _moe_generate(shell, **kwargs):
+    input_ids = torch.tensor([PROMPT], dtype=torch.long)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return shell.generate(input_ids, **kwargs)
+
+
+def test_engine_routes_greedy_through_native_strategy():
+    """QA scenario (a): greedy batch==1 + drafter -> strategy.run once."""
+    shell, target = _tiny_moe_shell()
+    engine = shell._native_generation_engine
+    spec = _tiny_speculator(shell, target)
+    run_calls = _spy_on_run(spec)
+
+    standard_calls = []
+    orig_standard = engine._generate_standard
+
+    def standard_spy(*args, **kwargs):
+        standard_calls.append((args, kwargs))
+        return orig_standard(*args, **kwargs)
+
+    engine._generate_standard = standard_spy
+
+    out = _moe_generate(
+        shell,
+        do_sample=False,
+        max_new_tokens=MAX_NEW_TOKENS,
+        speculative_draft=spec,
+    )
+
+    assert len(run_calls) == 1
+    assert standard_calls == []
+    call = run_calls[0]
+    assert call["engine"] is engine
+    assert call["prompt_token_ids"] == PROMPT
+    assert call["sampling_params"].temperature == 0.0
+    assert call["sampling_params"].max_tokens == MAX_NEW_TOKENS
+    assert engine.spec_strategy is spec
+
+    # run() strips the prompt; MoE.generate re-prepends it exactly once.
+    new_ids = out[0, len(PROMPT) :].tolist()
+    assert 0 < len(new_ids) <= MAX_NEW_TOKENS
+
+    standalone = spec.generate(
+        torch.tensor([PROMPT], dtype=torch.long, device=DEVICE),
+        max_new_tokens=MAX_NEW_TOKENS,
+        temperature=0.0,
+        stop_token_ids=[engine.eos_token_id],
+    )
+    assert new_ids == standalone[0, len(PROMPT) :].tolist()
+
+    print(
+        f"engine-routed: run_calls={len(run_calls)} "
+        f"new_tokens={len(new_ids)} ids={new_ids}"
+    )
+
+
+def test_no_drafter_uses_standard_path():
+    """QA scenario (b): no drafter -> _generate_standard, baseline-equal."""
+    shell, _ = _tiny_moe_shell()
+    engine = shell._native_generation_engine
+
+    shell._cached_past_key_values = None
+    baseline = engine.generate(
+        prompt_token_ids=list(PROMPT),
+        sampling_params=SamplingParams(
+            temperature=0.0, top_p=1.0, top_k=0, max_tokens=MAX_NEW_TOKENS
+        ),
+    )
+    assert engine.spec_strategy is None
+
+    standard_calls = []
+    orig_standard = engine._generate_standard
+
+    def standard_spy(*args, **kwargs):
+        standard_calls.append((args, kwargs))
+        return orig_standard(*args, **kwargs)
+
+    engine._generate_standard = standard_spy
+
+    out = _moe_generate(
+        shell, do_sample=False, max_new_tokens=MAX_NEW_TOKENS
+    )
+
+    assert engine.spec_strategy is None
+    assert len(standard_calls) == 1
+    assert out[0].tolist() == PROMPT + baseline.output_token_ids
+
+    print(
+        f"no-drafter standard: new_tokens={len(baseline.output_token_ids)} "
+        f"ids={baseline.output_token_ids}"
+    )
+
+
+def test_omitted_kwarg_detaches_previously_attached_strategy():
+    """The speculative_draft kwarg is per-call: omitting it restores the
+    standard path (never sticky), so baseline/spec comparisons interleave
+    safely."""
+    shell, target = _tiny_moe_shell()
+    engine = shell._native_generation_engine
+    spec = _tiny_speculator(shell, target)
+
+    _moe_generate(
+        shell,
+        do_sample=False,
+        max_new_tokens=4,
+        speculative_draft=spec,
+    )
+    assert engine.spec_strategy is spec
+
+    shell._cached_past_key_values = None
+    baseline = engine.generate(
+        prompt_token_ids=list(PROMPT),
+        sampling_params=SamplingParams(
+            temperature=0.0, top_p=1.0, top_k=0, max_tokens=4
+        ),
+    )
+    out = _moe_generate(shell, do_sample=False, max_new_tokens=4)
+    assert engine.spec_strategy is None
+    assert out[0].tolist() == PROMPT + baseline.output_token_ids
+
+
+def test_non_greedy_with_drafter_uses_standard_path():
+    """T1 gate through the MoE API: temperature>0 bypasses the strategy."""
+    shell, target = _tiny_moe_shell()
+    engine = shell._native_generation_engine
+    spec = _tiny_speculator(shell, target)
+    run_calls = _spy_on_run(spec)
+
+    torch.manual_seed(123)
+    out = _moe_generate(
+        shell,
+        do_sample=True,
+        temperature=0.7,
+        max_new_tokens=8,
+        speculative_draft=spec,
+    )
+    assert run_calls == []
+    assert out.shape[1] > len(PROMPT)
+
+
+def test_batch_larger_than_one_with_drafter_raises():
+    """v1 guardrail: spec decoding is batch==1 only; fail loudly."""
+    shell, target = _tiny_moe_shell()
+    spec = _tiny_speculator(shell, target)
+    input_ids = torch.tensor([PROMPT, PROMPT], dtype=torch.long)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(NotImplementedError, match="batch"):
+            shell.generate(input_ids, do_sample=False, speculative_draft=spec)

--- a/tests/python/dflash/test_gpu_120b.py
+++ b/tests/python/dflash/test_gpu_120b.py
@@ -1,0 +1,279 @@
+"""Task 11: GPU-gated gpt-oss-120b native DFlash validation harness.
+
+This module is the DOCUMENTED, GPU-only correctness/throughput harness for the
+native draft->verify->rollback DFlash path (T6/T8) on the real 120B target. It
+is *not* part of the autonomous CPU suite: the whole module is guarded by a
+single ``skipif`` that reports it as SKIPPED (never failed/errored) unless ALL
+of the following hold:
+
+  1. ``MOE_DFLASH_GPU`` is set in the environment (opt-in flag), AND
+  2. CUDA is available, AND
+  3. both checkpoints -- ``openai/gpt-oss-120b`` (target) and
+     ``z-lab/gpt-oss-120b-DFlash`` (drafter) -- are present in the HuggingFace
+     cache under ``$HF_HOME`` (falling back to the standard HF resolution when
+     ``HF_HOME`` is unset).
+
+The autonomous assertion for this task is exactly that: with no GPU flag the
+test is reported SKIPPED, so it runs clean in normal CI without the ~60GB
+checkpoints or a GPU. The conditions are checked cheapest-first so the common
+(no-flag) path never touches CUDA or the filesystem past ``os.environ``.
+
+When enabled it loads the resident 120B target + drafter and, over a fixed
+128-token continuation for each prompt, records to
+``.sisyphus/evidence/gpu-gated/task-11-120b-results.json``:
+
+  * token **agreement-rate** -- native DFlash greedy vs plain greedy;
+  * plain-decode **self-consistency** -- pairwise agreement of repeat plain
+    greedy runs (the MXFP4 FP-near-tie floor the agreement-rate must clear);
+  * **acceptance-length histogram** -- tokens advanced per verify step
+    (``NativeStepTrace.accept + 1``) read from ``spec.step_trace``;
+  * decode **tok/s** -- DFlash vs no-spec (single-stream).
+
+Documented pass conditions (RFC Phase 0: mean accept ~= 3.66, single-stream
+~1.18-1.32x):
+
+  * agreement-rate >= plain self-consistency (losslessness on MXFP4 is measured
+    as agreement, NOT string identity);
+  * mean acceptance length in the sanity band ~3-5;
+  * tok/s recorded for both paths.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import torch
+
+TARGET_REPO = "openai/gpt-oss-120b"
+DRAFTER_REPO = "z-lab/gpt-oss-120b-DFlash"
+
+CONTINUATION_TOKENS = 128
+SELF_CONSISTENCY_RUNS = 3
+PROMPTS = (
+    "The capital of France is",
+    "In a shocking turn of events, scientists discovered that",
+    "def fibonacci(n):\n    ",
+)
+
+# Mean acceptance length == tokens advanced per verify (trace.accept + 1).
+# RFC Phase 0 reports mean accept ~= 3.66; keep a slightly widened sanity band
+# so a real GPU run is not brittle against FP-near-tie flips.
+ACCEPT_LEN_LO = 2.0
+ACCEPT_LEN_HI = 6.0
+# Native greedy may flip FP near-ties vs plain greedy on MXFP4, so the gate is
+# agreement-rate >= plain self-consistency (with a tiny float tolerance).
+AGREEMENT_EPS = 1e-9
+
+# tests/python/dflash/test_gpu_120b.py -> repo root is parents[3].
+REPO_ROOT = Path(__file__).resolve().parents[3]
+EVIDENCE_DIR = REPO_ROOT / ".sisyphus" / "evidence" / "gpu-gated"
+RESULTS_PATH = EVIDENCE_DIR / "task-11-120b-results.json"
+
+
+def _hf_home() -> Path:
+    """Resolve the HF cache root the same way the ``huggingface_hub`` does.
+
+    Honors ``$HF_HOME`` first (as the task specifies), then
+    ``$HUGGINGFACE_HUB_CACHE`` (which points directly at the ``hub`` dir), then
+    ``$XDG_CACHE_HOME``/``~/.cache`` -- so the checkpoint probe still works when
+    ``HF_HOME`` is unset in the environment.
+    """
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home).expanduser()
+    hub = os.environ.get("HUGGINGFACE_HUB_CACHE")
+    if hub:
+        return Path(hub).expanduser().parent
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".cache"
+    return base / "huggingface"
+
+
+def _checkpoint_present(repo_id: str) -> bool:
+    """True iff ``repo_id`` has a non-empty snapshot in the HF hub cache."""
+    folder = "models--" + repo_id.replace("/", "--")
+    snapshots = _hf_home() / "hub" / folder / "snapshots"
+    if not snapshots.is_dir():
+        return False
+    return any(child.is_dir() for child in snapshots.iterdir())
+
+
+def _skip_reason() -> Optional[str]:
+    """Return why the harness must skip, or ``None`` when it may run.
+
+    Cheapest-first: the opt-in flag gates before CUDA, which gates before the
+    filesystem probe -- so the normal (no-flag) run skips without importing
+    heavy deps or touching the checkpoint cache.
+    """
+    if not os.environ.get("MOE_DFLASH_GPU"):
+        return "MOE_DFLASH_GPU unset (GPU-gated 120B DFlash harness)"
+    if not torch.cuda.is_available():
+        return "CUDA unavailable (GPU-gated 120B DFlash harness)"
+    missing = [
+        repo
+        for repo in (TARGET_REPO, DRAFTER_REPO)
+        if not _checkpoint_present(repo)
+    ]
+    if missing:
+        return "checkpoints not present in $HF_HOME: " + ", ".join(missing)
+    return None
+
+
+SKIP_REASON = _skip_reason()
+
+pytestmark = pytest.mark.skipif(
+    SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated"
+)
+
+
+def _load_resident_target():
+    """Load the 120B target resident by default (offload is a tunable knob).
+
+    ``device_memory_ratio`` defaults high (experts resident) per the
+    Reconciliation Contract; ``MOE_DFLASH_MEM_RATIO`` /
+    ``MOE_DFLASH_OFFLOAD`` let a GPU operator retune without editing the test.
+    """
+    from moe_infinity import MoE
+
+    offload_path = os.environ.get(
+        "MOE_DFLASH_OFFLOAD",
+        str(_hf_home() / "moe-infinity" / "gpt-oss-120b-dflash"),
+    )
+    ratio = float(os.environ.get("MOE_DFLASH_MEM_RATIO", "0.9"))
+    return MoE(
+        TARGET_REPO,
+        {"offload_path": offload_path, "device_memory_ratio": ratio},
+    )
+
+
+def _greedy(model, input_ids, spec=None) -> list[int]:
+    """Greedy-decode ``CONTINUATION_TOKENS`` new ids; return only the new ids."""
+    kwargs: dict = {
+        "do_sample": False,
+        "max_new_tokens": CONTINUATION_TOKENS,
+    }
+    if spec is not None:
+        kwargs["speculative_draft"] = spec
+    out = model.generate(input_ids, **kwargs)
+    return [int(t) for t in out[0, input_ids.shape[1] :].tolist()]
+
+
+def _agreement(a: list[int], b: list[int]) -> float:
+    """Token agreement-rate over the shared prefix length of ``a`` and ``b``."""
+    n = min(len(a), len(b))
+    if n == 0:
+        return 0.0
+    matches = sum(1 for i in range(n) if a[i] == b[i])
+    return matches / n
+
+
+def test_120b_native_dflash_validation() -> None:
+    """Agreement-rate parity + acceptance-length + tok/s on the resident 120B.
+
+    Writes the full metric set to ``RESULTS_PATH`` and asserts the documented
+    pass conditions. Only reached on a GPU with both checkpoints cached; the
+    autonomous run skips this entire module via ``pytestmark``.
+    """
+    from transformers import AutoTokenizer
+
+    from moe_infinity.spec_decode import DFlashSpeculator
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        TARGET_REPO, trust_remote_code=True
+    )
+    model = _load_resident_target()
+    spec = DFlashSpeculator(model, DRAFTER_REPO)
+
+    per_prompt: list[dict] = []
+    accept_lengths: list[int] = []
+
+    for prompt in PROMPTS:
+        input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+        if torch.cuda.is_available():
+            input_ids = input_ids.to("cuda:0")
+
+        t0 = time.perf_counter()
+        plain = _greedy(model, input_ids)
+        plain_dt = time.perf_counter() - t0
+        plain_tok_s = len(plain) / plain_dt if plain_dt > 0 else 0.0
+
+        spec.step_trace = []
+        t0 = time.perf_counter()
+        dflash = _greedy(model, input_ids, spec=spec)
+        dflash_dt = time.perf_counter() - t0
+        dflash_tok_s = len(dflash) / dflash_dt if dflash_dt > 0 else 0.0
+
+        # Acceptance length == tokens advanced per verify step (accept + 1).
+        step_lengths = [int(tr.accept) + 1 for tr in spec.step_trace]
+        accept_lengths.extend(step_lengths)
+        mean_step = (
+            sum(step_lengths) / len(step_lengths) if step_lengths else 0.0
+        )
+
+        repeats = [
+            _greedy(model, input_ids) for _ in range(SELF_CONSISTENCY_RUNS)
+        ]
+        sc_scores = [_agreement(plain, r) for r in repeats]
+        self_consistency = sum(sc_scores) / len(sc_scores)
+
+        per_prompt.append(
+            {
+                "prompt": prompt,
+                "agreement_rate": _agreement(dflash, plain),
+                "self_consistency": self_consistency,
+                "mean_accept_len": mean_step,
+                "num_steps": len(step_lengths),
+                "plain_tok_s": plain_tok_s,
+                "dflash_tok_s": dflash_tok_s,
+                "speedup": (
+                    dflash_tok_s / plain_tok_s if plain_tok_s > 0 else 0.0
+                ),
+            }
+        )
+
+    histogram: dict[int, int] = {}
+    for length in accept_lengths:
+        histogram[length] = histogram.get(length, 0) + 1
+    mean_accept = (
+        sum(accept_lengths) / len(accept_lengths) if accept_lengths else 0.0
+    )
+
+    summary = {
+        "target": TARGET_REPO,
+        "drafter": DRAFTER_REPO,
+        "continuation_tokens": CONTINUATION_TOKENS,
+        "self_consistency_runs": SELF_CONSISTENCY_RUNS,
+        "mean_accept_len": mean_accept,
+        "acceptance_histogram": {
+            str(k): histogram[k] for k in sorted(histogram)
+        },
+        "per_prompt": per_prompt,
+    }
+    EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+    RESULTS_PATH.write_text(json.dumps(summary, indent=2))
+
+    # Pass condition 1: agreement-rate >= plain self-consistency per prompt.
+    for row in per_prompt:
+        assert (
+            row["agreement_rate"] >= row["self_consistency"] - AGREEMENT_EPS
+        ), (
+            f"agreement {row['agreement_rate']:.4f} < self-consistency "
+            f"{row['self_consistency']:.4f} for prompt {row['prompt']!r}"
+        )
+
+    # Pass condition 2: mean acceptance length in the documented sanity band.
+    assert accept_lengths, "no DFlash steps recorded (spec.step_trace empty)"
+    assert ACCEPT_LEN_LO <= mean_accept <= ACCEPT_LEN_HI, (
+        f"mean acceptance length {mean_accept:.2f} outside sanity band "
+        f"[{ACCEPT_LEN_LO}, {ACCEPT_LEN_HI}]"
+    )
+
+    # Pass condition 3: tok/s recorded for both paths.
+    for row in per_prompt:
+        assert row["plain_tok_s"] > 0.0, "plain decode tok/s not recorded"
+        assert row["dflash_tok_s"] > 0.0, "DFlash decode tok/s not recorded"

--- a/tests/python/dflash/test_native_e2e.py
+++ b/tests/python/dflash/test_native_e2e.py
@@ -1,0 +1,238 @@
+"""Task 9: tiny-model E2E losslessness parity (native DFlash == plain greedy).
+
+The definitive autonomous correctness gate for DFlash losslessness -- no 120B,
+no network, no GPU requirement. For a set of FIXED prompts it drives the REAL
+sync engine path end to end:
+
+    MoE.generate(..., speculative_draft=spec)
+        -> GenerationEngine.generate (greedy gate applies)
+        -> spec.run -> DFlashSpeculator.generate  (via MoE._native_model_forward_rich)
+
+and asserts the emitted token-id sequence is EXACTLY identical to
+``plain_greedy_decode`` on the same tiny target over >= 64 new tokens for EVERY
+prompt (the tiny CPU model is bit-reproducible, so token identity -- not just
+agreement rate -- is the gate; on the MXFP4 120B this becomes agreement-rate
+parity). A first-divergence index is reported on failure.
+
+A second check proves the drafter is actually exercised: mean per-step
+acceptance (accepted drafts, ``NativeStepTrace.accept``) is > 0 on at least one
+prompt, so parity is a real draft->verify->accept loss-free path and not a
+degenerate accept-0 fallback that trivially equals plain greedy.
+
+Device follows the sibling tests (``cuda:0`` when available, else ``cpu``):
+``MoE._native_model_forward_rich`` moves inputs to ``cuda:0`` whenever CUDA is
+present, so the target must live there too. The tiny fixtures are
+bit-reproducible on both, verified identical.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+    set_determinism,
+)
+
+from moe_infinity.engine.generation_loop import GenerationEngine  # noqa: E402
+from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
+from moe_infinity.memory.kv_cache_manager import KVCacheManager  # noqa: E402
+from moe_infinity.runtime.attention_types import KVCacheSpec  # noqa: E402
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+
+DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
+MAX_NEW_TOKENS = 64
+UNREACHABLE_EOS = -1
+
+# Fixed prompts spanning several lengths; token ids stay inside the tiny vocab.
+PROMPTS = [
+    [3, 7, 11, 2, 5],
+    [1, 2, 3],
+    [10, 20, 30, 40],
+    [5],
+    [8, 16, 24, 32, 40, 48],
+    [42, 17, 33, 9],
+]
+
+_EVIDENCE_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", ".sisyphus", "evidence"
+    )
+)
+
+
+def _build_engine_shell(seed: int = 0):
+    """MoE shell around the tiny target with a real ``GenerationEngine``.
+
+    Mirrors the production wiring (engine ``model_forward_fn`` bound to
+    ``shell._native_model_forward``) without an offload runtime, exactly like
+    ``test_engine_wire.py``. ``eos_token_id`` is unreachable so the engine
+    never forces an early stop; the tiny target config's own ``eos_token_id``
+    is ``None``, matching ``plain_greedy_decode(eos_token_id=None)``.
+    """
+    set_determinism(seed)
+    target = build_tiny_target(seed=seed).to(DEVICE)
+    shell = MoE.__new__(MoE)
+    shell.model = target
+    shell.use_native_engine = True
+    shell.max_seq_length = 256
+    shell._cached_past_key_values = None
+    shell._native_attention_backend = None
+    shell._configure_hook = lambda input_ids: None
+
+    engine = GenerationEngine(
+        kv_cache_manager=KVCacheManager(
+            num_gpu_blocks=256, num_cpu_blocks=64, block_size=4
+        ),
+        kv_spec=KVCacheSpec(
+            num_kv_heads=2, head_dim=8, dtype=torch.float32, block_size=4
+        ),
+        num_layers=int(target.config.num_hidden_layers),
+        vocab_size=int(target.config.vocab_size),
+        model_forward_fn=shell._native_model_forward,
+        eos_token_id=UNREACHABLE_EOS,
+        max_seq_length=256,
+    )
+    shell._native_generation_engine = engine
+    return shell, target
+
+
+def _native_generate(shell, spec, prompt):
+    input_ids = torch.tensor([prompt], dtype=torch.long)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        out = shell.generate(
+            input_ids,
+            do_sample=False,
+            max_new_tokens=MAX_NEW_TOKENS,
+            speculative_draft=spec,
+        )
+    new_ids = out[0, len(prompt) :].tolist()
+    accepts = [rec.accept for rec in spec.step_trace]
+    return new_ids, accepts
+
+
+def _decode_all():
+    """Decode every prompt both ways; return per-prompt plain/native/accepts."""
+    shell, target = _build_engine_shell(seed=0)
+    drafter = build_tiny_drafter(target, seed=1).to(DEVICE)
+    config = read_dflash_config(make_tiny_drafter_config(target.config))
+    spec = DFlashSpeculator.from_models(shell, drafter, config=config, device=DEVICE)
+
+    results = []
+    for prompt in PROMPTS:
+        plain = plain_greedy_decode(
+            target,
+            torch.tensor([prompt], dtype=torch.long, device=DEVICE),
+            max_new_tokens=MAX_NEW_TOKENS,
+        )
+        plain_new = plain[0, len(prompt) :].tolist()
+        native_new, accepts = _native_generate(shell, spec, prompt)
+        results.append(
+            {
+                "prompt": prompt,
+                "plain_new": plain_new,
+                "native_new": native_new,
+                "accepts": accepts,
+            }
+        )
+    return results
+
+
+def _first_divergence(a, b):
+    for i in range(min(len(a), len(b))):
+        if a[i] != b[i]:
+            return i
+    return None if len(a) == len(b) else min(len(a), len(b))
+
+
+def _write_evidence(filename, lines):
+    os.makedirs(_EVIDENCE_DIR, exist_ok=True)
+    path = os.path.join(_EVIDENCE_DIR, filename)
+    with open(path, "w") as handle:
+        handle.write(f"device={DEVICE} max_new_tokens={MAX_NEW_TOKENS}\n")
+        handle.write("\n".join(lines) + "\n")
+    return path
+
+
+@pytest.fixture(scope="module")
+def decoded():
+    return _decode_all()
+
+
+def test_native_equals_plain_greedy_token_identical(decoded):
+    """QA (happy): native DFlash == plain greedy, token-identical, >= 64 ids."""
+    lines = []
+    failures = []
+    for record in decoded:
+        prompt = record["prompt"]
+        plain_new = record["plain_new"]
+        native_new = record["native_new"]
+        first_div = _first_divergence(plain_new, native_new)
+        identical = plain_new == native_new
+        length_ok = len(native_new) >= 64
+        lines.append(
+            f"prompt={str(prompt):<26} new_tokens={len(native_new)} "
+            f"len>=64={length_ok} identical={identical} "
+            f"first_divergence={first_div}"
+        )
+        if not (identical and length_ok):
+            failures.append((prompt, first_div, plain_new, native_new))
+
+    _write_evidence("task-9-native-parity.txt", lines)
+    print("\n".join(lines))
+
+    if failures:
+        prompt, first_div, plain_new, native_new = failures[0]
+        raise AssertionError(
+            f"native DFlash diverged from plain greedy for prompt {prompt} "
+            f"at new-token index {first_div} "
+            f"({len(failures)} of {len(decoded)} prompts failed):\n"
+            f"  plain ={plain_new}\n  native={native_new}"
+        )
+
+
+def test_acceptance_length_is_non_degenerate(decoded):
+    """QA (sanity): the drafter is exercised -- mean accept > 0 on >= 1 prompt."""
+    lines = []
+    per_prompt_mean = []
+    total_accept = 0
+    for record in decoded:
+        prompt = record["prompt"]
+        accepts = record["accepts"]
+        step_total = sum(accepts)
+        total_accept += step_total
+        mean = step_total / len(accepts) if accepts else 0.0
+        per_prompt_mean.append(mean)
+        lines.append(
+            f"prompt={str(prompt):<26} steps={len(accepts)} "
+            f"total_accept={step_total} mean_accept={mean:.4f}"
+        )
+
+    prompts_with_accept = sum(1 for mean in per_prompt_mean if mean > 0)
+    lines.append(
+        f"aggregate total_accept={total_accept} "
+        f"prompts_with_accept={prompts_with_accept}/{len(decoded)} "
+        f"max_mean_accept={max(per_prompt_mean):.4f}"
+    )
+
+    _write_evidence("task-9-accept-nonzero.txt", lines)
+    print("\n".join(lines))
+
+    assert any(mean > 0 for mean in per_prompt_mean), (
+        "DFlash accepted zero drafts on every prompt (degenerate accept-0 "
+        f"loop -- drafter never exercised); per-prompt means={per_prompt_mean}"
+    )

--- a/tests/python/dflash/test_native_step.py
+++ b/tests/python/dflash/test_native_step.py
@@ -1,0 +1,247 @@
+"""Task 6: native DFlash draft->verify->rollback state machine.
+
+Pins the two Task-6 QA scenarios on the tiny CPU fixtures (T5):
+
+(a) A single native step commits ``accept + 1`` tokens and crops the target
+    cache to ``start`` — the bonus token is emitted but NOT cached, so the
+    cache length trails the emitted count by exactly one (the bonus-token
+    trap: ``cache length == emitted length`` would mean the bonus was cached).
+(b) The verify forward runs with FULL logits — no ``logits_to_keep=1``
+    slicing — spied at both the speculator's rich-forward seam and the target
+    model's own forward (prefill/anchor uses 1, verify uses none).
+
+It also pins multi-step greedy parity against ``plain_greedy_decode`` (the
+losslessness smoke signal for the state machine; the strict E2E gate is
+Task 9) and routing through the MoE engine's ``_native_model_forward_rich``
+seam (the production path Task 8 wires up).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    TINY_BLOCK_SIZE,
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+)
+
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+
+PROMPT = torch.tensor([[3, 7, 11, 2, 5]])
+PROMPT_LEN = int(PROMPT.shape[1])
+DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def _tiny_spec(device: str = "cpu"):
+    target = build_tiny_target(seed=0)
+    drafter = build_tiny_drafter(target, seed=1)
+    config = read_dflash_config(make_tiny_drafter_config(target.config))
+    if device != "cpu":
+        target = target.to(device)
+        drafter = drafter.to(device)
+    spec = DFlashSpeculator.from_models(target, drafter, config=config, device=device)
+    return spec, target, drafter
+
+
+def _assert_step_invariants(spec: DFlashSpeculator) -> None:
+    for rec in spec.step_trace:
+        # The cache advance is accept+1 (anchor + accepted drafts); the bonus
+        # token is emitted on top and is NOT part of the cache advance.
+        assert rec.start == rec.prev_start + rec.accept + 1
+        assert rec.target_cache_len == rec.start
+
+
+def test_single_native_step_commits_and_crops_caches():
+    """QA scenario (a): one native step; emitted vs cached accounting."""
+    spec, _, _ = _tiny_spec()
+
+    # max_new_tokens=2: the prefill anchor is token 1, so exactly one
+    # draft->verify->rollback step runs before the loop exits.
+    out = spec.generate(PROMPT, max_new_tokens=2)
+
+    assert len(spec.step_trace) == 1
+    rec = spec.step_trace[0]
+
+    assert rec.prev_start == PROMPT_LEN
+    assert 0 <= rec.accept <= TINY_BLOCK_SIZE - 1
+    # start advances by accept+1: the bonus token is NOT added to the cache.
+    assert rec.start == PROMPT_LEN + rec.accept + 1
+    # The target cache is cropped to start.
+    assert rec.target_cache_len == rec.start
+    # emitted grew by accept+1 over the prefill anchor (accepted drafts ++ bonus).
+    assert rec.emitted_len == 1 + rec.accept + 1
+    # Bonus-token trap guard: the absolute emitted length (prompt + emitted)
+    # must be exactly one ahead of the cache length — never equal.
+    assert (PROMPT_LEN + rec.emitted_len) - rec.target_cache_len == 1
+
+    assert spec.last_target_cache is not None
+    assert int(spec.last_target_cache.get_seq_length()) == rec.start
+    # The tiny drafter is stateless: no draft KV cache exists on this path.
+    assert spec.last_draft_cache is None
+
+    # The public contract returns prompt ++ at most max_new_tokens new ids.
+    assert tuple(out.shape) == (1, PROMPT_LEN + 2)
+
+    print(
+        "step-state prev_start={} accept={} start={} emitted_len={} "
+        "target_cache_len={} draft_cache_len={}".format(
+            rec.prev_start,
+            rec.accept,
+            rec.start,
+            rec.emitted_len,
+            rec.target_cache_len,
+            rec.draft_cache_len,
+        )
+    )
+
+
+def test_verify_forward_uses_full_logits():
+    """QA scenario (b): prefill slices logits, verify must NOT."""
+    spec, target, _ = _tiny_spec()
+
+    seam_calls = []
+    orig_forward_target = spec._forward_target
+
+    def seam_spy(input_ids, past_key_values=None, logits_to_keep=0):
+        seam_calls.append(int(logits_to_keep))
+        return orig_forward_target(
+            input_ids, past_key_values=past_key_values, logits_to_keep=logits_to_keep
+        )
+
+    spec._forward_target = seam_spy
+
+    model_calls = []
+    orig_model_forward = target.forward
+
+    def model_spy(*args, **kwargs):
+        model_calls.append((args, dict(kwargs)))
+        return orig_model_forward(*args, **kwargs)
+
+    target.forward = model_spy
+
+    spec.generate(PROMPT, max_new_tokens=2)
+
+    # One prefill (anchor, sliced) + one verify (full) for a single step.
+    assert seam_calls == [1, 0]
+
+    assert len(model_calls) == 2
+    _, prefill_kwargs = model_calls[0]
+    assert prefill_kwargs.get("past_key_values") is None
+    assert prefill_kwargs.get("logits_to_keep") == 1
+
+    verify_args, verify_kwargs = model_calls[1]
+    assert verify_kwargs.get("past_key_values") is not None
+    # Full-logits verify: the kwarg is absent (helper/seam only pass it when > 0).
+    assert "logits_to_keep" not in verify_kwargs
+    block_ids = verify_args[0] if verify_args else verify_kwargs["input_ids"]
+    assert tuple(block_ids.shape) == (1, TINY_BLOCK_SIZE)
+
+    print(f"verify-fulllogits seam_calls={seam_calls}")
+
+
+def test_native_multistep_greedy_matches_plain_greedy():
+    """Core loop works: native multi-step greedy == plain greedy (CPU, fp32)."""
+    spec, target, _ = _tiny_spec()
+
+    max_new_tokens = 32
+    native = spec.generate(PROMPT, max_new_tokens=max_new_tokens)
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=max_new_tokens)
+
+    assert tuple(native.shape) == (1, PROMPT_LEN + max_new_tokens)
+    assert torch.equal(native, plain), (
+        "native DFlash greedy diverged from plain greedy:\n"
+        f"  native={native[0].tolist()}\n  plain={plain[0].tolist()}"
+    )
+
+    # Multi-step actually ran, with consistent emitted-vs-cached accounting.
+    assert len(spec.step_trace) >= 2
+    _assert_step_invariants(spec)
+    assert int(spec.last_target_cache.get_seq_length()) == spec.step_trace[-1].start
+
+    accepts = [rec.accept for rec in spec.step_trace]
+    print(f"multistep steps={len(accepts)} accepts={accepts}")
+
+
+def test_native_step_routes_through_moe_rich_forward():
+    """Production seam: with an MoE shell present, every target forward goes
+    through ``_native_model_forward_rich`` (standard expert dispatch)."""
+    from moe_infinity.entrypoints.big_modeling import MoE
+
+    spec, target, _ = _tiny_spec(device=DEVICE)
+
+    shell = MoE.__new__(MoE)
+    shell.model = target
+    shell._cached_past_key_values = None
+    shell._native_attention_backend = None
+    # The bare shell has no offload runtime; the speculator skips a None hook.
+    shell._configure_hook = None
+
+    spec = DFlashSpeculator.from_models(
+        shell, spec.draft, config=spec.config, device=DEVICE
+    )
+
+    rich_calls = []
+    orig_rich = shell._native_model_forward_rich
+
+    def rich_spy(token_ids, attention_metadata=None, logits_to_keep=0):
+        rich_calls.append(
+            {
+                "n_tokens": len(token_ids),
+                "logits_to_keep": int(logits_to_keep),
+                "is_prefill": (
+                    True
+                    if attention_metadata is None
+                    else bool(getattr(attention_metadata, "is_prefill", True))
+                ),
+            }
+        )
+        return orig_rich(token_ids, attention_metadata, logits_to_keep=logits_to_keep)
+
+    shell._native_model_forward_rich = rich_spy
+
+    max_new_tokens = 16
+    out = spec.generate(PROMPT.to(DEVICE), max_new_tokens=max_new_tokens)
+
+    # Every target forward went through the rich helper: prefill (sliced
+    # logits) then one full-logits verify per step.
+    assert len(rich_calls) == 1 + len(spec.step_trace)
+    assert rich_calls[0]["logits_to_keep"] == 1
+    assert rich_calls[0]["is_prefill"] is True
+    for call in rich_calls[1:]:
+        assert call["logits_to_keep"] == 0
+        assert call["is_prefill"] is False
+        assert call["n_tokens"] == TINY_BLOCK_SIZE
+
+    _assert_step_invariants(spec)
+    # The engine-side cache (same object the loop cropped) ends at start.
+    assert int(shell._cached_past_key_values.get_seq_length()) == spec.step_trace[-1].start
+
+    # Parity against sequential greedy through the SAME rich helper.
+    shell._cached_past_key_values = None
+    reference = []
+    step_ids = PROMPT[0].tolist()
+    for i in range(max_new_tokens):
+        meta = None if i == 0 else SimpleNamespace(is_prefill=False)
+        logits, _, _ = orig_rich(step_ids, meta, logits_to_keep=1)
+        nxt = int(logits[0, -1].argmax().item())
+        reference.append(nxt)
+        step_ids = [nxt]
+
+    assert out[0, PROMPT_LEN:].tolist() == reference
+
+    print(
+        f"moe-rich forwards={len(rich_calls)} steps={len(spec.step_trace)} "
+        f"final_cache={int(shell._cached_past_key_values.get_seq_length())}"
+    )

--- a/tests/python/dflash/test_spec_off_regression.py
+++ b/tests/python/dflash/test_spec_off_regression.py
@@ -1,0 +1,232 @@
+"""Task 10: spec-off byte-identity regression.
+
+The full DFlash integration (T1 seam + ``_generate_standard``, T2 rich
+forward helper, T3/T4 ops + loader, T6/T7 state machine, T8
+``MoE.generate(..., speculative_draft=...)``) must leave the standard,
+non-speculative decode path byte-identical to the pre-integration baseline.
+
+Proof (A) pins ``GenerationEngine.generate(spec_strategy=None)`` on a
+seeded pure-CPU GPT-2 model to the same literal Task 1 captured before the
+seam refactor -- device-independent, so the literal is portable.
+
+Proof (B) drives ``MoE.generate`` without ``speculative_draft`` through the
+real sync path on the tiny gpt-oss target. Since ``_native_model_forward``
+runs on the model device (``cuda:0`` when present), tiny-target ids are
+hardware-dependent; (B) therefore asserts equality against the in-process
+``_generate_standard`` baseline (and non-sticky ``spec_strategy is None``)
+rather than a hard-coded literal, which stays in the CPU-only proof (A).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    build_tiny_target,
+    set_determinism,
+)
+
+from moe_infinity.engine.generation_loop import (  # noqa: E402
+    GenerationEngine,
+    GenerationResult,
+)
+from moe_infinity.engine.types import (  # noqa: E402
+    SamplingParams,
+    SequenceStatus,
+)
+from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
+from moe_infinity.memory.kv_cache_manager import KVCacheManager  # noqa: E402
+from moe_infinity.runtime.attention_types import KVCacheSpec  # noqa: E402
+from moe_infinity.spec_decode.dflash import _resolve_stop_ids  # noqa: E402
+
+GPT2_VOCAB = 128
+GPT2_PROMPT = [3, 11, 42, 7, 90]
+GPT2_MAX_TOKENS = 16
+
+# Captured from the pre-refactor GenerationEngine standard loop (seed-7 tiny
+# GPT-2 fixture below). This is the identical baseline pinned by Task 1's
+# ``test_spec_seam.py``; the full DFlash integration must not move it.
+BASELINE_IDS = [61, 61, 108, 108, 108, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]
+
+
+def _build_cpu_gpt2_forward():
+    """A deterministic, CPU-only model_forward_fn (no device moves)."""
+    torch.manual_seed(7)
+    cfg = GPT2Config(
+        vocab_size=GPT2_VOCAB,
+        n_layer=2,
+        n_head=2,
+        n_embd=32,
+        n_positions=64,
+        n_ctx=64,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    model = GPT2LMHeadModel(cfg).eval()
+    ctx: list[int] = []
+
+    def forward(token_ids, attention_metadata):
+        ctx.extend(token_ids)
+        ids = torch.tensor([ctx], dtype=torch.long)
+        with torch.no_grad():
+            out = model(ids)
+        return out.logits[0, -1:, :]
+
+    return forward
+
+
+def _gpt2_engine(spec_strategy=None):
+    return GenerationEngine(
+        kv_cache_manager=KVCacheManager(
+            num_gpu_blocks=64, num_cpu_blocks=16, block_size=4
+        ),
+        kv_spec=KVCacheSpec(
+            num_kv_heads=2, head_dim=8, dtype=torch.float32, block_size=4
+        ),
+        num_layers=2,
+        vocab_size=GPT2_VOCAB,
+        model_forward_fn=_build_cpu_gpt2_forward(),
+        eos_token_id=2,
+        spec_strategy=spec_strategy,
+    )
+
+
+def _greedy_params(max_tokens=GPT2_MAX_TOKENS):
+    return SamplingParams(
+        temperature=0.0, top_p=1.0, top_k=0, max_tokens=max_tokens
+    )
+
+
+def test_spec_off_default_matches_committed_baseline():
+    """Default engine (no strategy) == committed pre-integration literal."""
+    result = _gpt2_engine().generate(
+        prompt_token_ids=list(GPT2_PROMPT), sampling_params=_greedy_params()
+    )
+    assert isinstance(result, GenerationResult)
+    assert result.output_token_ids == BASELINE_IDS
+    assert result.finish_reason == SequenceStatus.FINISHED_LENGTH
+
+
+def test_spec_off_explicit_none_matches_committed_baseline():
+    """Explicit ``spec_strategy=None`` == committed baseline (byte-ident)."""
+    result = _gpt2_engine(spec_strategy=None).generate(
+        prompt_token_ids=list(GPT2_PROMPT), sampling_params=_greedy_params()
+    )
+    assert result.output_token_ids == BASELINE_IDS
+    assert result.finish_reason == SequenceStatus.FINISHED_LENGTH
+
+
+def test_spec_off_standard_path_is_deterministic():
+    """The seeded standard path is bit-reproducible (validates the literal)."""
+    first = _gpt2_engine().generate(
+        prompt_token_ids=list(GPT2_PROMPT), sampling_params=_greedy_params()
+    )
+    second = _gpt2_engine().generate(
+        prompt_token_ids=list(GPT2_PROMPT), sampling_params=_greedy_params()
+    )
+    assert first.output_token_ids == second.output_token_ids == BASELINE_IDS
+
+
+OSS_PROMPT = [3, 7, 11, 2, 5]
+OSS_MAX_NEW_TOKENS = 16
+DEVICE = "cuda:0" if torch.cuda.is_available() else "cpu"
+
+
+def _tiny_moe_shell(seed: int = 0):
+    """MoE shell around the tiny gpt-oss target + a real native engine.
+
+    Mirrors production wiring (engine holds
+    ``model_forward_fn=shell._native_model_forward``) without the offload
+    runtime, matching ``test_engine_wire.py``'s shell.
+    """
+    set_determinism(seed)
+    target = build_tiny_target(seed=seed).to(DEVICE)
+    shell = MoE.__new__(MoE)
+    shell.model = target
+    shell.use_native_engine = True
+    shell.max_seq_length = 64
+    shell._cached_past_key_values = None
+    shell._native_attention_backend = None
+    shell._configure_hook = lambda input_ids: None
+
+    stop_ids = _resolve_stop_ids(target, None)
+    eos_token_id = stop_ids[0] if stop_ids else -1
+
+    engine = GenerationEngine(
+        kv_cache_manager=KVCacheManager(
+            num_gpu_blocks=64, num_cpu_blocks=16, block_size=4
+        ),
+        kv_spec=KVCacheSpec(
+            num_kv_heads=2, head_dim=8, dtype=torch.float32, block_size=4
+        ),
+        num_layers=int(target.config.num_hidden_layers),
+        vocab_size=int(target.config.vocab_size),
+        model_forward_fn=shell._native_model_forward,
+        eos_token_id=eos_token_id,
+        max_seq_length=64,
+    )
+    shell._native_generation_engine = engine
+    return shell, engine
+
+
+def _moe_generate(shell, **kwargs):
+    input_ids = torch.tensor([OSS_PROMPT], dtype=torch.long)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return shell.generate(input_ids, **kwargs)
+
+
+def test_moe_generate_without_drafter_matches_standard_path():
+    """No drafter => _generate_standard; output == in-process baseline."""
+    shell, engine = _tiny_moe_shell()
+
+    shell._cached_past_key_values = None
+    baseline = engine.generate(
+        prompt_token_ids=list(OSS_PROMPT),
+        sampling_params=SamplingParams(
+            temperature=0.0,
+            top_p=1.0,
+            top_k=0,
+            max_tokens=OSS_MAX_NEW_TOKENS,
+        ),
+    )
+    assert engine.spec_strategy is None
+
+    standard_calls = []
+    orig_standard = engine._generate_standard
+
+    def standard_spy(*args, **kwargs):
+        standard_calls.append((args, kwargs))
+        return orig_standard(*args, **kwargs)
+
+    engine._generate_standard = standard_spy
+
+    out = _moe_generate(
+        shell, do_sample=False, max_new_tokens=OSS_MAX_NEW_TOKENS
+    )
+
+    assert engine.spec_strategy is None
+    assert len(standard_calls) == 1
+    assert out[0].tolist() == OSS_PROMPT + baseline.output_token_ids
+    new_ids = out[0, len(OSS_PROMPT) :].tolist()
+    assert 0 < len(new_ids) <= OSS_MAX_NEW_TOKENS
+
+
+def test_moe_generate_without_drafter_is_deterministic():
+    """Two independent no-drafter runs agree (standard path is stable)."""
+    shell_a, _ = _tiny_moe_shell()
+    out_a = _moe_generate(
+        shell_a, do_sample=False, max_new_tokens=OSS_MAX_NEW_TOKENS
+    )
+    shell_b, _ = _tiny_moe_shell()
+    out_b = _moe_generate(
+        shell_b, do_sample=False, max_new_tokens=OSS_MAX_NEW_TOKENS
+    )
+    assert out_a[0].tolist() == out_b[0].tolist()

--- a/tests/python/dflash/test_spec_seam.py
+++ b/tests/python/dflash/test_spec_seam.py
@@ -1,0 +1,148 @@
+import torch
+from transformers import GPT2Config, GPT2LMHeadModel
+
+from moe_infinity.engine.generation_loop import (
+    GenerationEngine,
+    GenerationResult,
+    SpecDecodeStrategy,
+)
+from moe_infinity.engine.types import SamplingParams, SequenceStatus
+from moe_infinity.memory.kv_cache_manager import KVCacheManager
+from moe_infinity.runtime.attention_types import KVCacheSpec
+
+VOCAB = 128
+PROMPT = [3, 11, 42, 7, 90]
+MAX_TOKENS = 16
+
+# Captured from the pre-refactor GenerationEngine (seed 7 tiny GPT-2 fixture below);
+# the seam refactor must leave the standard path byte-identical to this.
+BASELINE_IDS = [61, 61, 108, 108, 108, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]
+
+
+def _build_forward():
+    torch.manual_seed(7)
+    cfg = GPT2Config(
+        vocab_size=VOCAB,
+        n_layer=2,
+        n_head=2,
+        n_embd=32,
+        n_positions=64,
+        n_ctx=64,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    model = GPT2LMHeadModel(cfg).eval()
+    ctx: list[int] = []
+
+    def forward(token_ids, attention_metadata):
+        ctx.extend(token_ids)
+        ids = torch.tensor([ctx], dtype=torch.long)
+        with torch.no_grad():
+            out = model(ids)
+        return out.logits[0, -1:, :]
+
+    return forward
+
+
+def _make_engine(spec_strategy=None, **engine_kwargs):
+    spec = KVCacheSpec(
+        num_kv_heads=2, head_dim=8, dtype=torch.float32, block_size=4
+    )
+    mgr = KVCacheManager(num_gpu_blocks=64, num_cpu_blocks=16, block_size=4)
+    return GenerationEngine(
+        kv_cache_manager=mgr,
+        kv_spec=spec,
+        num_layers=2,
+        vocab_size=VOCAB,
+        model_forward_fn=_build_forward(),
+        eos_token_id=2,
+        spec_strategy=spec_strategy,
+        **engine_kwargs,
+    )
+
+
+def _greedy_params():
+    return SamplingParams(temperature=0.0, top_p=1.0, top_k=0, max_tokens=MAX_TOKENS)
+
+
+class _ExplodingStrategy:
+    def run(self, *, engine, prompt_token_ids, sampling_params, request_id=None):
+        raise RuntimeError("spec strategy must not be called on this path")
+
+
+class _RecordingStrategy:
+    def __init__(self, ids):
+        self._ids = ids
+        self.calls = []
+
+    def run(self, *, engine, prompt_token_ids, sampling_params, request_id=None):
+        self.calls.append(
+            {
+                "engine": engine,
+                "prompt_token_ids": prompt_token_ids,
+                "sampling_params": sampling_params,
+                "request_id": request_id,
+            }
+        )
+        return list(self._ids)
+
+
+def test_spec_off_default_matches_prerefactor_baseline():
+    engine = _make_engine()
+    result = engine.generate(
+        prompt_token_ids=list(PROMPT), sampling_params=_greedy_params()
+    )
+    assert isinstance(result, GenerationResult)
+    assert result.output_token_ids == BASELINE_IDS
+    assert result.finish_reason == SequenceStatus.FINISHED_LENGTH
+
+
+def test_spec_off_explicit_none_matches_prerefactor_baseline():
+    engine = _make_engine(spec_strategy=None)
+    result = engine.generate(
+        prompt_token_ids=list(PROMPT), sampling_params=_greedy_params()
+    )
+    assert result.output_token_ids == BASELINE_IDS
+    assert result.finish_reason == SequenceStatus.FINISHED_LENGTH
+
+
+def test_nongreedy_params_bypass_spec_strategy():
+    non_greedy = [
+        SamplingParams(temperature=0.7, max_tokens=8),
+        SamplingParams(temperature=1.0, top_p=0.9, max_tokens=8),
+        SamplingParams(temperature=1.0, top_k=10, max_tokens=8),
+    ]
+    for params in non_greedy:
+        torch.manual_seed(99)
+        guarded = _make_engine(spec_strategy=_ExplodingStrategy())
+        guarded_result = guarded.generate(
+            prompt_token_ids=list(PROMPT), sampling_params=params
+        )
+
+        torch.manual_seed(99)
+        reference = _make_engine()
+        reference_result = reference.generate(
+            prompt_token_ids=list(PROMPT), sampling_params=params
+        )
+
+        assert guarded_result.output_token_ids == reference_result.output_token_ids
+        assert guarded_result.finish_reason == reference_result.finish_reason
+
+
+def test_greedy_delegates_to_spec_strategy():
+    canned_ids = [5, 6, 7, 8]
+    strategy = _RecordingStrategy(canned_ids)
+    engine = _make_engine(spec_strategy=strategy)
+    result = engine.generate(
+        prompt_token_ids=list(PROMPT), sampling_params=_greedy_params()
+    )
+    assert len(strategy.calls) == 1
+    call = strategy.calls[0]
+    assert call["engine"] is engine
+    assert call["prompt_token_ids"] == PROMPT
+    assert result.output_token_ids == canned_ids
+    assert isinstance(result, GenerationResult)
+
+
+def test_spec_strategy_protocol_runtime_shape():
+    assert hasattr(SpecDecodeStrategy, "run")

--- a/tests/python/dflash/test_tiny_fixtures.py
+++ b/tests/python/dflash/test_tiny_fixtures.py
@@ -1,0 +1,119 @@
+"""Tiny gpt-oss target + DFlash drafter fixtures — CPU determinism contract.
+
+Pins the Task 5 QA scenarios: (1) tiny target greedy is bit-reproducible on CPU
+(the token-identity gate the Task 9 losslessness proof depends on) and (2) the
+tiny drafter projects a random 5-layer feature to ``[B, block_size-1, vocab]``
+through the *target* lm_head. The fixtures under test deliberately contain NO
+DFlash acceptance / verify / rollback logic — that is the code under test in
+Task 6.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    TINY_BLOCK_SIZE,
+    TINY_HIDDEN,
+    TINY_MASK_TOKEN_ID,
+    TINY_TARGET_LAYER_IDS,
+    TINY_VOCAB,
+    build_tiny_drafter,
+    build_tiny_target,
+    context_feature_from_hidden_states,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+)
+
+PROMPT = torch.tensor([[3, 7, 11, 2, 5]])
+
+
+def test_tiny_target_greedy_bit_reproducible_across_fresh_builds():
+    g1 = plain_greedy_decode(build_tiny_target(seed=0), PROMPT, max_new_tokens=32)
+    g2 = plain_greedy_decode(build_tiny_target(seed=0), PROMPT, max_new_tokens=32)
+
+    assert g1.dtype == torch.long
+    assert tuple(g1.shape) == (1, PROMPT.shape[1] + 32)
+    assert torch.equal(g1, g2), (
+        "tiny target greedy decode is not bit-reproducible across two fresh "
+        f"same-seed builds:\n  run1={g1.tolist()}\n  run2={g2.tolist()}"
+    )
+
+
+def test_tiny_target_greedy_reproducible_same_instance():
+    model = build_tiny_target(seed=0)
+    a = plain_greedy_decode(model, PROMPT, max_new_tokens=24)
+    b = plain_greedy_decode(model, PROMPT, max_new_tokens=24)
+    assert torch.equal(a, b)
+
+
+def test_tiny_drafter_shape_via_target_lm_head():
+    target = build_tiny_target(seed=0)
+    drafter = build_tiny_drafter(target, seed=1)
+
+    batch = 1
+    ctx_len = PROMPT.shape[1]
+    feat_dim = len(TINY_TARGET_LAYER_IDS) * TINY_HIDDEN
+    feature = torch.randn(batch, ctx_len, feat_dim)
+
+    anchor = 4
+    block = torch.tensor([[anchor] + [TINY_MASK_TOKEN_ID] * (TINY_BLOCK_SIZE - 1)])
+    assert tuple(block.shape) == (batch, TINY_BLOCK_SIZE)
+
+    with torch.no_grad():
+        drafter_out = drafter(block, feature)
+        assert tuple(drafter_out.shape) == (batch, TINY_BLOCK_SIZE, TINY_HIDDEN)
+        draft_logits = target.lm_head(drafter_out)[:, -(TINY_BLOCK_SIZE - 1):, :]
+
+    assert tuple(draft_logits.shape) == (batch, TINY_BLOCK_SIZE - 1, TINY_VOCAB)
+    assert torch.isfinite(draft_logits).all()
+
+
+def test_tiny_drafter_deterministic_and_non_causal():
+    target = build_tiny_target(seed=0)
+    drafter = build_tiny_drafter(target, seed=1)
+
+    feature = torch.randn(1, PROMPT.shape[1], len(TINY_TARGET_LAYER_IDS) * TINY_HIDDEN)
+    block = torch.tensor([[4] + [TINY_MASK_TOKEN_ID] * (TINY_BLOCK_SIZE - 1)])
+
+    with torch.no_grad():
+        out_a = drafter(block, feature)
+        out_b = drafter(block, feature)
+
+    assert torch.equal(out_a, out_b)
+    # Non-causal attention is part of the DFlash drafter contract (RFC §1.2).
+    assert getattr(drafter, "is_causal", True) is False
+
+
+def test_target_exposes_five_layer_context_feature():
+    target = build_tiny_target(seed=0)
+    with torch.no_grad():
+        out = target(PROMPT, output_hidden_states=True, use_cache=False)
+
+    # hidden_states[0] is the embedding output; layer i output is index i+1.
+    assert len(out.hidden_states) == target.config.num_hidden_layers + 1
+
+    feat = context_feature_from_hidden_states(out.hidden_states, TINY_TARGET_LAYER_IDS)
+    assert tuple(feat.shape[:2]) == (1, PROMPT.shape[1])
+    assert feat.shape[-1] == len(TINY_TARGET_LAYER_IDS) * TINY_HIDDEN
+
+
+def test_tiny_pair_parsed_by_real_config_layer():
+    from moe_infinity.spec_decode import read_dflash_config
+
+    target = build_tiny_target(seed=0)
+    cfg = read_dflash_config(make_tiny_drafter_config(target.config))
+
+    assert cfg.block_size == TINY_BLOCK_SIZE
+    assert cfg.mask_token_id == TINY_MASK_TOKEN_ID
+    assert list(cfg.target_layer_ids) == list(TINY_TARGET_LAYER_IDS)
+    assert cfg.hidden_size == TINY_HIDDEN == int(target.config.hidden_size)
+    assert cfg.vocab_size == TINY_VOCAB == int(target.config.vocab_size)
+
+    assert cfg.mask_token_id < int(target.config.vocab_size)
+    assert max(cfg.target_layer_ids) + 1 <= int(target.config.num_hidden_layers)


### PR DESCRIPTION
## Native gpt-oss DFlash speculative decoding (engine-integrated, greedy, resident)

Implements the RFC (PR #131) natively: replaces the passthrough `DFlashSpeculator.generate()` with a native **draft → verify → rollback** loop wired into `GenerationEngine` via a flag-gated strategy seam. Builds on the existing `feat/dflash-spec-decode` scaffold; drafter loaded via `trust_remote_code`.

### What's included (13 commits)

| Area | Change |
|---|---|
| **Engine seam** | Extract `_generate_standard` + `SpecDecodeStrategy` protocol in `engine/generation_loop.py` — **spec-off path is a verbatim extraction, byte-identical**. |
| **Forward/capture** | `_native_model_forward_rich` (on-device `(logits, hidden, past_kv)`) + `extract_context_feature` (5-layer `[1,9,17,25,33]`) in `entrypoints/big_modeling.py`. |
| **Accept-rule ops** | Pure `build_block` / `acceptance_length` / `committed_tokens` in `spec_decode/_dflash_ops.py`. |
| **Drafter loader** | Contract asserts (dim/vocab/mask/block/layer-ids), shared `embed_tokens`/`lm_head` by reference. |
| **Native loop** | `DFlashSpeculator.generate()` — bonus emitted-not-cached, full-logits verify, non-causal drafter, dual-cache rollback, suffix-only hidden refresh. |
| **Edge cases** | EOS mid-block, `max_new_tokens` boundary, accept 0/9, batch==1 guard. |
| **Engine wiring** | `MoE.generate(..., speculative_draft=...)` → routes greedy/batch-1 through the native strategy; no drafter ⇒ standard path (byte-identical). |
| **Tests + docs** | tiny-model E2E parity, spec-off regression, GPU-gated 120B harness, `docs/dflash.md`, example. |

### Notable deviation from the RFC (Oracle-reviewed)

The RFC assumed `DynamicCache.crop()` for KV rollback. This is **invalid for gpt-oss's sliding-window attention** (transformers 5.12 `DynamicSlidingWindowLayer` evicts prefix KV and refuses to crop once the window is saturated). Replaced with a **snapshot-before-verify + rebuild-after-accept** rollback for sliding layers (`crop()` retained for full-attention layers). Requires `block_size ≤ sliding_window − 1` (real gpt-oss: 10 ≤ 128 ✓); the tiny test fixture window was raised 8 → 128 accordingly.

### Testing

- **Autonomous (CPU, tiny model)** — `pytest tests/python/dflash -q` → **103 passed, 2 skipped**.
  - Losslessness gate: `test_native_e2e.py` — native DFlash == plain greedy, **token-identical** (engine path, ≥64 tokens, multi-prompt).
  - `test_spec_off_regression.py` — spec-off byte-identical to the committed baseline.
  - + accept-rule, capture, drafter-contract, edge-cases, engine-wire, native-step parity.
- **GPU-gated (120B)** — `test_gpu_120b.py` skips cleanly; run with `MOE_DFLASH_GPU=1` + cached checkpoints (TP=2 SM120) for agreement-rate / acceptance-length / tok-s.
- `ruff` (CI-pinned 0.6.9): clean. `generation_loop.py` non-spec path only extracted, not altered.

### Scope (v1)

Greedy + resident + batch==1 + sync path. **Deferred:** sampled speculative decoding, async serving, and expert-offload/prefetch coupling (offload remains a tunable knob via `device_memory_ratio`, not coupled to the spec loop in v1).

> Base: this PR stacks on the `feat/dflash-spec-decode` scaffold branch. An unrelated in-progress GLM FP8 commit that was present on the local branch is **excluded** from this PR.

🤖 Generated with [opencode](https://opencode.ai)
