### PR TITLE
fix(offload): enable offloaded MoE decode — ExpertDispatcher CAS race + Qwen3/3.5 support

### DIFF
--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -213,11 +213,6 @@ void ArcherPrefetchHandle::ReplaceCacheCandidates(
   std::vector<NodePtr> candidates;
   for (std::uint32_t tensor_id : tensor_ids) {
     auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
-    {
-      auto expected = NodeExecState::IDLE;
-      node->exec_state.compare_exchange_strong(
-          expected, NodeExecState::FETCHING, std::memory_order_acq_rel);
-    }
     candidates.push_back(node);
   }
 

--- a/moe_infinity/models/qwen.py
+++ b/moe_infinity/models/qwen.py
@@ -1,13 +1,30 @@
+from typing import Optional, Protocol
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
 from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeMLP
 
 
-class Qwen3MoEBlock(nn.Module):
-    layer_id = None
+class _ExpertExecutor(Protocol):
+    def dispatch_local(
+        self,
+        layer_id: Optional[int],
+        hidden_states: torch.Tensor,
+        router_mask: torch.Tensor,
+        router_weights: torch.Tensor,
+        router_logits: Optional[torch.Tensor] = None,
+        prefetcher: object = None,
+    ) -> None: ...
 
-    def __init__(self, config):
+    def wait_dispatch_local(self) -> torch.Tensor: ...
+
+
+class Qwen3MoEBlock(nn.Module):
+    layer_id: Optional[int] = None
+
+    def __init__(self, config: Qwen3MoeConfig):
         super().__init__()
         self.num_experts = config.num_experts
         self.top_k = config.num_experts_per_tok
@@ -25,8 +42,8 @@ class Qwen3MoEBlock(nn.Module):
             ]
         )
 
-        self.expert_executor = None
-        self.lib = None
+        self.expert_executor: Optional[_ExpertExecutor] = None
+        self.lib: Optional[object] = None
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         batch_size, sequence_length, hidden_dim = hidden_states.shape
@@ -49,17 +66,20 @@ class Qwen3MoEBlock(nn.Module):
         router_mask = torch.any(router_mask, dim=-1)
         routing_weights_mask = torch.sum(routing_weights_mask, dim=-1)
 
-        self.expert_executor.dispatch_local(
+        executor = self.expert_executor
+        if executor is None:
+            raise RuntimeError("Qwen3MoEBlock requires an expert executor")
+        executor.dispatch_local(
             self.layer_id,
             hidden_states,
             router_mask,
             routing_weights_mask,
             router_logits=router_logits,
         )
-        final_hidden_states = self.expert_executor.wait_dispatch_local()
+        final_hidden_states = executor.wait_dispatch_local()
 
         final_hidden_states = final_hidden_states.view(
             batch_size, sequence_length, hidden_dim
         ).to(hidden_states.dtype)
 
-        return final_hidden_states, router_logits
+        return final_hidden_states

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -964,6 +964,13 @@ class OffloadEngine(object):
     def get_topology(self, model):
         name_lst = []
         ret_dict = {}
+        is_qwen3_5 = "qwen3_5" in _arch_name(self.config)
+
+        def is_routed_expert(name):
+            if is_qwen3_5:
+                _, expert_id = parse_expert_id(name, self.config)
+                return expert_id is not None
+            return "expert" in name and "shared_experts" not in name
 
         for name, _ in model.named_parameters(recurse=True):
             match = re.search(r"\d+", name)
@@ -971,7 +978,7 @@ class OffloadEngine(object):
                 print("param not in self.name_id_map", name)
                 continue
             if match:
-                if "expert" in name and "shared_experts" not in name:
+                if is_routed_expert(name):
                     match = re.match(r"(.*experts)", name)
                     assert match, "Not correct expert name!"
                     stored_name = match.group(1)
@@ -1028,7 +1035,7 @@ class OffloadEngine(object):
             if name not in self.name_id_map:
                 continue
             if match:
-                if "expert" in name and "shared_experts" not in name:
+                if is_routed_expert(name):
                     match = re.match(r"(.*experts)", name)
                     assert match, "Not correct expert name!"
                     stored_name = match.group(1)

--- a/tests/python/unit/test_qwen3_5_moe.py
+++ b/tests/python/unit/test_qwen3_5_moe.py
@@ -16,6 +16,7 @@ from moe_infinity.common.constants import (
     parse_expert_type,
 )
 from moe_infinity.models import SyncQwen3_5MoeSparseMoeBlock
+from moe_infinity.runtime.model_offload import OffloadEngine
 from moe_infinity.utils.hf_config import parse_expert_id, parse_moe_param
 
 
@@ -134,3 +135,36 @@ def test_sync_block_executor_stays_unset():
     cfg = _tiny_text_config()
     block = SyncQwen3_5MoeSparseMoeBlock(cfg)
     assert block.expert_executor is None
+
+
+def test_qwen3_5_topology_distinguishes_shared_and_routed_experts():
+    class TinyQwen35(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.model = torch.nn.Module()
+            self.model.language_model = torch.nn.Module()
+            self.model.language_model.layers = torch.nn.ModuleList(
+                [torch.nn.Module()]
+            )
+            layer = self.model.language_model.layers[0]
+            layer.mlp = SyncQwen3_5MoeSparseMoeBlock(_tiny_text_config())
+
+    model = TinyQwen35()
+    engine = object.__new__(OffloadEngine)
+    engine.config = _arch("Qwen3_5MoeForConditionalGeneration")
+    engine.name_id_map = {
+        name: tensor_id
+        for tensor_id, (name, _) in enumerate(model.named_parameters())
+    }
+
+    topology = dict(engine.get_topology(model))
+
+    routed = topology["model.language_model.layers.0.mlp.experts"]
+    assert len(routed) == 8
+    shared_stage = topology["model.language_model.layers.0"][0]
+    shared_ids = {
+        engine.name_id_map[name]
+        for name, _ in model.named_parameters()
+        if ".shared_expert" in name
+    }
+    assert shared_ids <= set(shared_stage)

--- a/tests/python/unit/test_qwen3_moe.py
+++ b/tests/python/unit/test_qwen3_moe.py
@@ -1,0 +1,52 @@
+import torch
+from transformers.models.qwen3_moe.configuration_qwen3_moe import Qwen3MoeConfig
+
+from moe_infinity.models import Qwen3MoEBlock
+
+
+class _RecordingExecutor:
+    def __init__(self):
+        self.hidden_states: torch.Tensor | None = None
+        self.router_logits: torch.Tensor | None = None
+
+    def dispatch_local(
+        self,
+        layer_id: int | None,
+        hidden_states: torch.Tensor,
+        router_mask: torch.Tensor,
+        router_weights: torch.Tensor,
+        router_logits: torch.Tensor | None = None,
+        prefetcher: object = None,
+    ) -> None:
+        del layer_id, router_mask, router_weights, prefetcher
+        self.hidden_states = hidden_states
+        self.router_logits = router_logits
+
+    def wait_dispatch_local(self) -> torch.Tensor:
+        assert self.hidden_states is not None
+        return self.hidden_states.clone()
+
+
+def test_qwen3_block_returns_tensor_and_routes_logits_via_executor():
+    config = Qwen3MoeConfig(
+        hidden_size=16,
+        moe_intermediate_size=8,
+        num_experts=4,
+        num_experts_per_tok=2,
+        norm_topk_prob=True,
+    )
+    block = Qwen3MoEBlock(config)
+    executor = _RecordingExecutor()
+    block.expert_executor = executor
+    block.layer_id = 3
+    hidden_states = torch.randn(2, 5, config.hidden_size)
+
+    output = block(hidden_states)
+
+    assert isinstance(output, torch.Tensor)
+    assert output.shape == hidden_states.shape
+    assert executor.router_logits is not None
+    assert executor.router_logits.shape == (
+        hidden_states.shape[0] * hidden_states.shape[1],
+        config.num_experts,
+    )


### PR DESCRIPTION
Fixes three pre-existing bugs that broke **offloaded** MoE decode (independent of DFlash):

- **Native `ExpertDispatcher` CAS race** — `ReplaceCacheCandidates` prematurely CAS'd nodes `IDLE->FETCHING`, racing the dispatcher's own transition and fatally aborting (`exec_state CAS failed`) before the first forward in offloaded mode. Removed the premature CAS so the fetch path owns the state.
- **Qwen3 offloaded MoE-block tuple** — the offloaded MoE block returned `(hidden, router_logits)`; transformers 5.x `qwen3_moe` expects a bare tensor (`residual + hidden`). Now returns only `hidden_states`, routing router_logits via the `dispatch_local` side-channel.
- **Qwen3.5 `get_topology` expert-name** — routed through `parse_expert_id` (fixes `AssertionError: Not correct expert name!`).

**Validation:** offloaded Qwen3-30B-A3B greedy decode now works end-to-end on GPU (was fatal before); `tests/python/unit/test_qwen3_moe.py` + `test_qwen3_5_moe.py` green (17 passed). Native change requires an sm_120 rebuild.