### PR TITLE
feat(dflash): route-ahead prefetch, sampled/batched decoding, serving integration + drafter-driven contract

### DIFF
--- a/benchmarks/performance_model/__init__.py
+++ b/benchmarks/performance_model/__init__.py
@@ -1,4 +1,8 @@
-from benchmarks.performance_model.types import ModelParams, WorkloadPoint, DemandResult
 from benchmarks.performance_model.roofline import predict_decode
+from benchmarks.performance_model.types import (
+    DemandResult,
+    ModelParams,
+    WorkloadPoint,
+)
 
 __all__ = ["ModelParams", "WorkloadPoint", "DemandResult", "predict_decode"]

--- a/benchmarks/performance_model/bench_glm.py
+++ b/benchmarks/performance_model/bench_glm.py
@@ -8,12 +8,12 @@ import torch
 
 
 def measure_tiny_glm(tmp_dir: str, gen_len: int = 16) -> dict:
-    from tests.python.integration._glm_tiny import build_tiny_glm
-    from moe_infinity import MoE
-    from moe_infinity.spec_decode.glm_mtp import GlmMtpSpeculator
     from benchmarks.performance_model.model_config import extract_model_params
     from benchmarks.performance_model.roofline import predict_decode
     from benchmarks.performance_model.types import WorkloadPoint
+    from moe_infinity import MoE
+    from moe_infinity.spec_decode.glm_mtp import GlmMtpSpeculator
+    from tests.python.integration._glm_tiny import build_tiny_glm
 
     ckpt_dir = os.path.join(tmp_dir, "tiny_glm_ckpt")
     off_dir = os.path.join(tmp_dir, "tiny_glm_off")
@@ -85,15 +85,26 @@ def measure_tiny_glm(tmp_dir: str, gen_len: int = 16) -> dict:
 def run(out_csv: str, quick: bool = True, gen_len: int = 16) -> None:
     import tempfile
 
-    os.makedirs(os.path.dirname(out_csv) if os.path.dirname(out_csv) else ".", exist_ok=True)
+    os.makedirs(
+        os.path.dirname(out_csv) if os.path.dirname(out_csv) else ".",
+        exist_ok=True,
+    )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         row = measure_tiny_glm(tmp_dir, gen_len=gen_len)
 
     fieldnames = [
-        "model", "batch", "seq_len", "gen_len",
-        "decode_tok_s", "mtp_tok_s", "mean_accept_len", "peak_mem_bytes",
-        "pred_flops_per_token", "pred_hbm_bytes_per_token", "pred_bound",
+        "model",
+        "batch",
+        "seq_len",
+        "gen_len",
+        "decode_tok_s",
+        "mtp_tok_s",
+        "mean_accept_len",
+        "peak_mem_bytes",
+        "pred_flops_per_token",
+        "pred_hbm_bytes_per_token",
+        "pred_bound",
     ]
 
     with open(out_csv, "w", newline="") as f:

--- a/benchmarks/performance_model/model_config.py
+++ b/benchmarks/performance_model/model_config.py
@@ -19,8 +19,12 @@ def _extract_glm(config) -> ModelParams:
         name=getattr(config, "_name_or_path", "glm_moe_dsa"),
         num_layers=config.num_hidden_layers,
         num_attn_heads=config.num_attention_heads,
-        num_kv_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
-        head_dim=getattr(config, "head_dim", config.hidden_size // config.num_attention_heads),
+        num_kv_heads=getattr(
+            config, "num_key_value_heads", config.num_attention_heads
+        ),
+        head_dim=getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        ),
         hidden_size=config.hidden_size,
         vocab_size=config.vocab_size,
         num_experts=config.n_routed_experts,
@@ -36,20 +40,34 @@ def _extract_glm(config) -> ModelParams:
 
 
 def _extract_generic(config) -> ModelParams:
-    num_experts = getattr(config, "num_local_experts", None) or getattr(config, "n_routed_experts", None) or getattr(config, "num_experts", 1)
-    top_k = getattr(config, "num_experts_per_tok", None) or getattr(config, "top_k", 1)
+    num_experts = (
+        getattr(config, "num_local_experts", None)
+        or getattr(config, "n_routed_experts", None)
+        or getattr(config, "num_experts", 1)
+    )
+    top_k = getattr(config, "num_experts_per_tok", None) or getattr(
+        config, "top_k", 1
+    )
     return ModelParams(
         name=getattr(config, "_name_or_path", "unknown"),
         num_layers=config.num_hidden_layers,
         num_attn_heads=config.num_attention_heads,
-        num_kv_heads=getattr(config, "num_key_value_heads", config.num_attention_heads),
-        head_dim=getattr(config, "head_dim", config.hidden_size // config.num_attention_heads),
+        num_kv_heads=getattr(
+            config, "num_key_value_heads", config.num_attention_heads
+        ),
+        head_dim=getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        ),
         hidden_size=config.hidden_size,
         vocab_size=config.vocab_size,
         num_experts=num_experts,
         top_k=top_k,
         shared_experts=getattr(config, "n_shared_experts", 0),
-        expert_intermediate_size=getattr(config, "moe_intermediate_size", getattr(config, "intermediate_size", config.hidden_size * 4)),
+        expert_intermediate_size=getattr(
+            config,
+            "moe_intermediate_size",
+            getattr(config, "intermediate_size", config.hidden_size * 4),
+        ),
         first_k_dense=getattr(config, "first_k_dense_replace", 0),
         expert_dtype=_expert_dtype_from_config(config),
         attn_dtype="bf16",
@@ -61,7 +79,9 @@ def _extract_generic(config) -> ModelParams:
 def extract_model_params(model_name_or_path: str) -> ModelParams:
     from transformers import AutoConfig
 
-    config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
+    config = AutoConfig.from_pretrained(
+        model_name_or_path, trust_remote_code=True
+    )
     arch = (getattr(config, "architectures", None) or [""])[0].lower()
 
     if "glmmoedsa" in arch:

--- a/benchmarks/performance_model/report_glm.py
+++ b/benchmarks/performance_model/report_glm.py
@@ -1,4 +1,5 @@
 """GLM performance model validation report generator."""
+
 import argparse
 import csv
 import os
@@ -9,6 +10,7 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 # Summarize
 # ---------------------------------------------------------------------------
+
 
 def summarize(csv_path: str) -> dict:
     rows = []
@@ -24,11 +26,13 @@ def summarize(csv_path: str) -> dict:
             r["pred_hbm_bytes_per_token"] = float(r["pred_hbm_bytes_per_token"])
             r["arithmetic_intensity"] = (
                 r["pred_flops_per_token"] / r["pred_hbm_bytes_per_token"]
-                if r["pred_hbm_bytes_per_token"] > 0 else 0.0
+                if r["pred_hbm_bytes_per_token"] > 0
+                else 0.0
             )
             r["mtp_speedup"] = (
                 r["mtp_tok_s"] / r["decode_tok_s"]
-                if r["decode_tok_s"] > 0 else 0.0
+                if r["decode_tok_s"] > 0
+                else 0.0
             )
             rows.append(r)
 
@@ -56,11 +60,14 @@ def summarize(csv_path: str) -> dict:
 # Plots
 # ---------------------------------------------------------------------------
 
-def make_plots(csv_path: str, out_dir: str) -> list:
-    sys.path.insert(0, "/home/leyang/.config/opencode/skills/conference-plot/scripts")
-    from plot_utils import paper_style, WONG_PALETTE, HATCHES, save_dual_output
 
+def make_plots(csv_path: str, out_dir: str) -> list:
+    sys.path.insert(
+        0, "/home/leyang/.config/opencode/skills/conference-plot/scripts"
+    )
     import matplotlib
+    from plot_utils import HATCHES, WONG_PALETTE, paper_style, save_dual_output
+
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
     import numpy as np
@@ -80,12 +87,26 @@ def make_plots(csv_path: str, out_dir: str) -> list:
 
     with paper_style(width=max(3.3, len(rows) * 1.5), height=2.8):
         fig, ax = plt.subplots()
-        bars1 = ax.bar(x - w / 2, decode_vals, w, label="Decode (no MTP)",
-                       color=WONG_PALETTE[2], edgecolor="black", linewidth=0.4,
-                       hatch=HATCHES[0])
-        bars2 = ax.bar(x + w / 2, mtp_vals, w, label="MTP",
-                       color=WONG_PALETTE[1], edgecolor="black", linewidth=0.4,
-                       hatch=HATCHES[1])
+        bars1 = ax.bar(
+            x - w / 2,
+            decode_vals,
+            w,
+            label="Decode (no MTP)",
+            color=WONG_PALETTE[2],
+            edgecolor="black",
+            linewidth=0.4,
+            hatch=HATCHES[0],
+        )
+        bars2 = ax.bar(
+            x + w / 2,
+            mtp_vals,
+            w,
+            label="MTP",
+            color=WONG_PALETTE[1],
+            edgecolor="black",
+            linewidth=0.4,
+            hatch=HATCHES[1],
+        )
         ax.set_xticks(x)
         ax.set_xticklabels(labels, fontsize=6)
         ax.set_ylabel("Throughput (tok/s)")
@@ -105,18 +126,32 @@ def make_plots(csv_path: str, out_dir: str) -> list:
 
     with paper_style(width=3.5, height=2.8):
         fig, ax = plt.subplots()
-        for i, (ai, tput, bound, row) in enumerate(zip(ai_vals, tput_vals, bound_labels, rows)):
+        for i, (ai, tput, bound, row) in enumerate(
+            zip(ai_vals, tput_vals, bound_labels, rows)
+        ):
             color = WONG_PALETTE[5] if bound == "compute" else WONG_PALETTE[6]
-            ax.scatter(ai, tput, color=color, s=60, zorder=5,
-                       marker="o", edgecolors="black", linewidths=0.4)
+            ax.scatter(
+                ai,
+                tput,
+                color=color,
+                s=60,
+                zorder=5,
+                marker="o",
+                edgecolors="black",
+                linewidths=0.4,
+            )
             ax.annotate(
                 f"{bound}\n({row['model']})",
                 (ai, tput),
-                textcoords="offset points", xytext=(6, 4), fontsize=6,
+                textcoords="offset points",
+                xytext=(6, 4),
+                fontsize=6,
             )
 
         # Draw reference lines
-        ai_range = np.linspace(max(0.1, min(ai_vals) * 0.5), max(ai_vals) * 2, 100)
+        ai_range = np.linspace(
+            max(0.1, min(ai_vals) * 0.5), max(ai_vals) * 2, 100
+        )
         # Roofline: HBM-bound slope (arbitrary scale for illustration)
         hbm_bw_ref = 900e9  # H100 HBM BW bytes/s (illustrative)
         compute_roof = 312e12  # H100 FP16 TFLOPS (illustrative)
@@ -126,11 +161,17 @@ def make_plots(csv_path: str, out_dir: str) -> list:
             hbm_roof_toks = hbm_bw_ref / ref_row["pred_hbm_bytes_per_token"]
             compute_roof_toks = compute_roof / ref_row["pred_flops_per_token"]
             roof_vals = np.minimum(
-                ai_range * (hbm_roof_toks / ai_range[0]),
-                compute_roof_toks
+                ai_range * (hbm_roof_toks / ai_range[0]), compute_roof_toks
             )
-            ax.plot(ai_range, roof_vals, "--", color=WONG_PALETTE[0],
-                    linewidth=0.8, label="Roofline (H100 ref)", alpha=0.5)
+            ax.plot(
+                ai_range,
+                roof_vals,
+                "--",
+                color=WONG_PALETTE[0],
+                linewidth=0.8,
+                label="Roofline (H100 ref)",
+                alpha=0.5,
+            )
 
         ax.set_xlabel("Arithmetic Intensity (FLOP/byte)")
         ax.set_ylabel("Decode Throughput (tok/s)")
@@ -149,6 +190,7 @@ def make_plots(csv_path: str, out_dir: str) -> list:
 # Report
 # ---------------------------------------------------------------------------
 
+
 def write_report(csv_path: str, plots_dir: str, out_md: str) -> None:
     summary = summarize(csv_path)
     rows = summary["rows"]
@@ -166,8 +208,12 @@ def write_report(csv_path: str, plots_dir: str, out_md: str) -> None:
     lines.append(f"**CSV source:** `{csv_abs}`  ")
     lines.append(f"**Rows:** {summary['n_rows']}  ")
     lines.append("")
-    lines.append("> **Note:** Results use `MOE_GLM_TINY=1` (tiny model). Absolute throughput is")
-    lines.append("> illustrative only. The deliverable is the pipeline + bound classification methodology.")
+    lines.append(
+        "> **Note:** Results use `MOE_GLM_TINY=1` (tiny model). Absolute throughput is"
+    )
+    lines.append(
+        "> illustrative only. The deliverable is the pipeline + bound classification methodology."
+    )
     lines.append("")
 
     # --- Measured + Predicted table ---
@@ -267,6 +313,7 @@ def write_report(csv_path: str, plots_dir: str, out_md: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main():
     parser = argparse.ArgumentParser(description="GLM perf model report")
     parser.add_argument("--csv", required=True, help="Path to bench CSV")
@@ -276,9 +323,11 @@ def main():
 
     print(f"Summarizing {args.csv} ...")
     s = summarize(args.csv)
-    print(f"  {s['n_rows']} rows, avg decode={s['avg_decode_tok_s']:.1f} tok/s, "
-          f"avg mtp={s['avg_mtp_tok_s']:.1f} tok/s, "
-          f"avg speedup={s['avg_mtp_speedup']:.3f}x")
+    print(
+        f"  {s['n_rows']} rows, avg decode={s['avg_decode_tok_s']:.1f} tok/s, "
+        f"avg mtp={s['avg_mtp_tok_s']:.1f} tok/s, "
+        f"avg speedup={s['avg_mtp_speedup']:.3f}x"
+    )
 
     print(f"Generating plots in {args.out_dir} ...")
     saved = make_plots(args.csv, args.out_dir)

--- a/benchmarks/performance_model/roofline.py
+++ b/benchmarks/performance_model/roofline.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Literal
 
-from benchmarks.performance_model.types import DemandResult, ModelParams, WorkloadPoint
+from benchmarks.performance_model.types import (
+    DemandResult,
+    ModelParams,
+    WorkloadPoint,
+)
 
 
 def dtype_bytes(dtype: str) -> float:
@@ -18,11 +22,15 @@ def decode_flops_per_token(p: ModelParams) -> int:
     # K: hidden -> num_kv_heads * head_dim
     # V: hidden -> num_kv_heads * head_dim
     # O: num_attn_heads * head_dim -> hidden
-    attn_qkv_o = 2 * p.hidden_size * (
-        p.num_attn_heads * p.head_dim  # Q
-        + p.num_kv_heads * p.head_dim  # K
-        + p.num_kv_heads * p.head_dim  # V
-        + p.num_attn_heads * p.head_dim  # O
+    attn_qkv_o = (
+        2
+        * p.hidden_size
+        * (
+            p.num_attn_heads * p.head_dim  # Q
+            + p.num_kv_heads * p.head_dim  # K
+            + p.num_kv_heads * p.head_dim  # V
+            + p.num_attn_heads * p.head_dim  # O
+        )
     )
     attn_flops = p.num_layers * attn_qkv_o
 
@@ -48,8 +56,12 @@ def decode_flops_per_token(p: ModelParams) -> int:
     return attn_flops + dense_flops + moe_flops
 
 
-def decode_hbm_bytes_per_token(p: ModelParams, dtype_override: str | None = None) -> int:
-    expert_bw = dtype_bytes(dtype_override if dtype_override else p.expert_dtype)
+def decode_hbm_bytes_per_token(
+    p: ModelParams, dtype_override: str | None = None
+) -> int:
+    expert_bw = dtype_bytes(
+        dtype_override if dtype_override else p.expert_dtype
+    )
     attn_bw = dtype_bytes(p.attn_dtype)
 
     # Attention weight bytes per layer (Q, K, V, O projections)
@@ -72,20 +84,30 @@ def decode_hbm_bytes_per_token(p: ModelParams, dtype_override: str | None = None
     moe_layers = p.num_layers - p.first_k_dense
 
     # Routed expert weight bytes: top_k active experts per MoE layer
-    routed_expert_bytes_per_layer = expert_bw * p.top_k * (
-        p.hidden_size * p.expert_intermediate_size  # gate
-        + p.hidden_size * p.expert_intermediate_size  # up
-        + p.expert_intermediate_size * p.hidden_size  # down
+    routed_expert_bytes_per_layer = (
+        expert_bw
+        * p.top_k
+        * (
+            p.hidden_size * p.expert_intermediate_size  # gate
+            + p.hidden_size * p.expert_intermediate_size  # up
+            + p.expert_intermediate_size * p.hidden_size  # down
+        )
     )
 
     # Shared expert weight bytes (always bf16 / attn_bw)
-    shared_expert_bytes_per_layer = attn_bw * p.shared_experts * (
-        p.hidden_size * p.expert_intermediate_size
-        + p.hidden_size * p.expert_intermediate_size
-        + p.expert_intermediate_size * p.hidden_size
+    shared_expert_bytes_per_layer = (
+        attn_bw
+        * p.shared_experts
+        * (
+            p.hidden_size * p.expert_intermediate_size
+            + p.hidden_size * p.expert_intermediate_size
+            + p.expert_intermediate_size * p.hidden_size
+        )
     )
 
-    moe_bytes = moe_layers * (routed_expert_bytes_per_layer + shared_expert_bytes_per_layer)
+    moe_bytes = moe_layers * (
+        routed_expert_bytes_per_layer + shared_expert_bytes_per_layer
+    )
 
     return int(attn_bytes + dense_bytes + moe_bytes)
 
@@ -104,7 +126,11 @@ def classify_bound(
 ) -> Literal["compute", "hbm", "pcie"]:
     t_compute = flops / peak_flops
     t_hbm = hbm_bytes / (hbm_gbps * 1e9)
-    t_pcie = pcie_bytes / (pcie_gbps * 1e9) if pcie_gbps > 0 and pcie_bytes > 0 else 0.0
+    t_pcie = (
+        pcie_bytes / (pcie_gbps * 1e9)
+        if pcie_gbps > 0 and pcie_bytes > 0
+        else 0.0
+    )
 
     bottleneck = max(t_compute, t_hbm, t_pcie)
     if bottleneck == t_pcie and t_pcie > 0:
@@ -126,7 +152,9 @@ def predict_decode(
     pcie_bytes = 0
 
     ai = arithmetic_intensity(flops, hbm_bytes)
-    bound = classify_bound(flops, hbm_bytes, pcie_bytes, peak_flops, hbm_gbps, pcie_gbps)
+    bound = classify_bound(
+        flops, hbm_bytes, pcie_bytes, peak_flops, hbm_gbps, pcie_gbps
+    )
 
     return DemandResult(
         flops_per_token=flops,

--- a/benchmarks/performance_model/types.py
+++ b/benchmarks/performance_model/types.py
@@ -19,7 +19,7 @@ class ModelParams:
     expert_intermediate_size: int
     first_k_dense: int
     expert_dtype: str  # "fp8" | "bf16"
-    attn_dtype: str    # "bf16" | "fp16" | "fp32"
+    attn_dtype: str  # "bf16" | "fp16" | "fp32"
     kv_lora_rank: Optional[int] = None
     q_lora_rank: Optional[int] = None
 

--- a/core/parallel/expert_dispatcher.cpp
+++ b/core/parallel/expert_dispatcher.cpp
@@ -28,8 +28,8 @@ extern void fp8_dequant_blockwise_cuda(const void* weight, const void* scale,
                                        cudaStream_t stream);
 
 static torch::Tensor _fp8_dequant_on_device(const torch::Tensor& w_fp8,
-                                             const torch::Tensor& scale,
-                                             cudaStream_t stream) {
+                                            const torch::Tensor& scale,
+                                            cudaStream_t stream) {
   int N = w_fp8.size(0);
   int K = w_fp8.size(1);
   auto out = torch::empty(

--- a/core/parallel/expert_module.cpp
+++ b/core/parallel/expert_module.cpp
@@ -244,12 +244,12 @@ void MoEMLP::DequantFp8Params(cudaStream_t stream) {
     auto s_gpu = s.to(torch::kFloat32).to(CUDA_DEVICE(device));
     int N = w.size(0);
     int K = w.size(1);
-    auto out = torch::empty(
-        {N, K},
-        torch::TensorOptions().dtype(torch::kBFloat16).device(CUDA_DEVICE(device)));
+    auto out = torch::empty({N, K}, torch::TensorOptions()
+                                        .dtype(torch::kBFloat16)
+                                        .device(CUDA_DEVICE(device)));
     auto w_u8 = w.view(torch::kUInt8).contiguous();
-    fp8_dequant_blockwise_cuda(w_u8.data_ptr(), s_gpu.data_ptr(), out.data_ptr(),
-                               N, K, stream);
+    fp8_dequant_blockwise_cuda(w_u8.data_ptr(), s_gpu.data_ptr(),
+                               out.data_ptr(), N, K, stream);
     param_[i] = out;
   }
 }

--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -99,6 +99,10 @@ void ArcherPrefetchHandle::AcquireTensor(std::uint64_t& request_id,
   DLOG_TRACE("Acquire tensor ", tensor_id, old_ptr);
 
   auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
+  if (node == nullptr) {
+    DLOG_ERROR("AcquireTensor: no topology node for tensor_id ", tensor_id);
+    return;
+  }
   node->state = 1;
 
   // add node tensor_ids to node_id_to_tensor_ids_
@@ -149,6 +153,10 @@ void ArcherPrefetchHandle::ReleaseTensor(std::uint64_t& request_id,
   DLOG_TRACE("Release tensor ", tensor_id, old_ptr);
 
   auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
+  if (node == nullptr) {
+    DLOG_ERROR("ReleaseTensor: no topology node for tensor_id ", tensor_id);
+    return;
+  }
   // node->state = 1;
 
   if (node_id_to_tensor_ids_.find(node->id) == node_id_to_tensor_ids_.end()) {
@@ -167,7 +175,7 @@ void ArcherPrefetchHandle::ReleaseTensor(std::uint64_t& request_id,
   // TraceRequest(request_id, tensor_id);
 
   auto current_layer_id = node->corr_id & 0xFFFFFFFF;
-  if (current_layer_id != last_layer_id_ &&
+  if (last_node_ != nullptr && current_layer_id != last_layer_id_ &&
       node_id_to_tensor_ids_[last_node_->id].size() != 0) {
     node_id_to_tensor_ids_[last_node_->id].clear();
     kTaskPool->StopExec(request_id,
@@ -221,11 +229,6 @@ void ArcherPrefetchHandle::ReplaceCacheCandidates(
   std::vector<NodePtr> candidates;
   for (std::uint32_t tensor_id : tensor_ids) {
     auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
-    {
-      auto expected = NodeExecState::IDLE;
-      node->exec_state.compare_exchange_strong(
-          expected, NodeExecState::FETCHING, std::memory_order_acq_rel);
-    }
     candidates.push_back(node);
   }
 

--- a/core/python/py_archer_prefetch.cpp
+++ b/core/python/py_archer_prefetch.cpp
@@ -34,14 +34,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       // &ArcherPrefetchHandle::AcquireTensor) .def("end", (void
       // (ArcherPrefetchHandle::*)(torch::nn::Module&))
       // &ArcherPrefetchHandle::ReleaseTensor)
-      .def("begin",
-           (void(ArcherPrefetchHandle::*)(std::uint64_t&, torch::Tensor&,
-                                          std::uint32_t)) &
-               ArcherPrefetchHandle::AcquireTensor)
-      .def("end",
-           (void(ArcherPrefetchHandle::*)(std::uint64_t&, torch::Tensor&,
-                                          std::uint32_t)) &
-               ArcherPrefetchHandle::ReleaseTensor)
+      .def("begin", (void(ArcherPrefetchHandle::*)(
+                        std::uint64_t&, torch::Tensor&, std::uint32_t)) &
+                        ArcherPrefetchHandle::AcquireTensor)
+      .def("end", (void(ArcherPrefetchHandle::*)(std::uint64_t&, torch::Tensor&,
+                                                 std::uint32_t)) &
+                      ArcherPrefetchHandle::ReleaseTensor)
       // .def("begin",
       //      (void (ArcherPrefetchHandle::*)(torch::Tensor&, const
       //      std::uint32_t)) &

--- a/examples/dflash_gpt_oss_example.py
+++ b/examples/dflash_gpt_oss_example.py
@@ -35,7 +35,9 @@ import time
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--model_name_or_path", default="openai/gpt-oss-120b")
-    parser.add_argument("--draft_model_path", default="z-lab/gpt-oss-120b-DFlash")
+    parser.add_argument(
+        "--draft_model_path", default="z-lab/gpt-oss-120b-DFlash"
+    )
     parser.add_argument("--offload_dir", required=True)
     parser.add_argument("--device_memory_ratio", type=float, default=0.75)
     parser.add_argument("--max_new_tokens", type=int, default=64)

--- a/extensions/kernel/v4_fp4/fp8_dequant.cu
+++ b/extensions/kernel/v4_fp4/fp8_dequant.cu
@@ -5,13 +5,13 @@
 //
 // FP8 (E4M3) block-scale weight -> BF16 dequant for GLM-5.2-FP8 routed experts.
 // Weight: [N, K] float8_e4m3fn; Scale: [ceil(N/128), ceil(K/128)] float32.
-// Each 128x128 block of weights shares one scale (weight_scale_inv = multiplier).
-// Output: [N, K] bfloat16.
+// Each 128x128 block of weights shares one scale (weight_scale_inv =
+// multiplier). Output: [N, K] bfloat16.
 //
 // Reference: moe_infinity/utils/fp8.py::dequant_fp8_blockwise
 //   w_f32 = weight.float()
-//   s_full = scale.repeat_interleave(128, dim=0).repeat_interleave(128, dim=1)[:N, :K]
-//   out = (w_f32 * s_full).to(bfloat16)
+//   s_full = scale.repeat_interleave(128, dim=0).repeat_interleave(128,
+//   dim=1)[:N, :K] out = (w_f32 * s_full).to(bfloat16)
 
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
@@ -23,61 +23,58 @@ namespace {
 // Reads fp8 byte, interprets as float8_e4m3fn, multiplies by block scale.
 // fp8_e4m3fn: sign=1, exp=4, mantissa=3, bias=7, no inf (NaN=0x7F).
 __device__ __forceinline__ float fp8_e4m3fn_to_float(uint8_t bits) {
-    // Decode float8_e4m3fn (bias=7, no inf, NaN=0x7F/0xFF)
-    int sign = (bits >> 7) & 1;
-    int exp  = (bits >> 3) & 0xF;
-    int mant = bits & 0x7;
+  // Decode float8_e4m3fn (bias=7, no inf, NaN=0x7F/0xFF)
+  int sign = (bits >> 7) & 1;
+  int exp = (bits >> 3) & 0xF;
+  int mant = bits & 0x7;
 
-    float val;
-    if (exp == 0) {
-        // subnormal: value = (-1)^sign * 2^(-6) * (mant/8)
-        val = (float)mant / 8.0f * 0.015625f;  // 2^(-6) = 0.015625
-    } else if (exp == 15 && mant == 7) {
-        // NaN (0x7F or 0xFF)
-        val = 0.0f;  // treat NaN as 0 for dequant
-    } else {
-        // normal: value = (-1)^sign * 2^(exp-7) * (1 + mant/8)
-        val = ldexpf(1.0f + (float)mant / 8.0f, exp - 7);
-    }
-    return sign ? -val : val;
+  float val;
+  if (exp == 0) {
+    // subnormal: value = (-1)^sign * 2^(-6) * (mant/8)
+    val = (float)mant / 8.0f * 0.015625f;  // 2^(-6) = 0.015625
+  } else if (exp == 15 && mant == 7) {
+    // NaN (0x7F or 0xFF)
+    val = 0.0f;  // treat NaN as 0 for dequant
+  } else {
+    // normal: value = (-1)^sign * 2^(exp-7) * (1 + mant/8)
+    val = ldexpf(1.0f + (float)mant / 8.0f, exp - 7);
+  }
+  return sign ? -val : val;
 }
 
 __global__ void fp8_dequant_blockwise_kernel(
-    const uint8_t* __restrict__ weight,   // [N, K] fp8 bytes
-    const float*   __restrict__ scale,    // [SN, SK] float32, SN=ceil(N/128), SK=ceil(K/128)
-    __nv_bfloat16* __restrict__ out,      // [N, K] bf16
-    int N, int K, int SK                  // SK = ceil(K/128)
+    const uint8_t* __restrict__ weight,  // [N, K] fp8 bytes
+    const float* __restrict__ scale,     // [SN, SK] float32, SN=ceil(N/128),
+                                         // SK=ceil(K/128)
+    __nv_bfloat16* __restrict__ out,     // [N, K] bf16
+    int N, int K, int SK                 // SK = ceil(K/128)
 ) {
-    long idx = (long)blockIdx.x * blockDim.x + threadIdx.x;
-    long total = (long)N * K;
-    if (idx >= total) return;
+  long idx = (long)blockIdx.x * blockDim.x + threadIdx.x;
+  long total = (long)N * K;
+  if (idx >= total) return;
 
-    int row = (int)(idx / K);
-    int col = (int)(idx % K);
+  int row = (int)(idx / K);
+  int col = (int)(idx % K);
 
-    // Block indices
-    int br = row / 128;
-    int bc = col / 128;
-    float s = scale[(long)br * SK + bc];
+  // Block indices
+  int br = row / 128;
+  int bc = col / 128;
+  float s = scale[(long)br * SK + bc];
 
-    float w = fp8_e4m3fn_to_float(weight[idx]);
-    out[idx] = __float2bfloat16(w * s);
+  float w = fp8_e4m3fn_to_float(weight[idx]);
+  out[idx] = __float2bfloat16(w * s);
 }
 
 }  // namespace
 
-void fp8_dequant_blockwise_cuda(
-    const void* weight, const void* scale, void* out,
-    int N, int K, cudaStream_t stream
-) {
-    int SK = (K + 127) / 128;
-    long total = (long)N * K;
-    int threads = 256;
-    long blocks = (total + threads - 1) / threads;
-    fp8_dequant_blockwise_kernel<<<blocks, threads, 0, stream>>>(
-        reinterpret_cast<const uint8_t*>(weight),
-        reinterpret_cast<const float*>(scale),
-        reinterpret_cast<__nv_bfloat16*>(out),
-        N, K, SK
-    );
+void fp8_dequant_blockwise_cuda(const void* weight, const void* scale,
+                                void* out, int N, int K, cudaStream_t stream) {
+  int SK = (K + 127) / 128;
+  long total = (long)N * K;
+  int threads = 256;
+  long blocks = (total + threads - 1) / threads;
+  fp8_dequant_blockwise_kernel<<<blocks, threads, 0, stream>>>(
+      reinterpret_cast<const uint8_t*>(weight),
+      reinterpret_cast<const float*>(scale),
+      reinterpret_cast<__nv_bfloat16*>(out), N, K, SK);
 }

--- a/extensions/kernel/v4_fp4/v4_fp4_binding.cpp
+++ b/extensions/kernel/v4_fp4/v4_fp4_binding.cpp
@@ -12,8 +12,8 @@
 void fp4_dequant_to_bf16(const void* packed, const void* scale_e8m0, void* out,
                          int N, int K, cudaStream_t stream);
 
-void fp8_dequant_blockwise_cuda(const void* weight, const void* scale, void* out,
-                                int N, int K, cudaStream_t stream);
+void fp8_dequant_blockwise_cuda(const void* weight, const void* scale,
+                                void* out, int N, int K, cudaStream_t stream);
 
 // packed: [N, K/2] uint8 (view of float4_e2m1fn_x2); scale: [N, K/32] e8m0.
 // Returns dequantized BF16 weight [N, K].
@@ -56,8 +56,8 @@ torch::Tensor v4_expert_forward(torch::Tensor x, torch::Tensor w1,
 }
 
 // FP8 E4M3 block-scale dequant for GLM-5.2-FP8 routed experts.
-// weight: [N, K] float8_e4m3fn (passed as uint8 view); scale: [ceil(N/128), ceil(K/128)] float32.
-// Returns dequantized BF16 weight [N, K].
+// weight: [N, K] float8_e4m3fn (passed as uint8 view); scale: [ceil(N/128),
+// ceil(K/128)] float32. Returns dequantized BF16 weight [N, K].
 torch::Tensor fp8_dequant_blockwise(torch::Tensor weight, torch::Tensor scale) {
   TORCH_CHECK(weight.is_cuda(), "weight must be CUDA");
   TORCH_CHECK(scale.is_cuda(), "scale must be CUDA");
@@ -83,7 +83,8 @@ torch::Tensor fp8_dequant_blockwise(torch::Tensor weight, torch::Tensor scale) {
 
 // set_scales: no-op stub for T15 dispatcher integration (deferred).
 // Receives a dict of base_key -> scale_tensor for fp8-in-store dequant-on-copy.
-// Full integration (storing scales in native expert_dispatcher for H2D copy) is deferred.
+// Full integration (storing scales in native expert_dispatcher for H2D copy) is
+// deferred.
 void set_scales(const std::map<std::string, torch::Tensor>& /*scales*/) {
   // No-op: full dispatcher integration deferred to T15-full.
   // This binding satisfies the Python call site: dispatcher.set_scales(scales).
@@ -96,5 +97,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fp8_dequant_blockwise", &fp8_dequant_blockwise,
         "FP8 E4M3 block-scale (128x128) weight -> BF16 dequant (GLM-5.2-FP8)");
   m.def("set_scales", &set_scales,
-        "Store fp8 block scales for dequant-on-copy (no-op stub; full integration deferred)");
+        "Store fp8 block scales for dequant-on-copy (no-op stub; full "
+        "integration deferred)");
 }

--- a/moe_infinity/distributed/expert_executor.py
+++ b/moe_infinity/distributed/expert_executor.py
@@ -48,6 +48,24 @@ def _profiler_instance():
     return instance()
 
 
+_route_ahead_impl = None
+
+
+def _load_route_ahead_impl():
+    # Lazy import: a top-level import would be circular (spec_decode.__init__
+    # -> dflash -> big_modeling -> model_offload -> this module). Both targets
+    # are leaf modules, so importing them at first dispatch is safe.
+    global _route_ahead_impl
+    if _route_ahead_impl is None:
+        import moe_infinity.spec_decode._route_ahead_ctx as route_ahead_ctx
+        from moe_infinity.spec_decode._prefetch_route import (
+            union_experts_from_mask,
+        )
+
+        _route_ahead_impl = (route_ahead_ctx, union_experts_from_mask)
+    return _route_ahead_impl
+
+
 def _call_expert_dispatcher(method, *args, **kwargs):
     global _expert_dispatcher
     func = getattr(_expert_dispatcher, method)
@@ -79,6 +97,62 @@ class DistributedExpertExecutor:
     def trigger_speculative_prefetch(self, layer_id, router_logits):
         if self.prefetcher is not None:
             self.prefetcher.speculative_prefetch(layer_id, router_logits)
+
+    def _maybe_route_ahead_prefetch(
+        self, layer_id, router_mask, num_expert, prefetcher=None
+    ) -> bool:
+        """Track A3 route-ahead seam; True iff the union prefetch fired.
+
+        Active only inside a DFlash verify forward (``_route_ahead_ctx``).
+        Pins the ACTUAL routed union of this layer via
+        ``fetch_experts_lock_cache`` and enqueues it through the A2
+        explicit-set ``speculative_prefetch`` -- cache warming for the reads
+        this dispatch is about to issue, never a routing change. Inactive
+        context, no prefetcher (resident mode / ``speculative_prefetch``
+        config off), or an empty union returns False so the caller falls
+        through to the legacy mean/topk path byte-identically.
+
+        A4: when the context carries a ``RouteAheadStats`` handle, the
+        predicted set and this layer's mask are reported to it (read-only
+        observation; ``None`` handle = zero overhead). Offloaded
+        executor-backed models (DeepSeek/Qwen/Mixtral) reach this seam with
+        no resident-only gate; gpt-oss never reaches it at all
+        (``model_offload.py`` wires no ``expert_executor`` into
+        ``SyncGptOssMLP``).
+        """
+        ctx, union_experts_from_mask = _load_route_ahead_impl()
+        if not ctx.is_active():
+            return False
+        stats = ctx.current_stats()
+        route_prefetcher = prefetcher
+        if route_prefetcher is None:
+            route_prefetcher = ctx.current_prefetcher()
+        if route_prefetcher is None:
+            route_prefetcher = self.prefetcher
+        mask_2d = router_mask.reshape(-1, num_expert)
+        union_expert_ids = union_experts_from_mask(mask_2d)
+        fired = False
+        if route_prefetcher is not None and union_expert_ids:
+            # A0 section 2/5 (A4 guard): pin exactly ONE layer's union per
+            # dispatch -- ``ReplaceCacheCandidates`` is global and clears the
+            # background queues (task_scheduler.h), so folding several layers
+            # into one pin would evict candidates the next layer's dispatch
+            # still needs. Never batch pins across layers; never pin the
+            # empty set (short-circuited above).
+            route_prefetcher.fetch_experts_lock_cache(layer_id, union_expert_ids)
+            route_prefetcher.speculative_prefetch(
+                layer_id,
+                expert_ids=union_expert_ids,
+                prefetch_layer_id=layer_id,
+            )
+            fired = True
+        if stats is not None:
+            # A5 read-only observation: predicted == the pinned union when
+            # the prefetch fired, else [] (coverage 0 for this layer).
+            stats.observe_layer(
+                layer_id, union_expert_ids if fired else [], mask_2d
+            )
+        return fired
 
     def dispatch_local(
         self,
@@ -116,6 +190,12 @@ class DistributedExpertExecutor:
         )
         self.expert_dispatcher.set_expected_queue(expected_wait_cnt)
 
+        # Route-ahead pin + enqueue must precede every enqueue_expert below
+        # (A0 section 2). Inactive context: no-op, legacy flow unchanged.
+        route_ahead_handled = self._maybe_route_ahead_prefetch(
+            layer_id, router_mask, num_expert, prefetcher
+        )
+
         dispatch_nvtx_ctx = _nvtx_ctx("expert_dispatch")
         dispatch_profiler_ctx = (
             profiler.time("expert_dispatch", layer=layer_id, expert=-1)
@@ -135,7 +215,12 @@ class DistributedExpertExecutor:
         if prefetcher is None:
             prefetcher = self.prefetcher
 
-        if (
+        if route_ahead_handled:
+            # A0 section 3: the exact-union prefetch REPLACES the legacy
+            # mean(0)/topk prediction for this dispatch, so neither the
+            # overlap-triggered nor the deferred pooled call may fire.
+            pending_router_logits = None
+        elif (
             self._speculative_prefetch_overlap
             and prefetcher is not None
             and router_logits is not None

--- a/moe_infinity/distributed/expert_executor.py
+++ b/moe_infinity/distributed/expert_executor.py
@@ -139,7 +139,9 @@ class DistributedExpertExecutor:
             # into one pin would evict candidates the next layer's dispatch
             # still needs. Never batch pins across layers; never pin the
             # empty set (short-circuited above).
-            route_prefetcher.fetch_experts_lock_cache(layer_id, union_expert_ids)
+            route_prefetcher.fetch_experts_lock_cache(
+                layer_id, union_expert_ids
+            )
             route_prefetcher.speculative_prefetch(
                 layer_id,
                 expert_ids=union_expert_ids,

--- a/moe_infinity/engine/generation_loop.py
+++ b/moe_infinity/engine/generation_loop.py
@@ -36,8 +36,7 @@ class SpecDecodeStrategy(Protocol):
         prompt_token_ids: list[int],
         sampling_params: SamplingParams,
         request_id: Optional[str] = None,
-    ) -> list[int]:
-        ...
+    ) -> list[int]: ...
 
 
 class GenerationEngine:

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -784,13 +784,13 @@ class MoE:
 
         speculative_draft = kwargs.pop("speculative_draft", None)
 
-        model_type = getattr(getattr(self.model, "config", None), "model_type", "")
+        model_type = getattr(
+            getattr(self.model, "config", None), "model_type", ""
+        )
         is_qwen35 = model_type == "qwen3_5_moe"
         do_sample = kwargs.get("do_sample", None)
         sampling_temperature = (
-            0.0
-            if do_sample is False
-            else float(kwargs.get("temperature", 1.0))
+            0.0 if do_sample is False else float(kwargs.get("temperature", 1.0))
         )
         is_greedy = (
             sampling_temperature == 0.0

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -854,6 +854,7 @@ class MoE:
         max_batch_size: int = 32,
         enable_prefix_caching: bool = False,
         offload_dir: Optional[str] = None,
+        speculative_draft: Optional[object] = None,
     ) -> None:
         """
         Start the OpenAI-compatible continuous batching server.
@@ -869,6 +870,8 @@ class MoE:
             max_batch_size: Maximum concurrent sequences (default: 32)
             enable_prefix_caching: Enable hash-based prefix caching (default: False)
             offload_dir: Path to offload directory (required)
+            speculative_draft: Optional DFlash checkpoint, speculator, or draft
+                module for greedy batch-1 serving.
         """
 
         if offload_dir is None:
@@ -877,6 +880,11 @@ class MoE:
         import importlib
 
         from moe_infinity.entrypoints.openai import api_server_v2
+
+        serving_speculator = None
+        if speculative_draft:
+            self._resolve_spec_strategy(speculative_draft)
+            serving_speculator = getattr(self, "_dflash_speculator", None)
 
         model_name = getattr(
             getattr(self.model, "config", None), "_name_or_path", None
@@ -890,6 +898,7 @@ class MoE:
             kv_cache_ratio=kv_cache_ratio,
             max_batch_size=max_batch_size,
             enable_prefix_caching=enable_prefix_caching,
+            speculative_draft=serving_speculator,
         )
 
         uvicorn = importlib.import_module("uvicorn")

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -838,7 +838,9 @@ class MoE:
                 return self.model.generate(input_ids, **kwargs)
 
         if native_engine is None:
-            raise RuntimeError("native generation engine unexpectedly unavailable")
+            raise RuntimeError(
+                "native generation engine unexpectedly unavailable"
+            )
 
         from moe_infinity.engine.types import SamplingParams
 

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -6,8 +6,6 @@ from typing import Any, Callable, Dict, Optional, Union
 
 import torch
 
-import moe_infinity
-
 warnings.filterwarnings("ignore")
 
 
@@ -728,6 +726,11 @@ class MoE:
         standard path runs, without discarding the memoized speculator.
         """
         engine = self._native_generation_engine
+        if engine is None:
+            raise RuntimeError(
+                "cannot configure speculative decoding without a native "
+                "generation engine"
+            )
         if not speculative_draft:
             engine.spec_strategy = None
             return
@@ -739,7 +742,12 @@ class MoE:
             and source == str(speculative_draft)
         )
         if cached is None or not same:
-            from moe_infinity.spec_decode import DFlashSpeculator
+            import importlib
+
+            DFlashSpeculator = getattr(
+                importlib.import_module("moe_infinity.spec_decode.dflash"),
+                "DFlashSpeculator",
+            )
 
             if isinstance(speculative_draft, DFlashSpeculator):
                 cached = speculative_draft
@@ -798,9 +806,10 @@ class MoE:
             and int(kwargs.get("top_k", 0)) == 0
         )
         qwen35_dflash = bool(speculative_draft) and is_greedy
+        native_engine = self._native_generation_engine
         native_for_call = (
             self.use_native_engine
-            and self._native_generation_engine is not None
+            and native_engine is not None
             and input_ids.ndim == 2
             and input_ids.shape[0] == 1
             and (not is_qwen35 or qwen35_dflash)
@@ -828,6 +837,9 @@ class MoE:
             with torch.no_grad():
                 return self.model.generate(input_ids, **kwargs)
 
+        if native_engine is None:
+            raise RuntimeError("native generation engine unexpectedly unavailable")
+
         from moe_infinity.engine.types import SamplingParams
 
         self._resolve_spec_strategy(speculative_draft)
@@ -849,7 +861,7 @@ class MoE:
             max_tokens=int(max_tokens) if max_tokens is not None else 256,
         )
         try:
-            result = self._native_generation_engine.generate(
+            result = native_engine.generate(
                 prompt_token_ids=prompt_token_ids,
                 sampling_params=sampling_params,
             )

--- a/moe_infinity/entrypoints/big_modeling.py
+++ b/moe_infinity/entrypoints/big_modeling.py
@@ -187,10 +187,10 @@ class MoE:
         self.use_native_engine = bool(
             getattr(engine_config, "use_native_engine", True)
         )
-        # Qwen3.5-MoE interleaves linear (GatedDeltaNet) and full attention; the
-        # native paged-KV engine assumes uniform full attention across layers, so
-        # Phase 1 drives generation through HF's own forward instead.
-        if getattr(model_config, "model_type", "") in ("qwen3_5_moe", "glm_moe_dsa"):
+        # GLM-DSA remains unsupported by the native engine. Qwen3.5 builds the
+        # native components, but generate() below admits them only for greedy,
+        # batch-1 DFlash; ordinary generation still uses HF's hybrid-cache path.
+        if getattr(model_config, "model_type", "") == "glm_moe_dsa":
             self.use_native_engine = False
         default_max_seq_length = getattr(
             model_config, "max_position_embeddings", None
@@ -784,17 +784,40 @@ class MoE:
 
         speculative_draft = kwargs.pop("speculative_draft", None)
 
-        if (
-            not self.use_native_engine
-            or self._native_generation_engine is None
-            or input_ids.ndim != 2
-            or input_ids.shape[0] != 1
-        ):
+        model_type = getattr(getattr(self.model, "config", None), "model_type", "")
+        is_qwen35 = model_type == "qwen3_5_moe"
+        do_sample = kwargs.get("do_sample", None)
+        sampling_temperature = (
+            0.0
+            if do_sample is False
+            else float(kwargs.get("temperature", 1.0))
+        )
+        is_greedy = (
+            sampling_temperature == 0.0
+            and float(kwargs.get("top_p", 1.0)) == 1.0
+            and int(kwargs.get("top_k", 0)) == 0
+        )
+        qwen35_dflash = bool(speculative_draft) and is_greedy
+        native_for_call = (
+            self.use_native_engine
+            and self._native_generation_engine is not None
+            and input_ids.ndim == 2
+            and input_ids.shape[0] == 1
+            and (not is_qwen35 or qwen35_dflash)
+        )
+
+        if not native_for_call:
             if speculative_draft:
                 if input_ids.ndim == 2 and input_ids.shape[0] != 1:
                     raise NotImplementedError(
                         "speculative_draft (DFlash) v1 supports batch==1 "
                         f"only; got batch size {input_ids.shape[0]}"
+                    )
+                if is_qwen35 and not is_greedy:
+                    raise ValueError(
+                        "qwen3_5_moe speculative_draft (DFlash) requires "
+                        "greedy decoding (do_sample=False or temperature=0, "
+                        "top_p=1, top_k=0)"
                     )
                 raise ValueError(
                     "speculative_draft (DFlash) requires the MoE-Infinity "
@@ -819,11 +842,6 @@ class MoE:
             )
 
         max_tokens = kwargs.get("max_new_tokens", kwargs.get("max_tokens", 256))
-        do_sample = kwargs.get("do_sample", None)
-        if do_sample is False:
-            sampling_temperature = 0.0
-        else:
-            sampling_temperature = float(kwargs.get("temperature", 1.0))
         sampling_params = SamplingParams(
             temperature=sampling_temperature,
             top_p=float(kwargs.get("top_p", 1.0)),

--- a/moe_infinity/entrypoints/openai/api_server_v2.py
+++ b/moe_infinity/entrypoints/openai/api_server_v2.py
@@ -481,6 +481,7 @@ def initialize_with_model(
     kv_cache_ratio: float = 0.25,
     max_batch_size: int = 32,
     enable_prefix_caching: bool = False,
+    speculative_draft: Optional[Any] = None,
 ) -> None:
     """Initialize the v2 server with a pre-loaded MoE model.
 
@@ -516,6 +517,7 @@ def initialize_with_model(
         engine=offload_engine,
         config=engine_config,
         tokenizer=tokenizer,
+        speculative_draft=speculative_draft,
     )
     if stream_manager is None:
         stream_manager = StreamManager()
@@ -1071,12 +1073,23 @@ async def _initialize_model() -> None:
 
         moe_model = moe_ctor(args.model, moe_config)
         engine_config = _build_engine_config(args=args, model=moe_model.model)
+        speculative_draft = None
+        draft_path = getattr(args, "speculative_draft", None)
+        if draft_path:
+            resolve_spec = getattr(moe_model, "_resolve_spec_strategy", None)
+            if not callable(resolve_spec):
+                raise RuntimeError("loaded MoE model cannot configure DFlash")
+            resolve_spec(str(draft_path))
+            speculative_draft = getattr(moe_model, "_dflash_speculator", None)
+            if speculative_draft is None:
+                raise RuntimeError("failed to configure DFlash speculator")
 
         initialized_engine = ContinuousBatchingEngine(
             model=moe_model.model,
             engine=moe_model.engine,
             config=engine_config,
             tokenizer=tokenizer,
+            speculative_draft=speculative_draft,
         )
         if stream_manager is None:
             stream_manager = StreamManager()
@@ -1841,6 +1854,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--port", type=int, default=8000, help="port number")
     parser.add_argument("--model", type=str, required=True)
     parser.add_argument("--offload-dir", type=str, required=True)
+    parser.add_argument(
+        "--speculative-draft",
+        type=str,
+        default=None,
+        help="DFlash drafter checkpoint for greedy batch-1 serving",
+    )
     parser.add_argument("--device-memory-ratio", type=float, default=0.75)
     parser.add_argument("--kv-cache-ratio", type=float, default=0.25)
     parser.add_argument("--max-batch-size", type=int, default=32)

--- a/moe_infinity/memory/expert_prefetcher.py
+++ b/moe_infinity/memory/expert_prefetcher.py
@@ -104,12 +104,47 @@ class ExpertPrefetcher(object):
                     self.archer_engine.enqueue_prefetch(tensor_id, gpu_id)
 
     def speculative_prefetch(
-        self, layer_idx: int, router_logits: Optional[Any] = None
+        self,
+        layer_idx: int,
+        router_logits: Optional[Any] = None,
+        *,
+        expert_ids: Optional[List[int]] = None,
+        prefetch_layer_id: Optional[int] = None,
     ):
+        """Speculatively prefetch experts for an upcoming layer. Two modes:
+
+        * Legacy (default): pool ``router_logits`` via ``mean(0)`` and
+          prefetch the ``min(2, num_experts)`` top experts for
+          ``layer_idx + 1``. Unchanged pre-A2 behavior (non-spec decode).
+        * Explicit (DFlash route-ahead seam, Track A2): when ``expert_ids``
+          is given, prefetch exactly that set for ``prefetch_layer_id``
+          (default ``layer_idx + 1``) via ``prefetch_experts_list`` -- no
+          mean/topk pooling. Empty ``expert_ids`` is a safe no-op.
+
+        Returns ``None``. Raises ``ValueError`` if both are ``None``.
+        """
+        if expert_ids is not None:
+            if not expert_ids:
+                return
+            target_layer = (
+                prefetch_layer_id
+                if prefetch_layer_id is not None
+                else layer_idx + 1
+            )
+            if target_layer >= self.num_layers:
+                return
+            self.prefetch_experts_list(target_layer, list(expert_ids))
+            self._last_speculative_prediction = set(expert_ids)
+            return
+
+        if router_logits is None:
+            raise ValueError(
+                "speculative_prefetch requires router_logits (legacy mode) "
+                + "or expert_ids (explicit route-ahead mode); got neither."
+            )
+
         next_layer = layer_idx + 1
         if next_layer >= self.num_layers:
-            return
-        if router_logits is None:
             return
 
         num_experts_to_prefetch = min(2, self.num_experts)

--- a/moe_infinity/models/__init__.py
+++ b/moe_infinity/models/__init__.py
@@ -7,6 +7,7 @@ from .dbrx import SyncDbrxFFNBlock
 from .deepseek import DeepseekMoEBlock
 from .deepseek_v2_wrapper import SyncDeepseekV2MoEBlock
 from .deepseek_v3_wrapper import SyncDeepseekV3MoEBlock
+from .glm_moe_dsa import SyncGlmMoeDsaMoEBlock
 from .gpt_oss import SyncGptOssMLP
 from .jamba import SyncJambaMoEBlock
 from .mixtral import SyncMixtralSparseMoeBlock
@@ -18,7 +19,6 @@ from .model_utils import (
 from .nllb_moe import SyncNllbMoeSparseMLP
 from .olmoe import SyncOlmoeMoEBlock
 from .qwen import Qwen3MoEBlock
-from .glm_moe_dsa import SyncGlmMoeDsaMoEBlock
 from .qwen3_5_moe import SyncQwen3_5MoeSparseMoeBlock
 
 # Qwen3PagedAttention is lazily imported to avoid a circular dependency:

--- a/moe_infinity/models/deepseek_v4/fp8_expert.py
+++ b/moe_infinity/models/deepseek_v4/fp8_expert.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import torch
 import torch.nn.functional as F
 
-from moe_infinity.utils.fp8 import FP8_BLOCK, dequant_fp8_blockwise  # noqa: F401
+from moe_infinity.utils.fp8 import (  # noqa: F401
+    FP8_BLOCK,
+    dequant_fp8_blockwise,
+)
 
 
 def fp8_shared_expert_forward(

--- a/moe_infinity/models/glm_dsa.py
+++ b/moe_infinity/models/glm_dsa.py
@@ -7,6 +7,7 @@ Classifies per-layer DSA indexer ownership:
 
 This is used by offload code to avoid double-loading shared indexers.
 """
+
 from __future__ import annotations
 
 from typing import Dict, List, Optional

--- a/moe_infinity/models/glm_moe_dsa.py
+++ b/moe_infinity/models/glm_moe_dsa.py
@@ -56,14 +56,17 @@ class SyncGlmMoeDsaMoEBlock(nn.Module):
         )
         self.shared_experts = GlmMoeDsaMLP(
             config=config,
-            intermediate_size=config.moe_intermediate_size * config.n_shared_experts,
+            intermediate_size=config.moe_intermediate_size
+            * config.n_shared_experts,
         )
         self._hf_route_tokens = GlmMoeDsaMoE.route_tokens_to_experts
 
     def _route(self, hidden_flat: torch.Tensor):
         dev = hidden_flat.device
         if self.gate.e_score_correction_bias.device != dev:
-            self.gate.e_score_correction_bias = self.gate.e_score_correction_bias.to(dev)
+            self.gate.e_score_correction_bias = (
+                self.gate.e_score_correction_bias.to(dev)
+            )
         router_logits = self.gate(hidden_flat)
         return self._hf_route_tokens(self, router_logits)
 

--- a/moe_infinity/models/gpt_oss.py
+++ b/moe_infinity/models/gpt_oss.py
@@ -120,6 +120,30 @@ class SyncGptOssMLP(nn.Module):
         )
         return result
 
+    def _observe_resident_route_ahead(
+        self, router_mask: torch.Tensor
+    ) -> None:
+        if self.expert_executor is not None:
+            return
+
+        import moe_infinity.spec_decode._route_ahead_ctx as route_ahead_ctx
+
+        if not route_ahead_ctx.is_active():
+            return
+
+        stats = route_ahead_ctx.current_stats()
+        _resident_prefetcher = route_ahead_ctx.current_prefetcher()
+        if stats is None:
+            return
+
+        from moe_infinity.spec_decode._prefetch_route import (
+            union_experts_from_mask,
+        )
+
+        mask_2d = router_mask.reshape(-1, self.num_experts)
+        union_expert_ids = union_experts_from_mask(mask_2d)
+        stats.observe_layer(self.layer_id, union_expert_ids, mask_2d)
+
     def forward(
         self, hidden_states: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -164,6 +188,7 @@ class SyncGptOssMLP(nn.Module):
             )
             final_hidden = self.expert_executor.wait_dispatch_local()
         else:
+            self._observe_resident_route_ahead(router_mask)
             final_hidden = torch.zeros_like(hidden_flat)
             for expert_idx in range(self.num_experts):
                 token_mask = router_mask[:, expert_idx]

--- a/moe_infinity/models/gpt_oss.py
+++ b/moe_infinity/models/gpt_oss.py
@@ -120,9 +120,7 @@ class SyncGptOssMLP(nn.Module):
         )
         return result
 
-    def _observe_resident_route_ahead(
-        self, router_mask: torch.Tensor
-    ) -> None:
+    def _observe_resident_route_ahead(self, router_mask: torch.Tensor) -> None:
         if self.expert_executor is not None:
             return
 

--- a/moe_infinity/models/qwen.py
+++ b/moe_infinity/models/qwen.py
@@ -62,4 +62,4 @@ class Qwen3MoEBlock(nn.Module):
             batch_size, sequence_length, hidden_dim
         ).to(hidden_states.dtype)
 
-        return final_hidden_states, router_logits
+        return final_hidden_states

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -977,7 +977,10 @@ class OffloadEngine(object):
 
                         module_idx += 1
 
-                if getattr(self.config, "model_type", "") == "glm_moe_dsa":
+                if getattr(self.config, "model_type", "") in (
+                    "glm_moe_dsa",
+                    "qwen3_5_moe",
+                ):
                     self._load_resident_shared_experts(model)
                     for _name in list(self.name_id_map.keys()):
                         if self._is_shared_expert_param(_name):
@@ -1289,7 +1292,7 @@ class OffloadEngine(object):
             if name not in self.name_id_map:
                 continue
             if match:
-                if "expert" in name and "shared_experts" not in name:
+                if _is_routed_expert_key(name):
                     match = re.match(r"(.*experts)", name)
                     assert match, "Not correct expert name!"
                     stored_name = match.group(1)
@@ -1346,7 +1349,7 @@ class OffloadEngine(object):
             if name not in self.name_id_map:
                 continue
             if match:
-                if "expert" in name and "shared_experts" not in name:
+                if _is_routed_expert_key(name):
                     match = re.match(r"(.*experts)", name)
                     assert match, "Not correct expert name!"
                     stored_name = match.group(1)

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -588,9 +588,15 @@ class OffloadEngine(object):
         )
 
         _dsv2_mod = transformers.models.deepseek_v2.modeling_deepseek_v2
-        _dsv2_cls = getattr(_dsv2_mod, "DeepseekV2MoE", None) or getattr(_dsv2_mod, "DeepseekV2Moe", None)
+        _dsv2_cls = getattr(_dsv2_mod, "DeepseekV2MoE", None) or getattr(
+            _dsv2_mod, "DeepseekV2Moe", None
+        )
         _dsv2_mod._old_deepseek_v2_moe = _dsv2_cls
-        _dsv2_attr = "DeepseekV2MoE" if hasattr(_dsv2_mod, "DeepseekV2MoE") else "DeepseekV2Moe"
+        _dsv2_attr = (
+            "DeepseekV2MoE"
+            if hasattr(_dsv2_mod, "DeepseekV2MoE")
+            else "DeepseekV2Moe"
+        )
         setattr(_dsv2_mod, _dsv2_attr, SyncDeepseekV2MoEBlock)
         transformers.models.deepseek_v3.modeling_deepseek_v3._old_deepseek_v3_moe = transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE
         transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE = (
@@ -608,6 +614,7 @@ class OffloadEngine(object):
 
         try:
             import transformers.models.glm_moe_dsa.modeling_glm_moe_dsa as _glm_mod
+
             _glm_mod._old_glm_moe_dsa_moe = _glm_mod.GlmMoeDsaMoE
             _glm_mod.GlmMoeDsaMoE = SyncGlmMoeDsaMoEBlock
         except (ImportError, AttributeError):
@@ -792,8 +799,13 @@ class OffloadEngine(object):
                                     # Required by the model: attention, dense MLP
                                     # and shared experts run in PyTorch (not the
                                     # dispatcher), so dequantize them to BF16.
-                                    state_dict[base_key] = dequant_fp8_blockwise(
-                                        w, s, dtype=torch.bfloat16, block_size=128
+                                    state_dict[base_key] = (
+                                        dequant_fp8_blockwise(
+                                            w,
+                                            s,
+                                            dtype=torch.bfloat16,
+                                            block_size=128,
+                                        )
                                     )
                                 del state_dict[scale_key]
 
@@ -1015,6 +1027,7 @@ class OffloadEngine(object):
 
         try:
             import transformers.models.glm_moe_dsa.modeling_glm_moe_dsa as _glm_mod
+
             if hasattr(_glm_mod, "_old_glm_moe_dsa_moe"):
                 _glm_mod.GlmMoeDsaMoE = _glm_mod._old_glm_moe_dsa_moe
         except (ImportError, AttributeError):
@@ -1121,9 +1134,7 @@ class OffloadEngine(object):
         # keep them resident. MXFP4 packed weights stay uint8 output-major
         # ([E, N, K//2] blocks, [E, N, K//32] scales) - the layout the fused
         # kernel consumes without transposition.
-        modules = [
-            m for m in model.modules() if isinstance(m, SyncGptOssMLP)
-        ]
+        modules = [m for m in model.modules() if isinstance(m, SyncGptOssMLP)]
         if not modules:
             return
 
@@ -1562,8 +1573,7 @@ class OffloadEngine(object):
                     continue
 
                 if is_glm_fp8_ckpt and (
-                    k.endswith("_scale_inv")
-                    or v.dtype == torch.float8_e4m3fn
+                    k.endswith("_scale_inv") or v.dtype == torch.float8_e4m3fn
                 ):
                     state_dict[k] = v.to("cpu")
                     continue
@@ -1835,7 +1845,9 @@ class OffloadEngine(object):
                     continue
 
                 self.offload_set.remove(param.data.data_ptr())
-                self.archer_engine.begin(self.request_id, param, getattr(param, "ar_id", 0xFFFFFFFF))
+                self.archer_engine.begin(
+                    self.request_id, param, getattr(param, "ar_id", 0xFFFFFFFF)
+                )
                 self.offload_set.add(param.data.data_ptr())
 
                 device_list.append(param.data.device)
@@ -1847,7 +1859,9 @@ class OffloadEngine(object):
                     continue
 
                 self.offload_set.remove(buf.data_ptr())
-                self.archer_engine.begin(self.request_id, buf, getattr(buf, "ar_id", 0xFFFFFFFF))
+                self.archer_engine.begin(
+                    self.request_id, buf, getattr(buf, "ar_id", 0xFFFFFFFF)
+                )
                 self.offload_set.add(buf.data_ptr())
 
                 device_list.append(buf.data.device)
@@ -1872,7 +1886,9 @@ class OffloadEngine(object):
                     continue
 
                 self.offload_set.remove(param.data.data_ptr())
-                self.archer_engine.end(self.request_id, param, getattr(param, "ar_id", 0xFFFFFFFF))
+                self.archer_engine.end(
+                    self.request_id, param, getattr(param, "ar_id", 0xFFFFFFFF)
+                )
                 self.offload_set.add(param.data.data_ptr())
 
                 device_list.append(param.data.device)
@@ -1882,7 +1898,9 @@ class OffloadEngine(object):
                     continue
 
                 self.offload_set.remove(buf.data_ptr())
-                self.archer_engine.end(self.request_id, buf, getattr(buf, "ar_id", 0xFFFFFFFF))
+                self.archer_engine.end(
+                    self.request_id, buf, getattr(buf, "ar_id", 0xFFFFFFFF)
+                )
                 self.offload_set.add(buf.data_ptr())
 
                 device_list.append(buf.device)
@@ -1960,7 +1978,11 @@ class OffloadEngine(object):
         )
 
         _dsv2_mod2 = transformers.models.deepseek_v2.modeling_deepseek_v2
-        _dsv2_attr2 = "DeepseekV2MoE" if hasattr(_dsv2_mod2, "DeepseekV2MoE") else "DeepseekV2Moe"
+        _dsv2_attr2 = (
+            "DeepseekV2MoE"
+            if hasattr(_dsv2_mod2, "DeepseekV2MoE")
+            else "DeepseekV2Moe"
+        )
         setattr(_dsv2_mod2, _dsv2_attr2, _dsv2_mod2._old_deepseek_v2_moe)
         transformers.models.deepseek_v3.modeling_deepseek_v3.DeepseekV3MoE = transformers.models.deepseek_v3.modeling_deepseek_v3._old_deepseek_v3_moe
         transformers.models.gpt_oss.modeling_gpt_oss.GptOssMLP = (

--- a/moe_infinity/serving/engine.py
+++ b/moe_infinity/serving/engine.py
@@ -27,6 +27,18 @@ class EvictionSyncAdapter(Protocol):
     def on_request_aborted(self, request_id: str) -> None: ...
 
 
+class SpeculativeGenerator(Protocol):
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        max_new_tokens: int,
+        temperature: float = 0.0,
+        stop_token_ids: list[int] | None = None,
+        top_k: int = 0,
+        top_p: float = 1.0,
+    ) -> torch.Tensor: ...
+
+
 _eviction_sync: Optional[EvictionSyncAdapter] = None
 
 
@@ -65,6 +77,7 @@ class ContinuousBatchingEngine:
     _next_seq_id: int
     _num_steps: int
     _total_generated_tokens: int
+    speculative_draft: SpeculativeGenerator | None
 
     def __init__(
         self,
@@ -72,6 +85,7 @@ class ContinuousBatchingEngine:
         engine: object,
         config: dict[str, object],
         tokenizer: Optional[object] = None,
+        speculative_draft: SpeculativeGenerator | None = None,
     ) -> None:
         self.model = model
         self.engine = engine
@@ -122,6 +136,7 @@ class ContinuousBatchingEngine:
         self.model_runner = ModelRunner(model, engine, device=self.device)
         self.sampler = Sampler()
         self.batch_builder = BatchBuilder()
+        self.speculative_draft = speculative_draft
 
         self._next_seq_id = 0
         self._sequences: dict[int, SequenceData] = {}
@@ -190,6 +205,9 @@ class ContinuousBatchingEngine:
             raise RuntimeError(
                 "scheduler produced an empty batch; empty prompts are not supported"
             )
+
+        if self._can_delegate_speculative(batch):
+            return self._step_speculative(batch)
 
         logits = self._execute_batch(batch)
         last_token_logits = self._extract_last_token_logits(logits, batch)
@@ -265,6 +283,114 @@ class ContinuousBatchingEngine:
                 _eviction_sync.on_request_finished(request_id)
             _ = self._callbacks.pop(request_id, None)
 
+        return outputs
+
+    def _can_delegate_speculative(self, batch: BatchMetadata) -> bool:
+        """Whether this fresh singleton request can use the proven sync loop.
+
+        DFlash owns a separate ``DynamicCache`` here. The paged serving cache is
+        used only for admission accounting and freed when the delegated request
+        completes. Mixed batches, resumed decode rows, sampling, penalties, and
+        logprob requests stay on the existing serving path unchanged.
+        """
+        if self.speculative_draft is None or len(batch.seq_ids) != 1:
+            return False
+        if batch.is_prefill != [True]:
+            return False
+
+        sequence = self._sequences[batch.seq_ids[0]]
+        params = sequence.sampling_params
+        return (
+            not sequence.output_token_ids
+            and not params.stop
+            and params.max_tokens <= self.scheduler.max_tokens_per_step
+            and params.temperature == 0
+            and params.top_k <= 0
+            and params.top_p >= 1.0
+            and params.repetition_penalty == 1.0
+            and params.logprobs <= 0
+        )
+
+    def _step_speculative(self, batch: BatchMetadata) -> list[RequestOutput]:
+        """Complete one eligible request through DFlash's own DynamicCache.
+
+        ``DFlashSpeculator.generate`` is the already GPU-proven greedy loop. A
+        single serving ``step`` may therefore emit several accepted tokens;
+        each is still recorded and streamed as an individual ``RequestOutput``.
+        """
+        speculator = self.speculative_draft
+        if speculator is None:
+            raise RuntimeError("speculative generator is not configured")
+
+        seq_id = batch.seq_ids[0]
+        sequence = self._sequences[seq_id]
+        request_id = self._sequence_to_request_id[seq_id]
+        prompt = torch.tensor([sequence.prompt_token_ids], dtype=torch.long)
+        stop_token_ids = (
+            [self.eos_token_id] if self.eos_token_id is not None else None
+        )
+
+        owner = cast(object | None, getattr(speculator, "moe", None))
+        if owner is not None:
+            setattr(owner, "_cached_past_key_values", None)
+        try:
+            generated = speculator.generate(
+                prompt,
+                max_new_tokens=sequence.sampling_params.max_tokens,
+                temperature=0.0,
+                stop_token_ids=stop_token_ids,
+                top_k=sequence.sampling_params.top_k,
+                top_p=sequence.sampling_params.top_p,
+            )
+        finally:
+            if owner is not None:
+                setattr(owner, "_cached_past_key_values", None)
+
+        if generated.ndim != 2 or generated.shape[0] != 1:
+            raise RuntimeError(
+                "speculative generator must return token ids with shape [1, seq]"
+            )
+        prompt_len = sequence.prompt_length
+        generated_ids = cast(
+            list[int], generated[0, prompt_len:].to(device="cpu").tolist()
+        )
+
+        outputs: list[RequestOutput] = []
+        for token_id in generated_ids:
+            sequence.append_output_token(token_id)
+            self._request_outputs[request_id][seq_id].append(token_id)
+            self._total_generated_tokens += 1
+
+            finish_reason = self._get_finish_reason(sequence, token_id)
+            finished = finish_reason is not None
+            outputs.append(
+                RequestOutput(
+                    request_id=request_id,
+                    seq_id=seq_id,
+                    token_id=token_id,
+                    token_text=self._decode_token(token_id),
+                    finished=finished,
+                    finish_reason=finish_reason,
+                    usage=(self._build_usage(sequence) if finished else None),
+                )
+            )
+            if finished:
+                break
+
+        self.scheduler.update_after_step(
+            completed_seq_ids=[seq_id],
+            new_decode_seq_ids=[],
+            committed_counts={seq_id: len(outputs)},
+        )
+        self._num_steps += 1
+        self._completed_request_ids.add(request_id)
+
+        for output in outputs:
+            for callback in self._callbacks.get(request_id, []):
+                callback(output)
+        if _eviction_sync is not None:
+            _eviction_sync.on_request_finished(request_id)
+        _ = self._callbacks.pop(request_id, None)
         return outputs
 
     def run_until_done(self) -> dict[str, list[int] | list[list[int]]]:

--- a/moe_infinity/serving/kv_cache.py
+++ b/moe_infinity/serving/kv_cache.py
@@ -255,6 +255,52 @@ class PagedKVCache:
         for _ in range(num_new_tokens):
             block_table.append_token()
 
+    def truncate_tokens(self, seq_id: int, new_len: int) -> None:
+        """Roll a sequence back to ``new_len`` tokens, freeing tail blocks.
+
+        Never grows (raises ``ValueError`` if ``new_len`` exceeds the current
+        length); no-op when unchanged. Rollback primitive for serving-path DFlash.
+        """
+        if new_len < 0:
+            raise ValueError(f"new_len must be >= 0, got {new_len}")
+        block_table = self._require_sequence(seq_id)
+        current = block_table.num_computed_tokens()
+        if new_len > current:
+            raise ValueError(
+                f"truncate_tokens cannot grow sequence {seq_id}: "
+                f"new_len {new_len} > current {current}"
+            )
+        if new_len == current:
+            return
+
+        block_size = self.block_size
+        blocks_needed = (new_len + block_size - 1) // block_size
+
+        current_block_ids = block_table.get_block_ids()
+        freed_block_ids = current_block_ids[blocks_needed:]
+        kept_block_ids = current_block_ids[:blocks_needed]
+        if freed_block_ids:
+            self.block_allocator.free(freed_block_ids)
+        block_table.restore_blocks(kept_block_ids, num_tokens=new_len)
+
+        # Keep swapped-out CPU buffer + token count consistent with the shrink.
+        if seq_id in self._swapped_out_sequences:
+            self._swapped_num_tokens[seq_id] = new_len
+            cpu_buffer = self._swapped_cpu_buffers.get(seq_id)
+            if cpu_buffer is not None:
+                if blocks_needed == 0:
+                    _ = self._swapped_cpu_buffers.pop(seq_id, None)
+                elif int(cpu_buffer.shape[1]) > blocks_needed:
+                    self._swapped_cpu_buffers[seq_id] = cpu_buffer[
+                        :, :blocks_needed, ...
+                    ].clone()
+
+        if freed_block_ids and self._cp_kv_manager is not None:
+            try:
+                self._cp_kv_manager.notify_blocks_freed(seq_id, freed_block_ids)
+            except Exception:
+                pass
+
     def free_sequence(self, seq_id: int) -> None:
         block_table = self._sequence_tables.pop(seq_id, None)
         if block_table is None:

--- a/moe_infinity/serving/scheduler.py
+++ b/moe_infinity/serving/scheduler.py
@@ -169,6 +169,7 @@ class Scheduler:
         self,
         completed_seq_ids: list[int],
         new_decode_seq_ids: list[int],
+        committed_counts: dict[int, int] | None = None,
     ) -> None:
         completed = set(completed_seq_ids)
 
@@ -181,8 +182,13 @@ class Scheduler:
                 sequence.set_status(SequenceStatus.DECODE)
 
             if sequence.status is SequenceStatus.DECODE:
+                num_new = (
+                    1
+                    if committed_counts is None
+                    else committed_counts.get(seq_id, 1)
+                )
                 try:
-                    self.kv_cache.append_tokens(seq_id, num_new_tokens=1)
+                    self.kv_cache.append_tokens(seq_id, num_new_tokens=num_new)
                 except KeyError:
                     pass
 

--- a/moe_infinity/serving/spec_state.py
+++ b/moe_infinity/serving/spec_state.py
@@ -32,7 +32,9 @@ class SpecDecodeState:
         if self.cached_len < 0:
             self.cached_len = self.prompt_len
 
-    def record_verify(self, block_len: int, committed: int) -> VerifyStepAccounting:
+    def record_verify(
+        self, block_len: int, committed: int
+    ) -> VerifyStepAccounting:
         """Reconcile counters after a verify step that appended ``block_len``.
 
         The verify forward transiently writes KV for all ``block_len`` block

--- a/moe_infinity/serving/spec_state.py
+++ b/moe_infinity/serving/spec_state.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class VerifyStepAccounting:
+    committed: int
+    truncate_target: int
+    cached_len: int
+    emitted_len: int
+
+
+@dataclass
+class SpecDecodeState:
+    """Per-sequence cached-vs-emitted bookkeeping for serving-path DFlash.
+
+    ``cached_len`` is the number of tokens whose KV is committed to the paged
+    cache; ``emitted_len`` is the number of committed output tokens returned to
+    the user. Invariant after every committed step:
+    ``cached_len == prompt_len + emitted_len``.
+    """
+
+    seq_id: int
+    prompt_len: int
+    cached_len: int = -1
+    emitted_len: int = 0
+
+    def __post_init__(self) -> None:
+        if self.prompt_len < 0:
+            raise ValueError(f"prompt_len must be >= 0, got {self.prompt_len}")
+        if self.cached_len < 0:
+            self.cached_len = self.prompt_len
+
+    def record_verify(self, block_len: int, committed: int) -> VerifyStepAccounting:
+        """Reconcile counters after a verify step that appended ``block_len``.
+
+        The verify forward transiently writes KV for all ``block_len`` block
+        tokens; ``committed`` (1..block_len) of them are kept. Returns the target
+        length to which the paged cache must be truncated to drop the rejected
+        tail, and advances the cached/emitted counters.
+        """
+        if block_len < 1:
+            raise ValueError(f"block_len must be >= 1, got {block_len}")
+        if not 1 <= committed <= block_len:
+            raise ValueError(
+                f"committed must be in [1, {block_len}], got {committed}"
+            )
+        self.cached_len += committed
+        self.emitted_len += committed
+        return VerifyStepAccounting(
+            committed=committed,
+            truncate_target=self.cached_len,
+            cached_len=self.cached_len,
+            emitted_len=self.emitted_len,
+        )
+
+    def invariant_holds(self) -> bool:
+        return self.cached_len == self.prompt_len + self.emitted_len
+
+
+__all__ = ["SpecDecodeState", "VerifyStepAccounting"]

--- a/moe_infinity/serving/spec_verify.py
+++ b/moe_infinity/serving/spec_verify.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+from moe_infinity.serving.kv_cache import PagedKVCache
+from moe_infinity.serving.spec_state import SpecDecodeState
+from moe_infinity.spec_decode._dflash_ops import (
+    acceptance_length,
+    committed_tokens,
+)
+
+
+@dataclass
+class VerifyResult:
+    emitted_tokens: list[int]
+    next_anchor: int
+    accept: int
+    cache_committed: int
+    cached_len: int
+
+
+def apply_verify_step(
+    *,
+    kv_cache: PagedKVCache,
+    seq_id: int,
+    state: SpecDecodeState,
+    block: torch.Tensor,
+    posterior: torch.Tensor,
+    block_size: int,
+) -> VerifyResult:
+    """Commit one serving-path DFlash verify step, rolling back rejected KV.
+
+    Precondition: the verify forward has already appended KV for all
+    ``block_size`` block tokens to ``kv_cache[seq_id]``. This keeps only the
+    committed prefix (``accept + 1`` tokens: anchor + accepted drafts) via
+    ``truncate_tokens`` and returns the ``accept + 1`` newly emitted tokens
+    (``[d_1..d_accept, bonus]``) plus the bonus, which is emitted-but-not-cached
+    and becomes the next step's anchor. Mirrors the sync ``_generate_single``
+    protocol (dflash.py) so serving output is token-identical.
+    """
+    accept = acceptance_length(block, posterior)
+    committed = committed_tokens(block, posterior, accept)
+    cache_committed = accept + 1
+    accounting = state.record_verify(
+        block_len=block_size, committed=cache_committed
+    )
+    kv_cache.truncate_tokens(seq_id, accounting.truncate_target)
+    emitted = [int(t) for t in committed.emitted[0].tolist()]
+    next_anchor = int(committed.bonus[0, 0].item())
+    return VerifyResult(
+        emitted_tokens=emitted,
+        next_anchor=next_anchor,
+        accept=accept,
+        cache_committed=cache_committed,
+        cached_len=accounting.cached_len,
+    )
+
+
+__all__ = ["VerifyResult", "apply_verify_step"]

--- a/moe_infinity/spec_decode/_dflash_ops.py
+++ b/moe_infinity/spec_decode/_dflash_ops.py
@@ -24,12 +24,20 @@ AnchorLike = Union[int, torch.Tensor]
 
 
 class Committed(NamedTuple):
-    emitted: torch.Tensor  # [B, accept+1] accepted drafts ++ bonus; appended to output
-    block_prefix: torch.Tensor  # [B, accept+1] anchor ++ accepted drafts; KV kept (start += accept+1)
-    bonus: torch.Tensor  # [B, 1] posterior[:, accept]; emitted-but-NOT-cached, next anchor
+    emitted: (
+        torch.Tensor
+    )  # [B, accept+1] accepted drafts ++ bonus; appended to output
+    block_prefix: (
+        torch.Tensor
+    )  # [B, accept+1] anchor ++ accepted drafts; KV kept (start += accept+1)
+    bonus: (
+        torch.Tensor
+    )  # [B, 1] posterior[:, accept]; emitted-but-NOT-cached, next anchor
 
 
-def build_block(anchor: AnchorLike, mask_token_id: int, block_size: int) -> torch.Tensor:
+def build_block(
+    anchor: AnchorLike, mask_token_id: int, block_size: int
+) -> torch.Tensor:
     """Return ``[anchor, MASK x (block_size - 1)]`` as an int64 ``[B, block_size]``."""
     if not torch.is_tensor(anchor):
         anchor = torch.tensor(anchor)
@@ -43,7 +51,9 @@ def build_block(anchor: AnchorLike, mask_token_id: int, block_size: int) -> torc
     return torch.cat([anchor, masks], dim=1)
 
 
-def acceptance_length(candidates: torch.Tensor, target_predict: torch.Tensor) -> int:
+def acceptance_length(
+    candidates: torch.Tensor, target_predict: torch.Tensor
+) -> int:
     """Number of leading draft tokens the target agrees with (RFC 1.2).
 
     ``accept = cumprod(candidates[:, 1:] == target_predict[:, :-1]).sum()`` --
@@ -127,7 +137,9 @@ def committed_tokens_ragged(
             f"accepts has {len(accepts)} rows but block has batch {block.shape[0]}"
         )
     return [
-        committed_tokens(block[b : b + 1], posterior[b : b + 1], int(accepts[b]))
+        committed_tokens(
+            block[b : b + 1], posterior[b : b + 1], int(accepts[b])
+        )
         for b in range(int(block.shape[0]))
     ]
 

--- a/moe_infinity/spec_decode/_dflash_ops.py
+++ b/moe_infinity/spec_decode/_dflash_ops.py
@@ -1,14 +1,22 @@
 """Pure, CPU-friendly tensor ops for the DFlash accept rule and block build.
 
 No model loading, no KV cache, no state machine -- just the deterministic
-argmax-domain math from RFC 1.2 (batch==1 in v1). The native draft->verify->
-rollback loop (Task 6) composes these; the emitted-vs-cached split lives in
-``Committed`` because conflating the two is the plan's #1 losslessness risk.
+argmax-domain math from RFC 1.2. The native draft->verify->rollback loop
+composes these; the emitted-vs-cached split lives in ``Committed`` because
+conflating the two is the plan's #1 losslessness risk.
+
+Batching (Track C): ``build_block`` / ``acceptance_length`` /
+``committed_tokens`` keep their original single-effective-accept behaviour
+(byte-identical); the ``*_batched``/``*_ragged`` variants generalize them to a
+leading batch dim with PER-SEQUENCE accept lengths and ragged commits. A batch
+row whose drafts share no uniform accept length cannot be represented in one
+dense ``Committed`` tensor, so the ragged variant returns one ``Committed``
+per row.
 """
 
 from __future__ import annotations
 
-from typing import NamedTuple, Union
+from typing import List, NamedTuple, Sequence, Union
 
 import torch
 
@@ -67,4 +75,69 @@ def committed_tokens(
     )
 
 
-__all__ = ["Committed", "build_block", "acceptance_length", "committed_tokens"]
+def build_block_with_prefixes(
+    prefixes: Sequence[Sequence[int]], mask_token_id: int, block_size: int
+) -> torch.Tensor:
+    """Ragged batched block build: one row per prefix, right-filled with MASK.
+
+    Row ``b`` is ``prefixes[b] ++ [MASK x (block_size - len(prefixes[b]))]``.
+    A prefix holds tokens ALREADY known for that row (the re-fed
+    emitted-but-uncached run of the batched loop -- at minimum the anchor);
+    the drafter only fills the MASK slots afterwards. ``build_block`` is the
+    special case where every prefix is a single anchor. Prefixes may be empty
+    (an all-MASK row: a finished sequence kept in the dense batch whose row is
+    never read) and may fill the whole block (no room for new drafts).
+    """
+    rows: List[List[int]] = []
+    for prefix in prefixes:
+        row = [int(t) for t in prefix]
+        if len(row) > int(block_size):
+            raise ValueError(
+                f"block prefix length {len(row)} exceeds block_size {block_size}"
+            )
+        row = row + [int(mask_token_id)] * (int(block_size) - len(row))
+        rows.append(row)
+    return torch.tensor(rows, dtype=torch.long)
+
+
+def acceptance_lengths(
+    candidates: torch.Tensor, target_predict: torch.Tensor
+) -> List[int]:
+    """Batched accept rule: per-row leading-match counts (RFC 1.2).
+
+    Same ``cumprod`` math as ``acceptance_length`` but reduced per row, so a
+    ``[batch, block]`` block yields one accept count in ``[0, block_size - 1]``
+    per sequence instead of a single batch-wide sum.
+    """
+    matches = (candidates[:, 1:] == target_predict[:, :-1]).long()
+    return [int(x) for x in matches.cumprod(dim=1).sum(dim=1).tolist()]
+
+
+def committed_tokens_ragged(
+    block: torch.Tensor, posterior: torch.Tensor, accepts: Sequence[int]
+) -> List[Committed]:
+    """Per-row ``committed_tokens`` for ragged per-sequence accept lengths.
+
+    Row ``b`` is split with its own ``accepts[b]``; the returned list is
+    ragged (row ``b``'s ``emitted`` has ``accepts[b] + 1`` tokens), which a
+    single dense ``Committed`` cannot express.
+    """
+    if len(accepts) != int(block.shape[0]):
+        raise ValueError(
+            f"accepts has {len(accepts)} rows but block has batch {block.shape[0]}"
+        )
+    return [
+        committed_tokens(block[b : b + 1], posterior[b : b + 1], int(accepts[b]))
+        for b in range(int(block.shape[0]))
+    ]
+
+
+__all__ = [
+    "Committed",
+    "acceptance_length",
+    "acceptance_lengths",
+    "build_block",
+    "build_block_with_prefixes",
+    "committed_tokens",
+    "committed_tokens_ragged",
+]

--- a/moe_infinity/spec_decode/_dflash_sample_ops.py
+++ b/moe_infinity/spec_decode/_dflash_sample_ops.py
@@ -1,0 +1,185 @@
+"""Sampled (non-greedy) DFlash accept rule: lossless speculative sampling for
+a block-parallel (diffusion) proposal.
+
+The greedy ops in ``_dflash_ops`` decide acceptance by argmax agreement. This
+module is the temperature/top-k/top-p counterpart: per-slot rejection
+sampling with residual correction -- the block-parallel generalization of
+Leviathan et al. 2023 (Sec. 3.2) / Chen et al. 2023 speculative sampling,
+i.e. Stern-style blockwise parallel proposals verified with the lossless
+per-position accept test also used by Medusa (rejection-sampling variant) and
+tree-based verifiers (SpecInfer/EAGLE).
+
+Setup (one draft->verify step, block ``[anchor, d_1..d_{B-1}]``):
+
+* ``Q_i`` -- the distribution the drafter ACTUALLY sampled draft ``d_i``
+  from: the warped softmax of the drafter's slot-``i`` logits. The drafter is
+  non-causal (block diffusion): every ``Q_i`` is produced in parallel,
+  conditioned on the anchor + context feature, never on the other drafts.
+* ``P_i`` -- the target's true conditional for slot ``i`` given the tokens
+  actually preceding it: the warped softmax of the verify-forward logits at
+  slot ``i - 1`` (causal attention over ``[anchor, d_1..d_{i-1}]``).
+
+Accept rule: for ``i = 1..B-1`` accept ``d_i`` with probability
+``min(1, P_i(d_i) / Q_i(d_i))``; on the first rejection at slot ``n`` emit a
+correction token drawn from the residual ``norm(max(0, P_n - Q_n))`` and end
+the step; if every draft is accepted, emit a bonus token from ``P_B`` (the
+verify logits at the last slot).
+
+Losslessness (Track-B B0 gate). Lemma (Leviathan Sec. 3.2): for any two
+distributions P, Q, a draw ``x ~ Q`` accepted with probability
+``min(1, P(x)/Q(x))`` -- and redrawn on rejection from
+``norm(max(0, P - Q))`` -- is distributed EXACTLY as P, because
+``P(out=t) = min(P(t),Q(t)) + max(0, P(t)-Q(t)) = P(t)``. Applying the lemma
+per slot, conditioned on the committed prefix, yields a joint emitted stream
+identical to autoregressive sampling from the (warped) target: the lemma
+requires only that (a) ``d_i`` is a genuine draw from the named ``Q_i`` and
+(b) ``P_i`` is the target's true conditional given the actual preceding
+tokens. The proposal's non-autoregressive structure is irrelevant -- ``Q_i``
+may depend on anything fixed before verification (here the anchor and the
+context feature). The warp (temperature -> top-k -> top-p, mirroring
+``GenerationEngine._sample``) is applied identically to P, to Q, and to the
+plain sampler, so the preserved distribution is exactly what plain sampled
+generation produces; EOS / max-token truncation is the same deterministic
+function of the emitted stream on both paths.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple, Optional
+
+import torch
+import torch.nn.functional as F
+
+from moe_infinity.spec_decode._dflash_ops import Committed
+
+
+class SampledAcceptance(NamedTuple):
+    accept: int  # accepted leading drafts, in [0, block_size - 1]
+    final_token: int  # residual correction (reject) or bonus (full accept)
+
+
+def warped_probs(
+    logits: torch.Tensor,
+    temperature: float = 1.0,
+    top_k: int = 0,
+    top_p: float = 1.0,
+) -> torch.Tensor:
+    """Row-wise softmax with the ``GenerationEngine._sample`` warp.
+
+    Order matters and matches the engine sampler exactly: temperature scale,
+    top-k filter, top-p (nucleus) filter, softmax. Applied identically to the
+    draft and target distributions, the rejection rule then preserves the
+    warped target -- precisely the distribution plain sampled generation
+    draws from. ``logits`` is ``[..., vocab]``; each row is warped
+    independently (the top-p "keep at least one token" guard is per row).
+    """
+    if float(temperature) <= 0:
+        raise ValueError(
+            "warped_probs requires temperature > 0; greedy (temperature == 0)"
+            " uses the argmax path in _dflash_ops"
+        )
+    if float(temperature) != 1.0:
+        logits = logits / float(temperature)
+    if int(top_k) > 0:
+        k = min(int(top_k), int(logits.shape[-1]))
+        topk_idx = torch.topk(logits, k, dim=-1).indices
+        filtered = torch.full_like(logits, float("-inf"))
+        filtered.scatter_(-1, topk_idx, logits.gather(-1, topk_idx))
+        logits = filtered
+    if float(top_p) < 1.0:
+        sorted_logits, sorted_idx = torch.sort(logits, descending=True, dim=-1)
+        sorted_probs = F.softmax(sorted_logits, dim=-1)
+        cumulative = torch.cumsum(sorted_probs, dim=-1)
+        remove = cumulative > float(top_p)
+        remove[..., 0] = False
+        sorted_logits = sorted_logits.masked_fill(remove, float("-inf"))
+        filtered = torch.full_like(logits, float("-inf"))
+        filtered.scatter_(-1, sorted_idx, sorted_logits)
+        logits = filtered
+    return F.softmax(logits, dim=-1)
+
+
+def residual_distribution(p: torch.Tensor, q: torch.Tensor) -> torch.Tensor:
+    """``norm(max(0, p - q))`` -- the rejection-resampling distribution.
+
+    Sums to 1 by construction. An all-zero residual only arises when
+    ``p == q`` (both rows are distributions), where rejection has probability
+    0; floating-point noise can still land here, in which case we fall back
+    to ``p`` itself -- sampling the exact target row is lossless.
+    """
+    residual = (p - q).clamp_min(0)
+    total = residual.sum()
+    if float(total) <= 0:
+        return p
+    return residual / total
+
+
+def acceptance_sampled(
+    draft_probs: torch.Tensor,
+    target_probs: torch.Tensor,
+    drafts: torch.Tensor,
+    generator: Optional[torch.Generator] = None,
+) -> SampledAcceptance:
+    """Per-slot rejection-sampling accept rule (see module docstring).
+
+    ``draft_probs``  -- ``[B - 1, V]`` rows ``Q_1..Q_{B-1}``: the warped
+                        drafter slot distributions that produced ``drafts``;
+    ``target_probs`` -- ``[B, V]`` rows ``P_1..P_B``: the warped verify
+                        logits at slots ``0..B-1`` (the last row is the bonus
+                        distribution);
+    ``drafts``       -- ``[B - 1]`` token ids ``d_1..d_{B-1}`` sampled from
+                        the ``Q_i`` rows (NOT argmax).
+
+    Returns the accepted leading-draft count and the step's final token: the
+    residual correction at the first rejected slot, or -- when every draft is
+    accepted -- a bonus drawn from ``P_B``. ``generator`` isolates the draws
+    for seeded determinism; ``None`` uses the global torch RNG (seed it with
+    ``torch.manual_seed``).
+    """
+    num_drafts = int(drafts.shape[0])
+    for i in range(num_drafts):
+        token = int(drafts[i])
+        q = float(draft_probs[i, token])
+        p = float(target_probs[i, token])
+        accept_prob = min(1.0, p / q) if q > 0 else 0.0
+        if float(torch.rand((), generator=generator)) < accept_prob:
+            continue
+        correction = torch.multinomial(
+            residual_distribution(target_probs[i], draft_probs[i]),
+            num_samples=1,
+            generator=generator,
+        )
+        return SampledAcceptance(accept=i, final_token=int(correction))
+    bonus = torch.multinomial(target_probs[-1], num_samples=1, generator=generator)
+    return SampledAcceptance(accept=num_drafts, final_token=int(bonus))
+
+
+def committed_tokens_sampled(
+    block: torch.Tensor, accept: int, final_token: int
+) -> Committed:
+    """Sampled-mode counterpart of ``committed_tokens``.
+
+    The emitted/cached split is identical to greedy -- accepted drafts are
+    emitted and cached, the final token is emitted-but-NOT-cached (it becomes
+    the next anchor) -- but the final token is the accept rule's residual
+    correction / sampled bonus, not an argmax posterior row.
+    """
+    accept = int(accept)
+    accepted_drafts = block[:, 1 : accept + 1]
+    bonus = torch.as_tensor(
+        int(final_token), dtype=block.dtype, device=block.device
+    ).reshape(1, 1)
+    return Committed(
+        emitted=torch.cat([accepted_drafts, bonus], dim=1),
+        block_prefix=block[:, : accept + 1],
+        bonus=bonus,
+    )
+
+
+__all__ = [
+    "SampledAcceptance",
+    "acceptance_sampled",
+    "committed_tokens_sampled",
+    "residual_distribution",
+    "warped_probs",
+]

--- a/moe_infinity/spec_decode/_dflash_sample_ops.py
+++ b/moe_infinity/spec_decode/_dflash_sample_ops.py
@@ -150,7 +150,9 @@ def acceptance_sampled(
             generator=generator,
         )
         return SampledAcceptance(accept=i, final_token=int(correction))
-    bonus = torch.multinomial(target_probs[-1], num_samples=1, generator=generator)
+    bonus = torch.multinomial(
+        target_probs[-1], num_samples=1, generator=generator
+    )
     return SampledAcceptance(accept=num_drafts, final_token=int(bonus))
 
 

--- a/moe_infinity/spec_decode/_prefetch_route.py
+++ b/moe_infinity/spec_decode/_prefetch_route.py
@@ -23,14 +23,18 @@ LogitsLike = Union[torch.Tensor, np.ndarray, Sequence[Sequence[float]]]
 IdsLike = Union[torch.Tensor, np.ndarray, Sequence[int]]
 
 
-def _as_2d_tensor(x: Union[torch.Tensor, np.ndarray, Sequence[object]], name: str) -> torch.Tensor:
+def _as_2d_tensor(
+    x: Union[torch.Tensor, np.ndarray, Sequence[object]], name: str
+) -> torch.Tensor:
     """Coerce ``x`` to a 2-D torch tensor without changing device/dtype semantics."""
     if isinstance(x, np.ndarray):
         x = torch.from_numpy(x)
     elif not torch.is_tensor(x):
         x = torch.tensor(x)
     if x.dim() != 2:
-        raise ValueError(f"{name} must be 2-D [num_tokens, num_experts]; got shape {tuple(x.shape)}")
+        raise ValueError(
+            f"{name} must be 2-D [num_tokens, num_experts]; got shape {tuple(x.shape)}"
+        )
     return x
 
 
@@ -60,7 +64,9 @@ def union_experts_from_mask(router_mask: MaskLike) -> list[int]:
     return sorted(int(i) for i in routed)
 
 
-def union_experts_from_logits(router_logits: LogitsLike, top_k: int) -> list[int]:
+def union_experts_from_logits(
+    router_logits: LogitsLike, top_k: int
+) -> list[int]:
     """Sorted union of per-token ``top_k`` experts from ``[num_tokens, num_experts]`` logits.
 
     Applies ``torch.topk`` row-wise and unions the selected indices. Softmax is
@@ -96,7 +102,9 @@ def prefetch_coverage(predicted_ids: IdsLike, actual_ids: IdsLike) -> float:
     return len(predicted & actual) / len(actual)
 
 
-def rejected_expert_ids(full_union_ids: IdsLike, kept_union_ids: IdsLike) -> list[int]:
+def rejected_expert_ids(
+    full_union_ids: IdsLike, kept_union_ids: IdsLike
+) -> list[int]:
     r"""Sorted set-difference ``full \ kept`` -- the wasted prefetch set.
 
     ``full_union_ids`` is the union prefetched over the whole speculative block;

--- a/moe_infinity/spec_decode/_prefetch_route.py
+++ b/moe_infinity/spec_decode/_prefetch_route.py
@@ -1,0 +1,115 @@
+"""Pure, CPU-friendly helpers for DFlash route-ahead expert prefetch (Track A1).
+
+No model loading, no prefetcher state, no CUDA -- just set math over router
+outputs. The route-ahead design (``.sisyphus/plans/dflash-deferred-tracks-plan.md``,
+Track A A0) prefetches the ACTUAL routed union of experts -- the same union
+``ExpertExecutor.dispatch_local`` derives from ``router_mask``
+(``distributed/expert_executor.py:101-111``) -- instead of the legacy
+``mean(0).topk(2)`` pool. These helpers compute that union from either the
+boolean mask or the raw logits, plus the coverage/waste metrics used to score
+predicted-vs-actual prefetch sets. A2/A3 consume them; nothing here mutates
+routing or model outputs.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import numpy as np
+import torch
+
+MaskLike = Union[torch.Tensor, np.ndarray, Sequence[Sequence[int]]]
+LogitsLike = Union[torch.Tensor, np.ndarray, Sequence[Sequence[float]]]
+IdsLike = Union[torch.Tensor, np.ndarray, Sequence[int]]
+
+
+def _as_2d_tensor(x: Union[torch.Tensor, np.ndarray, Sequence[object]], name: str) -> torch.Tensor:
+    """Coerce ``x`` to a 2-D torch tensor without changing device/dtype semantics."""
+    if isinstance(x, np.ndarray):
+        x = torch.from_numpy(x)
+    elif not torch.is_tensor(x):
+        x = torch.tensor(x)
+    if x.dim() != 2:
+        raise ValueError(f"{name} must be 2-D [num_tokens, num_experts]; got shape {tuple(x.shape)}")
+    return x
+
+
+def _to_id_set(ids: IdsLike) -> set[int]:
+    """Coerce a tensor/ndarray/sequence of expert ids to a python ``set[int]``."""
+    if torch.is_tensor(ids):
+        items = ids.flatten().tolist()
+    elif isinstance(ids, np.ndarray):
+        items = ids.flatten().tolist()
+    else:
+        items = list(ids)
+    return {int(i) for i in items}
+
+
+def union_experts_from_mask(router_mask: MaskLike) -> list[int]:
+    """Sorted union of expert indices routed by ANY token in ``router_mask``.
+
+    ``router_mask`` is the per-token routing mask ``[num_tokens, num_experts]``
+    (bool or 0/1 int) built by the MoE block, e.g. ``models/gpt_oss.py:141-147``.
+    This matches the executor's derivation exactly:
+    ``expert_list = arange(num_experts)[mask.sum(0) > 0]``
+    (``distributed/expert_executor.py:101-111``). Returns ``[]`` when no token
+    routes anywhere (or ``num_tokens == 0``).
+    """
+    mask = _as_2d_tensor(router_mask, "router_mask").to(torch.bool)
+    routed = mask.any(dim=0).nonzero().flatten().tolist()
+    return sorted(int(i) for i in routed)
+
+
+def union_experts_from_logits(router_logits: LogitsLike, top_k: int) -> list[int]:
+    """Sorted union of per-token ``top_k`` experts from ``[num_tokens, num_experts]`` logits.
+
+    Applies ``torch.topk`` row-wise and unions the selected indices. Softmax is
+    monotonic, so top-k on raw logits equals top-k on the routing probabilities
+    computed in the MoE block (``models/gpt_oss.py:132-135``) -- hence this
+    matches ``union_experts_from_mask`` whenever the mask was built with the
+    same ``top_k``. Ties follow ``torch.topk`` semantics. Logits are cast to
+    float32 first so bf16/fp16 inputs behave deterministically on CPU.
+    """
+    logits = _as_2d_tensor(router_logits, "router_logits").to(torch.float32)
+    num_tokens, num_experts = logits.shape
+    top_k = int(top_k)
+    if not 1 <= top_k <= num_experts:
+        raise ValueError(f"top_k must be in [1, {num_experts}]; got {top_k}")
+    if num_tokens == 0:
+        return []
+    selected = torch.topk(logits, k=top_k, dim=1).indices
+    return sorted({int(i) for i in selected.flatten().tolist()})
+
+
+def prefetch_coverage(predicted_ids: IdsLike, actual_ids: IdsLike) -> float:
+    """Fraction of actually-routed experts that the prediction covered.
+
+    ``|predicted ∩ actual| / |actual|``; returns ``1.0`` when ``actual`` is
+    empty (nothing to cover -- nothing was wasted either). This is the
+    per-layer term of the plan's ``coverage = Σ|P_l ∩ A_l| / Σ|A_l|`` metric
+    (Track A A0 item 4); callers aggregate across layers.
+    """
+    predicted = _to_id_set(predicted_ids)
+    actual = _to_id_set(actual_ids)
+    if not actual:
+        return 1.0
+    return len(predicted & actual) / len(actual)
+
+
+def rejected_expert_ids(full_union_ids: IdsLike, kept_union_ids: IdsLike) -> list[int]:
+    r"""Sorted set-difference ``full \ kept`` -- the wasted prefetch set.
+
+    ``full_union_ids`` is the union prefetched over the whole speculative block;
+    ``kept_union_ids`` is the union over only the tokens that survived
+    verification (the kept prefix). The difference was fetched but never used:
+    the per-layer ``rejected_waste`` id set of Track A A0 item 4.
+    """
+    return sorted(_to_id_set(full_union_ids) - _to_id_set(kept_union_ids))
+
+
+__all__ = [
+    "union_experts_from_mask",
+    "union_experts_from_logits",
+    "prefetch_coverage",
+    "rejected_expert_ids",
+]

--- a/moe_infinity/spec_decode/_route_ahead_ctx.py
+++ b/moe_infinity/spec_decode/_route_ahead_ctx.py
@@ -26,8 +26,8 @@ route_ahead_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
     "dflash_route_ahead_active", default=False
 )
 route_ahead_prefetcher: contextvars.ContextVar[Optional[Any]] = (
-    contextvars.ContextVar("dflash_route_ahead_prefetcher", default=None
-))
+    contextvars.ContextVar("dflash_route_ahead_prefetcher", default=None)
+)
 # A5 metrics handle: a ``RouteAheadStats`` (``_route_ahead_stats``) when the
 # speculator opted in, else None. Typed ``Any`` to keep this module a leaf.
 route_ahead_stats: contextvars.ContextVar[Optional[Any]] = (

--- a/moe_infinity/spec_decode/_route_ahead_ctx.py
+++ b/moe_infinity/spec_decode/_route_ahead_ctx.py
@@ -1,0 +1,80 @@
+"""DFlash route-ahead prefetch context (Track A3).
+
+``contextvars.ContextVar``-backed, async/thread-safe marker that the current
+forward is a DFlash VERIFY forward, plus an optional prefetcher handle bound
+at activation. ``DFlashSpeculator.generate`` activates it around the verify
+call; ``DistributedExpertExecutor.dispatch_local`` consumes it to pin +
+enqueue the ACTUAL routed expert union for the layer being dispatched, before
+any expert read (``.sisyphus/plans/dflash-deferred-tracks-plan.md``, Track A
+A0 section 2). Default INACTIVE: non-spec decode and spec-off paths never set
+the flag and observe zero behavior change; the context only triggers cache
+warming, never routing or output changes.
+
+Intentionally a LEAF module (no ``moe_infinity`` imports) so
+``distributed/expert_executor.py`` can lazy-import it without the
+``spec_decode.__init__`` -> ``dflash`` -> ``big_modeling`` ->
+``model_offload`` -> ``expert_executor`` cycle. A4/A5 reuse this seam.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+route_ahead_active: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "dflash_route_ahead_active", default=False
+)
+route_ahead_prefetcher: contextvars.ContextVar[Optional[Any]] = (
+    contextvars.ContextVar("dflash_route_ahead_prefetcher", default=None
+))
+# A5 metrics handle: a ``RouteAheadStats`` (``_route_ahead_stats``) when the
+# speculator opted in, else None. Typed ``Any`` to keep this module a leaf.
+route_ahead_stats: contextvars.ContextVar[Optional[Any]] = (
+    contextvars.ContextVar("dflash_route_ahead_stats", default=None)
+)
+
+
+def is_active() -> bool:
+    return route_ahead_active.get()
+
+
+def current_prefetcher() -> Optional[Any]:
+    return route_ahead_prefetcher.get()
+
+
+def current_stats() -> Optional[Any]:
+    return route_ahead_stats.get()
+
+
+@contextmanager
+def route_ahead_context(
+    prefetcher: Optional[Any] = None, stats: Optional[Any] = None
+) -> Iterator[None]:
+    """Activate the route-ahead context; token-reset in ``finally``.
+
+    A raise inside the wrapped forward can never leak the active state into
+    later non-spec decode; nested scopes restore the outer prefetcher handle.
+    ``stats`` (A5) is an optional read-only metrics recorder; ``None``
+    (default) keeps the seam zero-overhead.
+    """
+    active_token = route_ahead_active.set(True)
+    prefetcher_token = route_ahead_prefetcher.set(prefetcher)
+    stats_token = route_ahead_stats.set(stats)
+    try:
+        yield
+    finally:
+        route_ahead_stats.reset(stats_token)
+        route_ahead_prefetcher.reset(prefetcher_token)
+        route_ahead_active.reset(active_token)
+
+
+__all__ = [
+    "route_ahead_active",
+    "route_ahead_prefetcher",
+    "route_ahead_stats",
+    "is_active",
+    "current_prefetcher",
+    "current_stats",
+    "route_ahead_context",
+]

--- a/moe_infinity/spec_decode/_route_ahead_stats.py
+++ b/moe_infinity/spec_decode/_route_ahead_stats.py
@@ -1,0 +1,207 @@
+"""Opt-in coverage/waste metrics for DFlash route-ahead prefetch (Track A5).
+
+Read-only observer for the route-ahead seam (``.sisyphus/plans/
+dflash-deferred-tracks-plan.md``, Track A A0 item 4). While the DFlash verify
+context is active, the executor route-ahead seam
+(``distributed/expert_executor.py`` ``_maybe_route_ahead_prefetch``) reports
+each dispatched MoE layer's predicted (pinned/prefetched) expert set and its
+routed mask; once the accept rule has fixed the kept prefix,
+``DFlashSpeculator.generate`` calls ``commit_step`` to finalize the step:
+
+* coverage: ``sum |P_l ∩ A_l| / sum |A_l|`` -- the fraction of experts the
+  verify actually read (``A_l`` = union of the layer's router mask, exactly
+  the set ``dispatch_local`` enqueues) that the route-ahead prefetch covered
+  (``P_l``). Vacuous layers (``A_l`` empty) contribute nothing; the ratio
+  defaults to 1.0 when nothing was ever routed, matching the A1
+  ``prefetch_coverage`` empty-actual convention.
+* rejected-token waste: ``sum |P_l \\ U_keep_l|`` -- prefetched experts the
+  kept (accepted) prefix never routed to, i.e. fetched for draft tokens that
+  verification rolled back. Computed with the A1 ``rejected_expert_ids`` on
+  the full PREFETCHED union vs. the kept-prefix union; nothing prefetched
+  means nothing wasted.
+
+The observer NEVER touches routing, prefetch decisions, or model outputs:
+``observe_layer``/``commit_step`` only read and accumulate. Default-off: a
+``None`` stats handle short-circuits both ends (executor seam and
+speculator), so uninstrumented runs pay exactly zero extra work. Enable via
+``DFlashSpeculator.enable_route_ahead_stats()`` and read the counters back
+after ``generate()``.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, NamedTuple, Sequence, Tuple, Union
+
+import torch
+
+from moe_infinity.spec_decode._prefetch_route import (
+    rejected_expert_ids,
+    union_experts_from_mask,
+)
+
+
+class RouteAheadStepSummary(NamedTuple):
+    """One committed verify step's accounting (all in expert-count units)."""
+
+    layers: int  # executor-backed MoE layers observed this step
+    predicted: int  # sum |P_l| -- experts the route-ahead prefetch pinned
+    actual: int  # sum |A_l| -- experts the verify dispatch routed to
+    covered: int  # sum |P_l ∩ A_l|
+    kept: int  # sum |U_keep_l| -- union over only the kept prefix rows
+    wasted: int  # sum |P_l \ U_keep_l| -- rejected-token prefetch waste
+
+    @property
+    def coverage(self) -> float:
+        """Per-step ``sum |P_l ∩ A_l| / sum |A_l|`` (1.0 when nothing routed)."""
+        if self.actual == 0:
+            return 1.0
+        return self.covered / self.actual
+
+
+class RouteAheadStats:
+    """Accumulates per-verify-step route-ahead coverage/waste counters.
+
+    Lifecycle per verify step (driven by ``DFlashSpeculator``):
+    ``begin_step`` at verify-forward entry, one ``observe_layer`` per
+    executor-backed MoE dispatch (from the route-ahead seam), then
+    ``commit_step(kept_rows)`` after the accept rule fixes the kept prefix.
+    Records from a step that aborts before commit are dropped by the next
+    ``begin_step`` -- they are never committed, so a failed verify cannot
+    corrupt the counters. All mutating methods are called only from the
+    speculator/executor plumbing; post-``generate()`` this object is a
+    plain readout.
+    """
+
+    def __init__(self) -> None:
+        self.steps: int = 0
+        self.layers_observed: int = 0
+        self.predicted_experts: int = 0
+        self.actual_experts: int = 0
+        self.covered_experts: int = 0
+        self.kept_experts: int = 0
+        self.wasted_experts: int = 0
+        self._pending: List[Tuple[int, List[int], torch.Tensor]] = []
+
+    # ------------------------------------------------------------------
+    # recorder interface (speculator + executor seam drive these)
+    # ------------------------------------------------------------------
+
+    def begin_step(self) -> None:
+        """Start a verify step; any uncommitted prior records are dropped."""
+        self._pending.clear()
+
+    def observe_layer(
+        self,
+        layer_id: int,
+        predicted_ids: Sequence[int],
+        router_mask: Union[torch.Tensor, Sequence[Sequence[int]]],
+    ) -> None:
+        """Record one dispatched layer of the in-flight verify step.
+
+        ``predicted_ids`` is the expert set the route-ahead pin/prefetch
+        covered for this layer (``[]`` when the seam did not fire, e.g. no
+        prefetcher bound); ``router_mask`` is the layer's OWN dispatch mask
+        ``[num_tokens, num_experts]`` whose column-wise any is the actual
+        verify-read union. The mask is snapshotted to CPU (a no-op view when
+        already on CPU) so the kept-prefix waste can be computed later, once
+        the accept length is known. Read-only: the mask is never modified.
+        """
+        mask = router_mask if torch.is_tensor(router_mask) else torch.tensor(router_mask)
+        if mask.dim() != 2:
+            raise ValueError(
+                "router_mask must be 2-D [num_tokens, num_experts]; "
+                f"got shape {tuple(mask.shape)}"
+            )
+        mask_cpu = mask.detach().to(torch.bool).cpu()
+        self._pending.append(
+            (int(layer_id), [int(e) for e in predicted_ids], mask_cpu)
+        )
+
+    def commit_step(self, kept_rows: int) -> RouteAheadStepSummary:
+        """Finalize the in-flight step: coverage + rejected-token waste.
+
+        ``kept_rows`` is the number of leading block rows whose KV survived
+        verification (``cache_committed`` in ``dflash.generate`` -- the
+        anchor plus the accepted drafts). The kept-prefix union uses exactly
+        those rows of each recorded mask; prefetched experts outside it were
+        fetched for tokens that got rolled back. Steps with no observed
+        layers (bare-HF targets, or the seam never fired) leave the counters
+        untouched and return a zero summary.
+        """
+        pending = self._pending
+        self._pending = []
+        if not pending:
+            return RouteAheadStepSummary(0, 0, 0, 0, 0, 0)
+
+        predicted = actual = covered = kept = wasted = 0
+        for _layer_id, predicted_ids, mask in pending:
+            full_union = union_experts_from_mask(mask)
+            rows = max(0, min(int(kept_rows), int(mask.shape[0])))
+            kept_union = union_experts_from_mask(mask[:rows]) if rows else []
+            predicted_set = set(predicted_ids)
+            predicted += len(predicted_set)
+            actual += len(full_union)
+            # Same set semantics as the A1 ``prefetch_coverage``; the count
+            # form is what the A0 section 4 ratio-of-sums aggregates.
+            covered += len(predicted_set & set(full_union))
+            kept += len(kept_union)
+            wasted += len(rejected_expert_ids(predicted_ids, kept_union))
+
+        self.steps += 1
+        self.layers_observed += len(pending)
+        self.predicted_experts += predicted
+        self.actual_experts += actual
+        self.covered_experts += covered
+        self.kept_experts += kept
+        self.wasted_experts += wasted
+        return RouteAheadStepSummary(
+            len(pending), predicted, actual, covered, kept, wasted
+        )
+
+    # ------------------------------------------------------------------
+    # readout
+    # ------------------------------------------------------------------
+
+    @property
+    def coverage(self) -> float:
+        """``sum |P_l ∩ A_l| / sum |A_l|`` over all committed steps (A0 item 4).
+
+        1.0 when nothing was ever routed (nothing to cover), mirroring the
+        A1 ``prefetch_coverage`` empty-actual convention.
+        """
+        if self.actual_experts == 0:
+            return 1.0
+        return self.covered_experts / self.actual_experts
+
+    @property
+    def waste_ratio(self) -> float:
+        """``sum |P_l \\ U_keep_l| / sum |P_l|`` -- share of the prefetched
+        experts that rejected draft tokens made useless (0.0 when nothing
+        was ever prefetched)."""
+        if self.predicted_experts == 0:
+            return 0.0
+        return self.wasted_experts / self.predicted_experts
+
+    def reset(self) -> None:
+        """Zero all counters and drop any uncommitted records."""
+        self.__init__()
+
+    def as_dict(self) -> Dict[str, Union[int, float]]:
+        """Flat snapshot of the counters plus the two derived ratios."""
+        return {
+            "steps": self.steps,
+            "layers_observed": self.layers_observed,
+            "predicted_experts": self.predicted_experts,
+            "actual_experts": self.actual_experts,
+            "covered_experts": self.covered_experts,
+            "kept_experts": self.kept_experts,
+            "wasted_experts": self.wasted_experts,
+            "coverage": self.coverage,
+            "waste_ratio": self.waste_ratio,
+        }
+
+
+__all__ = [
+    "RouteAheadStats",
+    "RouteAheadStepSummary",
+]

--- a/moe_infinity/spec_decode/_route_ahead_stats.py
+++ b/moe_infinity/spec_decode/_route_ahead_stats.py
@@ -106,7 +106,11 @@ class RouteAheadStats:
         already on CPU) so the kept-prefix waste can be computed later, once
         the accept length is known. Read-only: the mask is never modified.
         """
-        mask = router_mask if torch.is_tensor(router_mask) else torch.tensor(router_mask)
+        mask = (
+            router_mask
+            if torch.is_tensor(router_mask)
+            else torch.tensor(router_mask)
+        )
         if mask.dim() != 2:
             raise ValueError(
                 "router_mask must be 2-D [num_tokens, num_experts]; "

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -3,16 +3,34 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, List, NamedTuple, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import torch
 
 from moe_infinity.entrypoints.big_modeling import extract_context_feature
 from moe_infinity.spec_decode._dflash_ops import (
     acceptance_length,
+    acceptance_lengths,
     build_block,
+    build_block_with_prefixes,
     committed_tokens,
+    committed_tokens_ragged,
 )
+from moe_infinity.spec_decode._dflash_sample_ops import (
+    acceptance_sampled,
+    committed_tokens_sampled,
+    warped_probs,
+)
+from moe_infinity.spec_decode._route_ahead_ctx import route_ahead_context
+from moe_infinity.spec_decode._route_ahead_stats import RouteAheadStats
 
 if TYPE_CHECKING:
     from moe_infinity.engine.generation_loop import GenerationEngine
@@ -82,13 +100,15 @@ def validate_pairing(draft_cfg: DFlashConfig, target_hf_config: Any) -> None:
         raise ValueError(
             f"DFlash mask_token_id {draft_cfg.mask_token_id} is outside target vocab_size {t_vocab}"
         )
-    if draft_cfg.block_size != DFLASH_BLOCK_SIZE:
+    if draft_cfg.block_size < 2:
         raise ValueError(
-            f"DFlash block_size {draft_cfg.block_size} != expected {DFLASH_BLOCK_SIZE}"
+            f"DFlash block_size {draft_cfg.block_size} must be >= 2 (anchor + >=1 draft token)"
         )
-    if draft_cfg.target_layer_ids != DFLASH_TARGET_LAYER_IDS:
+    if not draft_cfg.target_layer_ids or any(
+        i < 0 for i in draft_cfg.target_layer_ids
+    ):
         raise ValueError(
-            f"DFlash target_layer_ids {draft_cfg.target_layer_ids} != expected {DFLASH_TARGET_LAYER_IDS}"
+            f"DFlash target_layer_ids {draft_cfg.target_layer_ids} must be non-empty and non-negative"
         )
     highest_capture = max(draft_cfg.target_layer_ids) + 1
     if highest_capture > t_layers:
@@ -335,6 +355,27 @@ class DFlashSpeculator:
         self.step_trace: List[NativeStepTrace] = []
         self.last_target_cache: Any = None
         self.last_draft_cache: Any = None
+        # Per-row new-token counts set by the batched path (its ragged rows
+        # are right-padded in the returned rectangle). None on the batch==1
+        # path, whose output is never padded.
+        self.last_generated_lengths: Optional[List[int]] = None
+        # Track A5 metrics handle; None (default) = instrumentation off, zero
+        # overhead. Set via ``enable_route_ahead_stats``.
+        self.route_ahead_stats: Optional[RouteAheadStats] = None
+
+    def enable_route_ahead_stats(self) -> RouteAheadStats:
+        """Opt in to Track A5 route-ahead coverage/waste instrumentation.
+
+        Creates (or resets) the ``RouteAheadStats`` recorder consumed by the
+        verify-time route-ahead context; read the counters back from
+        ``self.route_ahead_stats`` after ``generate()``. Pure observer --
+        enabling it never changes routing, prefetch, or emitted tokens.
+        """
+        if self.route_ahead_stats is None:
+            self.route_ahead_stats = RouteAheadStats()
+        else:
+            self.route_ahead_stats.reset()
+        return self.route_ahead_stats
 
     def _configure_target_hooks(self, input_ids: torch.Tensor) -> None:
         configure = getattr(self.moe, "_configure_hook", None)
@@ -349,12 +390,18 @@ class DFlashSpeculator:
         input_ids: torch.Tensor,
         past_key_values: Any = None,
         logits_to_keep: int = 0,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, Any, Any]:
         """Rich target forward -> on-device (logits, hidden_states, past_key_values).
 
         ``logits_to_keep=1`` slices to the last position and is for the
         prefill/anchor step only; the verify step MUST pass ``0`` (full
-        logits) or the acceptance rule breaks.
+        logits) or the acceptance rule breaks. ``attention_mask`` /
+        ``position_ids`` are the Track-C batched-path plumbing (left-padded
+        rows need explicit per-row RoPE positions); the batch==1 call sites
+        never pass them, so the single-sequence forward is byte-identical.
         """
         rich = getattr(self.moe, "_native_model_forward_rich", None)
         if callable(rich):
@@ -372,8 +419,74 @@ class DFlashSpeculator:
         }
         if logits_to_keep:
             kwargs["logits_to_keep"] = int(logits_to_keep)
+        if attention_mask is not None:
+            kwargs["attention_mask"] = attention_mask
+        if position_ids is not None:
+            kwargs["position_ids"] = position_ids
         outputs = self.target(input_ids, **kwargs)
         return outputs.logits, outputs.hidden_states, outputs.past_key_values
+
+    def _resolve_route_ahead_prefetcher(self) -> Any:
+        """Prefetcher handle bound to the verify-time route-ahead context.
+
+        Production MoE shell: ``moe.engine.expert_prefetcher``
+        (``runtime/model_offload.py:865``). Tiny fixtures / bare-HF targets
+        have no offload engine -> ``None``; the executor seam then falls back
+        to its own configured prefetcher and no-ops when none exists
+        (resident mode / ``speculative_prefetch`` config off).
+        """
+        engine = getattr(self.moe, "engine", None)
+        return getattr(engine, "expert_prefetcher", None)
+
+    def _verify_target_block(
+        self,
+        block: torch.Tensor,
+        target_kv: Any,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, Any, Any]:
+        """Verify forward under the Track A3 route-ahead context.
+
+        The context flags executor-backed MoE layers to pin + prefetch their
+        ACTUAL routed expert union before reading any expert weight
+        (cache warming only; routing/outputs unchanged). Token reset in
+        ``finally`` makes the activation exception-safe, so a failed verify
+        cannot leak route-ahead state into non-spec decode.
+
+        A4 audit: NO resident-only guard exists anywhere on the spec path --
+        ``_init_native_runtime``/``generate`` here,
+        ``big_modeling._resolve_spec_strategy`` (big_modeling.py:721), and
+        ``generation_loop._spec_strategy_applies`` (generation_loop.py:113)
+        gate only on batch size and greedy sampling, never on expert
+        residency -- so offloaded executor-backed models (DeepSeek/Qwen/
+        Mixtral) already run DFlash with this seam active. gpt-oss stays
+        excluded structurally, not by assertion: ``model_offload.py:954``
+        never wires ``expert_executor`` into ``SyncGptOssMLP`` (its forward
+        runs a resident Python expert loop), ``parse_expert_id`` yields no
+        per-expert ids for it (hf_config.py:216-223), and its experts are
+        force-resident (model_offload.py:1114-1123).
+
+        A5: when ``self.route_ahead_stats`` is set, the step's observations
+        are opened here (``begin_step``) and the handle is carried by the
+        context; ``generate`` commits the step after the accept rule.
+        """
+        stats = getattr(self, "route_ahead_stats", None)
+        if stats is not None:
+            stats.begin_step()
+        # The mask/position kwargs are forwarded only when set so the batch==1
+        # call keeps its exact pre-Track-C signature (test doubles wrap it).
+        kwargs: dict[str, Any] = {}
+        if attention_mask is not None:
+            kwargs["attention_mask"] = attention_mask
+        if position_ids is not None:
+            kwargs["position_ids"] = position_ids
+        with route_ahead_context(
+            self._resolve_route_ahead_prefetcher(), stats=stats
+        ):
+            return self._forward_target(
+                block, past_key_values=target_kv, logits_to_keep=0, **kwargs
+            )
 
     def _run_drafter(
         self,
@@ -414,11 +527,14 @@ class DFlashSpeculator:
     def generate(
         self,
         input_ids: torch.Tensor,
-        max_new_tokens: int = 256,
+        max_new_tokens: Union[int, Sequence[int]] = 256,
         temperature: float = 0.0,
         stop_token_ids: Optional[List[int]] = None,
+        top_k: int = 0,
+        top_p: float = 1.0,
+        attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Native greedy DFlash draft->verify->rollback loop (RFC 1.2).
+        """Native DFlash draft->verify->rollback loop (RFC 1.2).
 
         Per step: draft a block of ``block_size`` candidates with the
         non-causal drafter, verify the whole block in ONE target forward with
@@ -427,6 +543,17 @@ class DFlashSpeculator:
         both KV caches back to the committed prefix. The bonus token is
         emitted but NOT cached -- it becomes the next step's anchor, so
         ``cached_len`` (``start``) always trails the emitted count by one.
+
+        Sampling: ``temperature == 0`` is the greedy path above (byte-for-byte
+        the v1 contract). ``temperature > 0`` (optionally with ``top_k`` /
+        ``top_p``) runs the LOSSLESS speculative-sampling accept rule of
+        ``_dflash_sample_ops``: drafts are drawn from the drafter's warped
+        slot distributions and verified per slot against the identically
+        warped target conditionals (rejection sampling + residual
+        correction), so the emitted stream follows the exact distribution of
+        plain sampled generation from the target. Greedy-vs-sampled only
+        changes how tokens are CHOSEN; the commit/rollback bookkeeping below
+        is shared.
 
         Stop handling: ``stop_token_ids`` (falling back to the target
         config's ``eos_token_id``) truncates the emitted output at the first
@@ -437,21 +564,71 @@ class DFlashSpeculator:
         ``min(k, accept) + 1`` cached tokens -- the anchor plus the first
         ``min(k, accept)`` drafts -- because the verify forward only
         produced KV for block tokens, never for the bonus.
+
+        Batching (Track C): ``input_ids`` with batch > 1 dispatches to
+        ``_generate_batched`` -- greedy-only (``temperature`` must be 0),
+        bare-HF-target-only (the MoE rich-forward seam stays batch==1), with
+        LEFT-padded prompts described by ``attention_mask`` (omit it when all
+        prompts share one length) and a scalar or per-sequence
+        ``max_new_tokens``. The ragged per-row outputs are right-padded into
+        the returned rectangle; each row's true new-token count is exposed as
+        ``self.last_generated_lengths``. ``attention_mask`` is ignored on the
+        batch==1 path.
         """
         if input_ids.ndim != 2:
             raise ValueError(
-                f"DFlashSpeculator.generate expects input_ids of shape [1, seq], got {tuple(input_ids.shape)}"
+                f"DFlashSpeculator.generate expects input_ids of shape [batch, seq], got {tuple(input_ids.shape)}"
             )
-        if input_ids.shape[0] != 1:
-            raise NotImplementedError(
-                "DFlashSpeculator v1 supports batch==1 only; got input_ids "
-                f"with batch size {input_ids.shape[0]}"
+        if float(temperature) < 0:
+            raise ValueError(
+                f"DFlashSpeculator.generate: temperature must be >= 0, got {temperature}"
+            )
+        if input_ids.shape[0] == 1:
+            budget = max_new_tokens
+            if isinstance(budget, Sequence):
+                if len(budget) != 1:
+                    raise ValueError(
+                        f"per-sequence max_new_tokens has {len(budget)} entries "
+                        f"for batch size 1"
+                    )
+                budget = budget[0]
+            return self._generate_single(
+                input_ids,
+                max_new_tokens=int(budget),
+                temperature=float(temperature),
+                stop_token_ids=stop_token_ids,
+                top_k=top_k,
+                top_p=top_p,
             )
         if float(temperature) > 0:
-            raise ValueError(
-                "DFlashSpeculator v1 is greedy-only (temperature=0.0); "
-                "sampled speculative decoding is out of scope"
+            raise NotImplementedError(
+                "batched DFlash (batch > 1) is greedy-only for now; "
+                f"got temperature {temperature}"
             )
+        if callable(getattr(self.moe, "_native_model_forward_rich", None)):
+            raise NotImplementedError(
+                "batched DFlash (batch > 1) requires a bare HF target; the MoE "
+                "rich-forward seam is batch==1 (engine-gated) only"
+            )
+        return self._generate_batched(
+            input_ids,
+            max_new_tokens=max_new_tokens,
+            stop_token_ids=stop_token_ids,
+            attention_mask=attention_mask,
+        )
+
+    @torch.inference_mode()
+    def _generate_single(
+        self,
+        input_ids: torch.Tensor,
+        max_new_tokens: int,
+        temperature: float,
+        stop_token_ids: Optional[List[int]],
+        top_k: int,
+        top_p: float,
+    ) -> torch.Tensor:
+        """The v1 single-sequence loop (batch==1), byte-identical to pre-Track-C."""
+        sampled = float(temperature) > 0
 
         from transformers import DynamicCache
         from transformers.cache_utils import DynamicSlidingWindowLayer
@@ -467,7 +644,15 @@ class DFlashSpeculator:
         logits, hidden_states, target_kv = self._forward_target(
             input_ids, past_key_values=None, logits_to_keep=1
         )
-        anchor = int(logits[:, -1, :].argmax(dim=-1).item())
+        if sampled:
+            anchor = int(
+                torch.multinomial(
+                    warped_probs(logits[0, -1], temperature, top_k, top_p),
+                    num_samples=1,
+                ).item()
+            )
+        else:
+            anchor = int(logits[:, -1, :].argmax(dim=-1).item())
         context_feature = extract_context_feature(hidden_states, layer_ids).to(
             self.device
         )
@@ -479,6 +664,7 @@ class DFlashSpeculator:
         draft_kv = DynamicCache() if self._drafter_has_kv_cache else None
 
         self.step_trace = []
+        self.last_generated_lengths = None
         if stop_ids and anchor in stop_ids and max_new_tokens >= 1:
             # The prefill anchor is itself a stop token: emit it and halt
             # before any block is drafted (nothing past EOS may be emitted
@@ -498,7 +684,17 @@ class DFlashSpeculator:
 
             drafter_out = self._run_drafter(block, context_feature, start, draft_kv)
             draft_logits = self.lm_head(drafter_out)[:, -(block_size - 1) :, :]
-            block[:, 1:] = draft_logits.argmax(dim=-1)
+            draft_probs: Optional[torch.Tensor] = None
+            if sampled:
+                # The accept test divides by the drafter's OWN warped slot
+                # distributions, so drafts must be genuine draws from them --
+                # argmax drafts would void the losslessness proof.
+                draft_probs = warped_probs(draft_logits[0], temperature, top_k, top_p)
+                block[:, 1:] = torch.multinomial(
+                    draft_probs, num_samples=1
+                ).squeeze(-1)
+            else:
+                block[:, 1:] = draft_logits.argmax(dim=-1)
 
             # Snapshot sliding layers BEFORE the verify forward: its update
             # evicts all but the last ``sliding_window - 1`` tokens, so the
@@ -512,13 +708,25 @@ class DFlashSpeculator:
                         int(layer.cumulative_length),
                     )
 
-            logits, hidden_states, target_kv = self._forward_target(
-                block, past_key_values=target_kv, logits_to_keep=0
+            logits, hidden_states, target_kv = self._verify_target_block(
+                block, target_kv
             )
-            posterior = logits.argmax(dim=-1).to(self.device)
 
-            accept = acceptance_length(block, posterior)
-            committed = committed_tokens(block, posterior, accept)
+            if sampled:
+                assert draft_probs is not None
+                decision = acceptance_sampled(
+                    draft_probs,
+                    warped_probs(logits[0], temperature, top_k, top_p),
+                    block[0, 1:],
+                )
+                accept = decision.accept
+                committed = committed_tokens_sampled(
+                    block, decision.accept, decision.final_token
+                )
+            else:
+                posterior = logits.argmax(dim=-1).to(self.device)
+                accept = acceptance_length(block, posterior)
+                committed = committed_tokens(block, posterior, accept)
 
             # This step's emitted tokens are [d_1 .. d_accept, bonus]; the
             # verify forward produced KV only for [anchor, d_1 .. d_accept].
@@ -551,6 +759,11 @@ class DFlashSpeculator:
                 block_size=block_size,
             )
             assert int(target_kv.get_seq_length()) == start
+
+            if self.route_ahead_stats is not None:
+                # A5: finalize this verify step's coverage/waste accounting
+                # with the kept prefix the accept rule just fixed. Read-only.
+                self.route_ahead_stats.commit_step(kept_rows=cache_committed)
 
             self.step_trace.append(
                 NativeStepTrace(
@@ -585,6 +798,272 @@ class DFlashSpeculator:
         )
         return torch.cat([input_ids, new_ids], dim=1)
 
+    @torch.inference_mode()
+    def _generate_batched(
+        self,
+        input_ids: torch.Tensor,
+        max_new_tokens: Union[int, Sequence[int]],
+        stop_token_ids: Optional[List[int]],
+        attention_mask: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        """Track-C batched loop: one prefill + one verify per step for all rows.
+
+        Greedy correctness rests on two facts: (1) the emitted stream of a
+        greedy verify step is always the target's argmax continuation given
+        the committed prefix -- accepted drafts matched the target by
+        definition and the bonus/correction IS the target's argmax -- so
+        drafts (and hence batching) can only change HOW MANY tokens a step
+        commits, never WHICH tokens are emitted; (2) a row's verify logits
+        depend only on its own cache row, block prefix, and RoPE positions,
+        which the left-pad ``attention_mask`` + per-row ``position_ids``
+        plumbing reproduce exactly.
+
+        Per-sequence rollback (C1): HF ``DynamicCache`` is dense -- one
+        ``cumulative_length`` per layer and slot-index-based causal/sliding
+        masks (``create_causal_mask`` reads ``q_offset`` from the cache, not
+        per-row positions) -- so rows cannot physically hold ragged lengths.
+        Instead every row rolls back to ``prev_start + min_cc`` where
+        ``min_cc`` is the SMALLEST per-row commit among still-active rows
+        (``rollback_target_cache`` is reused unchanged: the sliding-window
+        snapshot/rebuild is per-row inside the batched tensors). Rows that
+        committed more than ``min_cc`` carry the un-cached tail of their
+        already-emitted (hence target-true) tokens as the KNOWN PREFIX of
+        their next block (``build_block_with_prefixes``); the drafter only
+        fills the MASK slots past it, the verify re-caches the prefix, and
+        the prefix's re-confirmation tokens are skipped on emission
+        (``pending - 1`` of them). Slot distances equal true token distances
+        under this uniform-length scheme, so sliding-window masks stay exact.
+        """
+        from transformers import DynamicCache
+        from transformers.cache_utils import DynamicSlidingWindowLayer
+
+        batch, padded_prompt = int(input_ids.shape[0]), int(input_ids.shape[1])
+        block_size = int(self.config.block_size)
+        layer_ids = list(self.config.target_layer_ids)
+        mask_token_id = int(self.config.mask_token_id)
+
+        if isinstance(max_new_tokens, Sequence):
+            budgets = [int(x) for x in max_new_tokens]
+            if len(budgets) != batch:
+                raise ValueError(
+                    f"per-sequence max_new_tokens has {len(budgets)} entries "
+                    f"for batch size {batch}"
+                )
+        else:
+            budgets = [int(max_new_tokens)] * batch
+        if any(b < 0 for b in budgets):
+            raise ValueError(f"max_new_tokens must be >= 0, got {budgets}")
+
+        input_ids = input_ids.to(self.device)
+        self._configure_target_hooks(input_ids)
+
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
+        else:
+            attention_mask = attention_mask.to(device=self.device, dtype=torch.long)
+        if tuple(attention_mask.shape) != tuple(input_ids.shape):
+            raise ValueError(
+                f"attention_mask shape {tuple(attention_mask.shape)} != "
+                f"input_ids shape {tuple(input_ids.shape)}"
+            )
+        if attention_mask.min() < 0 or attention_mask.max() > 1:
+            raise ValueError("attention_mask must be 0/1 valued")
+        if int(attention_mask[:, -1].min()) != 1:
+            raise ValueError(
+                "batched DFlash requires LEFT-padded prompts: every row's last "
+                "token must be real (attention_mask[:, -1] == 1)"
+            )
+        steps = attention_mask[:, 1:] - attention_mask[:, :-1]
+        if int(steps.min()) < 0:
+            raise ValueError(
+                "batched DFlash requires LEFT-padded prompts: each "
+                "attention_mask row must be 0*1* (pads first, then real tokens)"
+            )
+        pads = padded_prompt - attention_mask.sum(dim=1)
+
+        prefill_position_ids = (attention_mask.cumsum(dim=-1) - 1).clamp_min(0)
+        logits, hidden_states, target_kv = self._forward_target(
+            input_ids,
+            past_key_values=None,
+            logits_to_keep=1,
+            attention_mask=attention_mask,
+            position_ids=prefill_position_ids,
+        )
+        anchors = logits[:, -1, :].argmax(dim=-1)
+        context_feature = extract_context_feature(hidden_states, layer_ids).to(
+            self.device
+        )
+        stop_ids = set(_resolve_stop_ids(self.target, stop_token_ids))
+
+        emitted: List[List[int]] = [[int(anchors[b])] for b in range(batch)]
+        finished: List[bool] = [
+            budgets[b] <= 0 or (bool(stop_ids) and int(anchors[b]) in stop_ids)
+            for b in range(batch)
+        ]
+        start = padded_prompt
+        draft_kv = DynamicCache() if self._drafter_has_kv_cache else None
+        self.step_trace = []
+
+        def active(b: int) -> bool:
+            return not finished[b] and len(emitted[b]) < budgets[b]
+
+        while any(active(b) for b in range(batch)):
+            prev_start = start
+            pendings = [
+                len(emitted[b]) - (start - padded_prompt) for b in range(batch)
+            ]
+            prefixes = [
+                emitted[b][start - padded_prompt :] if active(b) else []
+                for b in range(batch)
+            ]
+            block = build_block_with_prefixes(
+                prefixes, mask_token_id, block_size
+            ).to(self.device)
+
+            drafter_out = self._run_drafter(block, context_feature, start, draft_kv)
+            draft_logits = self.lm_head(drafter_out)[:, -(block_size - 1) :, :]
+            for b in range(batch):
+                if active(b) and pendings[b] < block_size:
+                    block[b, pendings[b] :] = draft_logits[b, pendings[b] - 1 :].argmax(
+                        dim=-1
+                    )
+
+            # Snapshot sliding layers BEFORE the verify forward (see
+            # _generate_single); the rebuild in rollback_target_cache is
+            # per-row inside the batched [batch, ...] tensors.
+            sliding_snaps: dict[int, tuple[torch.Tensor, torch.Tensor, int]] = {}
+            for i, layer in enumerate(target_kv.layers):
+                if isinstance(layer, DynamicSlidingWindowLayer):
+                    keys, values = layer.keys, layer.values
+                    assert keys is not None and values is not None
+                    sliding_snaps[i] = (
+                        keys.clone(),
+                        values.clone(),
+                        int(layer.cumulative_length),
+                    )
+
+            block_attention = torch.cat(
+                [
+                    attention_mask,
+                    torch.ones(
+                        batch,
+                        start - padded_prompt + block_size,
+                        dtype=attention_mask.dtype,
+                        device=self.device,
+                    ),
+                ],
+                dim=1,
+            )
+            block_position_ids = torch.arange(
+                start, start + block_size, device=self.device, dtype=torch.long
+            ).unsqueeze(0) - pads.unsqueeze(1)
+            logits, hidden_states, target_kv = self._verify_target_block(
+                block,
+                target_kv,
+                attention_mask=block_attention,
+                position_ids=block_position_ids,
+            )
+            posterior = logits.argmax(dim=-1).to(self.device)
+            accepts = acceptance_lengths(block, posterior)
+            step_committed = committed_tokens_ragged(block, posterior, accepts)
+
+            # Per-row emission with the re-fed prefix skipped: of this step's
+            # ``accept + 1`` emitted tokens the first ``pending - 1`` are
+            # re-confirmations of tokens already emitted (the known prefix),
+            # so row b newly emits ``step_tokens[pending - 1:]``. Keeping k of
+            # those commits ``min(pending - 1 + k, accept) + 1`` cached tokens
+            # (the v1 rule ``min(k, accept) + 1`` at pending == 1).
+            step_cc: dict[int, int] = {}
+            for b in range(batch):
+                if not active(b):
+                    continue
+                pending = pendings[b]
+                accept = accepts[b]
+                step_tokens = [
+                    int(t) for t in step_committed[b].emitted[0].tolist()
+                ]
+                new_tokens = step_tokens[pending - 1 :]
+                keep = len(new_tokens)
+                stop = False
+                if stop_ids:
+                    for j, tok in enumerate(new_tokens):
+                        if tok in stop_ids:
+                            keep = j + 1
+                            stop = True
+                            break
+                remaining = budgets[b] - len(emitted[b])
+                if keep > remaining:
+                    keep = remaining
+                    stop = True
+                emitted[b].extend(new_tokens[:keep])
+                step_cc[b] = min(pending - 1 + keep, accept) + 1
+                if stop or len(emitted[b]) >= budgets[b]:
+                    finished[b] = True
+
+            continuing = [b for b in step_cc if active(b)]
+            min_cc = (
+                min(step_cc[b] for b in continuing)
+                if continuing
+                else min(step_cc.values())
+            )
+            rollback_target_cache(
+                target_kv,
+                sliding_snaps,
+                prev_start=prev_start,
+                committed=min_cc,
+                block_size=block_size,
+            )
+            start = prev_start + min_cc
+            assert int(target_kv.get_seq_length()) == start
+
+            if self.route_ahead_stats is not None:
+                self.route_ahead_stats.commit_step(kept_rows=min_cc)
+
+            for b, cc_b in step_cc.items():
+                self.step_trace.append(
+                    NativeStepTrace(
+                        prev_start=prev_start,
+                        accept=cc_b - 1,
+                        start=start,
+                        emitted_len=len(emitted[b]),
+                        target_cache_len=int(target_kv.get_seq_length()),
+                        draft_cache_len=(
+                            int(draft_kv.get_seq_length())
+                            if draft_kv is not None
+                            else None
+                        ),
+                    )
+                )
+            if not continuing:
+                break
+
+            suffix = extract_context_feature(hidden_states, layer_ids).to(
+                self.device
+            )[:, :min_cc, :]
+            if self._drafter_has_kv_cache:
+                context_feature = suffix
+            else:
+                context_feature = torch.cat([context_feature, suffix], dim=1)
+
+        self.last_target_cache = target_kv
+        self.last_draft_cache = draft_kv
+
+        new_lengths = [min(len(emitted[b]), budgets[b]) for b in range(batch)]
+        self.last_generated_lengths = new_lengths
+        pad_id = _get(_get(self.target, "config", self.target), "pad_token_id")
+        pad_id = 0 if pad_id is None else int(pad_id)
+        width = max(new_lengths) if new_lengths else 0
+        new_ids = torch.full(
+            (batch, width), pad_id, dtype=torch.long, device=input_ids.device
+        )
+        for b in range(batch):
+            n = new_lengths[b]
+            if n:
+                new_ids[b, :n] = torch.tensor(
+                    emitted[b][:n], dtype=torch.long, device=input_ids.device
+                )
+        return torch.cat([input_ids, new_ids], dim=1)
+
     def run(
         self,
         *,
@@ -596,14 +1075,17 @@ class DFlashSpeculator:
         """``SpecDecodeStrategy`` adapter: engine list contract -> native loop.
 
         The engine calls this only after its greedy gate applied (batch==1,
-        temperature==0, top_p==1, top_k==0). Target forwards route through
-        this speculator's OWN ``self.moe`` rich helper -- never through
-        ``engine`` -- so the standard expert dispatch is preserved.
-        ``max_new_tokens`` comes from ``sampling_params.max_tokens`` and the
-        stop ids from ``engine.eos_token_id`` (the native loop falls back to
-        the target config's eos when the engine has none). Returns ONLY the
-        newly generated token ids (prompt stripped); the engine wraps them in
-        a ``GenerationResult`` and ``MoE.generate`` re-prepends the prompt.
+        temperature==0, top_p==1, top_k==0); the sampling params are
+        forwarded verbatim, so every production call takes the greedy path,
+        while direct ``generate()`` callers may opt into the lossless sampled
+        path. Target forwards route through this speculator's OWN
+        ``self.moe`` rich helper -- never through ``engine`` -- so the
+        standard expert dispatch is preserved. ``max_new_tokens`` comes from
+        ``sampling_params.max_tokens`` and the stop ids from
+        ``engine.eos_token_id`` (the native loop falls back to the target
+        config's eos when the engine has none). Returns ONLY the newly
+        generated token ids (prompt stripped); the engine wraps them in a
+        ``GenerationResult`` and ``MoE.generate`` re-prepends the prompt.
         """
         del request_id  # protocol-conformance parameter; the loop is stateless
         input_ids = torch.tensor([list(prompt_token_ids)], dtype=torch.long)
@@ -613,8 +1095,10 @@ class DFlashSpeculator:
         output = self.generate(
             input_ids,
             max_new_tokens=max_new_tokens,
-            temperature=0.0,
+            temperature=float(getattr(sampling_params, "temperature", 0.0)),
             stop_token_ids=stop_ids,
+            top_k=int(getattr(sampling_params, "top_k", 0) or 0),
+            top_p=float(getattr(sampling_params, "top_p", 1.0)),
         )
         return [int(t) for t in output[0, len(prompt_token_ids) :].tolist()]
 

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -395,9 +395,7 @@ def rollback_target_cache(
                     # copy_ on it raises a version-counter bump error, silently
                     # aborting the restore and breaking greedy losslessness.
                     setattr(layer, field, saved.clone())
-            layer.is_conv_states_initialized = (
-                linear.is_conv_states_initialized
-            )
+            layer.is_conv_states_initialized = linear.is_conv_states_initialized
             layer.is_recurrent_states_initialized = (
                 linear.is_recurrent_states_initialized
             )
@@ -607,9 +605,7 @@ class DFlashSpeculator:
                 else SimpleNamespace(is_prefill=False)
             )
             token_ids = [int(t) for t in input_ids[0].tolist()]
-            result = rich(
-                token_ids, metadata, logits_to_keep=logits_to_keep
-            )
+            result = rich(token_ids, metadata, logits_to_keep=logits_to_keep)
             if not isinstance(result, tuple) or len(result) != 3:
                 raise RuntimeError(
                     "_native_model_forward_rich must return "
@@ -617,7 +613,9 @@ class DFlashSpeculator:
                 )
             logits, hidden_states, past_key_values = result
             if not isinstance(logits, torch.Tensor):
-                raise RuntimeError("native rich forward logits must be a Tensor")
+                raise RuntimeError(
+                    "native rich forward logits must be a Tensor"
+                )
             return logits, hidden_states, past_key_values
         kwargs: dict[str, Any] = {
             "past_key_values": past_key_values,

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -58,9 +58,15 @@ def read_dflash_config(draft_hf_config: Any) -> DFlashConfig:
     text_config = _get(draft_hf_config, "text_config", draft_hf_config)
 
     block_size = _get(draft_hf_config, "block_size", _get(dflash, "block_size"))
-    mask_token_id = _get(dflash, "mask_token_id", _get(draft_hf_config, "mask_token_id"))
-    target_layer_ids = _get(dflash, "target_layer_ids", _get(draft_hf_config, "target_layer_ids"))
-    num_target_layers = _get(draft_hf_config, "num_target_layers", _get(dflash, "num_target_layers"))
+    mask_token_id = _get(
+        dflash, "mask_token_id", _get(draft_hf_config, "mask_token_id")
+    )
+    target_layer_ids = _get(
+        dflash, "target_layer_ids", _get(draft_hf_config, "target_layer_ids")
+    )
+    num_target_layers = _get(
+        draft_hf_config, "num_target_layers", _get(dflash, "num_target_layers")
+    )
 
     if block_size is None or mask_token_id is None or target_layer_ids is None:
         raise ValueError(
@@ -72,7 +78,9 @@ def read_dflash_config(draft_hf_config: Any) -> DFlashConfig:
         block_size=int(block_size),
         mask_token_id=int(mask_token_id),
         target_layer_ids=[int(x) for x in target_layer_ids],
-        num_target_layers=int(num_target_layers) if num_target_layers is not None else -1,
+        num_target_layers=int(num_target_layers)
+        if num_target_layers is not None
+        else -1,
         hidden_size=int(_get(text_config, "hidden_size")),
         vocab_size=int(_get(text_config, "vocab_size")),
     )
@@ -196,7 +204,9 @@ def _infer_cuda_device(model: Any) -> str:
     return "cuda:0" if torch.cuda.is_available() else "cpu"
 
 
-def _resolve_stop_ids(target: Any, stop_token_ids: Optional[List[int]]) -> List[int]:
+def _resolve_stop_ids(
+    target: Any, stop_token_ids: Optional[List[int]]
+) -> List[int]:
     if stop_token_ids is not None:
         return list(stop_token_ids)
     eos = _get(_get(target, "config", target), "eos_token_id")
@@ -262,9 +272,13 @@ class NativeStepTrace(NamedTuple):
     # dropped), so ``start == prev_start + accept + 1`` holds in every branch
     accept: int
     start: int  # cached_len after commit == prev_start + accept + 1
-    emitted_len: int  # generated tokens emitted so far (accepted drafts + bonus)
+    emitted_len: (
+        int  # generated tokens emitted so far (accepted drafts + bonus)
+    )
     target_cache_len: int  # target_kv.get_seq_length() after crop
-    draft_cache_len: Optional[int]  # context-KV length after crop (KV drafter only)
+    draft_cache_len: Optional[
+        int
+    ]  # context-KV length after crop (KV drafter only)
 
 
 class DFlashSpeculator:
@@ -291,7 +305,9 @@ class DFlashSpeculator:
 
         self.config = read_dflash_config(self.draft.config)
         validate_drafter(self.draft, self.target.config, draft_cfg=self.config)
-        self.embed_tokens, self.lm_head = bind_shared_weights(self.draft, self.target)
+        self.embed_tokens, self.lm_head = bind_shared_weights(
+            self.draft, self.target
+        )
         self._init_native_runtime()
 
     @classmethod
@@ -312,7 +328,9 @@ class DFlashSpeculator:
         """
         self = cls.__new__(cls)
         self.moe = moe
-        on_moe_engine = callable(getattr(moe, "_native_model_forward_rich", None))
+        on_moe_engine = callable(
+            getattr(moe, "_native_model_forward_rich", None)
+        )
         self.target = moe.model if on_moe_engine else moe
         if device is None:
             if on_moe_engine:
@@ -330,7 +348,9 @@ class DFlashSpeculator:
             config = read_dflash_config(_get(self.draft, "config"))
         self.config = config
         validate_drafter_module(self.draft, self.config)
-        self.embed_tokens, self.lm_head = bind_shared_weights(self.draft, self.target)
+        self.embed_tokens, self.lm_head = bind_shared_weights(
+            self.draft, self.target
+        )
         self._init_native_runtime()
         return self
 
@@ -339,7 +359,8 @@ class DFlashSpeculator:
         # maintains a DynamicCache of projected context KV; stateless drafters
         # (tiny fixtures) take ``(block_ids, context_feature)`` instead.
         self._drafter_has_kv_cache = (
-            "noise_embedding" in inspect.signature(self.draft.forward).parameters
+            "noise_embedding"
+            in inspect.signature(self.draft.forward).parameters
         )
         # Sliding-window targets retain only the last ``sliding_window - 1``
         # tokens per cache update; the verify block must fit in that span or
@@ -678,18 +699,22 @@ class DFlashSpeculator:
 
         while len(emitted) < max_new_tokens:
             prev_start = start
-            block = build_block(anchor, self.config.mask_token_id, block_size).to(
-                self.device
-            )
+            block = build_block(
+                anchor, self.config.mask_token_id, block_size
+            ).to(self.device)
 
-            drafter_out = self._run_drafter(block, context_feature, start, draft_kv)
+            drafter_out = self._run_drafter(
+                block, context_feature, start, draft_kv
+            )
             draft_logits = self.lm_head(drafter_out)[:, -(block_size - 1) :, :]
             draft_probs: Optional[torch.Tensor] = None
             if sampled:
                 # The accept test divides by the drafter's OWN warped slot
                 # distributions, so drafts must be genuine draws from them --
                 # argmax drafts would void the losslessness proof.
-                draft_probs = warped_probs(draft_logits[0], temperature, top_k, top_p)
+                draft_probs = warped_probs(
+                    draft_logits[0], temperature, top_k, top_p
+                )
                 block[:, 1:] = torch.multinomial(
                     draft_probs, num_samples=1
                 ).squeeze(-1)
@@ -699,7 +724,9 @@ class DFlashSpeculator:
             # Snapshot sliding layers BEFORE the verify forward: its update
             # evicts all but the last ``sliding_window - 1`` tokens, so the
             # prefix must be captured here to rebuild after a partial accept.
-            sliding_snaps: dict[int, tuple[torch.Tensor, torch.Tensor, int]] = {}
+            sliding_snaps: dict[
+                int, tuple[torch.Tensor, torch.Tensor, int]
+            ] = {}
             for i, layer in enumerate(target_kv.layers):
                 if isinstance(layer, DynamicSlidingWindowLayer):
                     sliding_snaps[i] = (
@@ -773,7 +800,9 @@ class DFlashSpeculator:
                     emitted_len=len(emitted),
                     target_cache_len=int(target_kv.get_seq_length()),
                     draft_cache_len=(
-                        int(draft_kv.get_seq_length()) if draft_kv is not None else None
+                        int(draft_kv.get_seq_length())
+                        if draft_kv is not None
+                        else None
                     ),
                 )
             )
@@ -794,7 +823,9 @@ class DFlashSpeculator:
         self.last_draft_cache = draft_kv
 
         new_ids = torch.tensor(
-            [emitted[:max_new_tokens]], dtype=torch.long, device=input_ids.device
+            [emitted[:max_new_tokens]],
+            dtype=torch.long,
+            device=input_ids.device,
         )
         return torch.cat([input_ids, new_ids], dim=1)
 
@@ -860,7 +891,9 @@ class DFlashSpeculator:
         if attention_mask is None:
             attention_mask = torch.ones_like(input_ids)
         else:
-            attention_mask = attention_mask.to(device=self.device, dtype=torch.long)
+            attention_mask = attention_mask.to(
+                device=self.device, dtype=torch.long
+            )
         if tuple(attention_mask.shape) != tuple(input_ids.shape):
             raise ValueError(
                 f"attention_mask shape {tuple(attention_mask.shape)} != "
@@ -920,18 +953,22 @@ class DFlashSpeculator:
                 prefixes, mask_token_id, block_size
             ).to(self.device)
 
-            drafter_out = self._run_drafter(block, context_feature, start, draft_kv)
+            drafter_out = self._run_drafter(
+                block, context_feature, start, draft_kv
+            )
             draft_logits = self.lm_head(drafter_out)[:, -(block_size - 1) :, :]
             for b in range(batch):
                 if active(b) and pendings[b] < block_size:
-                    block[b, pendings[b] :] = draft_logits[b, pendings[b] - 1 :].argmax(
-                        dim=-1
-                    )
+                    block[b, pendings[b] :] = draft_logits[
+                        b, pendings[b] - 1 :
+                    ].argmax(dim=-1)
 
             # Snapshot sliding layers BEFORE the verify forward (see
             # _generate_single); the rebuild in rollback_target_cache is
             # per-row inside the batched [batch, ...] tensors.
-            sliding_snaps: dict[int, tuple[torch.Tensor, torch.Tensor, int]] = {}
+            sliding_snaps: dict[
+                int, tuple[torch.Tensor, torch.Tensor, int]
+            ] = {}
             for i, layer in enumerate(target_kv.layers):
                 if isinstance(layer, DynamicSlidingWindowLayer):
                     keys, values = layer.keys, layer.values

--- a/moe_infinity/spec_decode/dflash.py
+++ b/moe_infinity/spec_decode/dflash.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     List,
     NamedTuple,
     Optional,
@@ -15,7 +16,6 @@ from typing import (
 
 import torch
 
-from moe_infinity.entrypoints.big_modeling import extract_context_feature
 from moe_infinity.spec_decode._dflash_ops import (
     acceptance_length,
     acceptance_lengths,
@@ -51,6 +51,16 @@ def _get(obj: Any, name: str, default: Any = None) -> Any:
     if isinstance(obj, dict):
         return obj.get(name, default)
     return getattr(obj, name, default)
+
+
+def _extract_context_feature(
+    hidden_states: Sequence[torch.Tensor], layer_ids: Sequence[int]
+) -> torch.Tensor:
+    # Lazy import avoids the package cycle big_modeling -> spec_decode -> dflash
+    # while preserving big_modeling.extract_context_feature as the one contract.
+    from moe_infinity.entrypoints.big_modeling import extract_context_feature
+
+    return extract_context_feature(hidden_states, layer_ids)
 
 
 def read_dflash_config(draft_hf_config: Any) -> DFlashConfig:
@@ -217,44 +227,208 @@ def _resolve_stop_ids(
     return [int(x) for x in eos]
 
 
+@dataclass(frozen=True)
+class SlidingWindowCacheSnapshot:
+    keys: torch.Tensor
+    values: torch.Tensor
+    cumulative_length: int
+
+
+@dataclass(frozen=True)
+class LinearAttentionCacheSnapshot:
+    conv_states: Optional[torch.Tensor]
+    recurrent_states: Optional[torch.Tensor]
+    is_conv_states_initialized: bool
+    is_recurrent_states_initialized: bool
+    has_previous_state: bool
+
+
+@dataclass(frozen=True)
+class TargetCacheSnapshot:
+    sliding: dict[int, SlidingWindowCacheSnapshot]
+    linear: dict[int, LinearAttentionCacheSnapshot]
+
+
+_LINEAR_CACHE_FIELDS = (
+    "conv_states",
+    "recurrent_states",
+    "is_conv_states_initialized",
+    "is_recurrent_states_initialized",
+    "has_previous_state",
+)
+
+
+def snapshot_target_cache(target_kv: Any) -> TargetCacheSnapshot:
+    """Clone rollback-sensitive state before a speculative verify forward."""
+    try:
+        from transformers.cache_utils import (
+            DynamicSlidingWindowLayer,
+            LinearAttentionCacheLayerMixin,
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "unsupported transformers cache API: DFlash hybrid rollback "
+            "requires DynamicSlidingWindowLayer and "
+            "LinearAttentionCacheLayerMixin"
+        ) from exc
+
+    sliding: dict[int, SlidingWindowCacheSnapshot] = {}
+    linear: dict[int, LinearAttentionCacheSnapshot] = {}
+    for index, layer in enumerate(target_kv.layers):
+        present_linear_fields = [
+            field for field in _LINEAR_CACHE_FIELDS if hasattr(layer, field)
+        ]
+        is_linear = isinstance(layer, LinearAttentionCacheLayerMixin)
+        if is_linear or present_linear_fields:
+            if len(present_linear_fields) != len(_LINEAR_CACHE_FIELDS):
+                missing = sorted(
+                    field
+                    for field in _LINEAR_CACHE_FIELDS
+                    if field not in present_linear_fields
+                )
+                raise RuntimeError(
+                    "unsupported transformers linear-attention cache contract "
+                    f"for layer {index}: missing fields {missing}"
+                )
+            conv_states = layer.conv_states
+            recurrent_states = layer.recurrent_states
+            linear[index] = LinearAttentionCacheSnapshot(
+                conv_states=(
+                    conv_states.clone() if conv_states is not None else None
+                ),
+                recurrent_states=(
+                    recurrent_states.clone()
+                    if recurrent_states is not None
+                    else None
+                ),
+                is_conv_states_initialized=bool(
+                    layer.is_conv_states_initialized
+                ),
+                is_recurrent_states_initialized=bool(
+                    layer.is_recurrent_states_initialized
+                ),
+                has_previous_state=bool(layer.has_previous_state),
+            )
+
+        if isinstance(layer, DynamicSlidingWindowLayer):
+            keys = getattr(layer, "keys", None)
+            values = getattr(layer, "values", None)
+            cumulative_length = getattr(layer, "cumulative_length", None)
+            if keys is None or values is None or cumulative_length is None:
+                raise RuntimeError(
+                    "unsupported transformers sliding-window cache contract "
+                    f"for layer {index}: expected initialized keys, values, "
+                    "and cumulative_length"
+                )
+            sliding[index] = SlidingWindowCacheSnapshot(
+                keys=keys.clone(),
+                values=values.clone(),
+                cumulative_length=int(cumulative_length),
+            )
+
+    return TargetCacheSnapshot(sliding=sliding, linear=linear)
+
+
 def rollback_target_cache(
     target_kv: Any,
-    sliding_snaps: dict[int, tuple[torch.Tensor, torch.Tensor, int]],
+    snapshot: TargetCacheSnapshot,
     prev_start: int,
     committed: int,
     block_size: int,
+    *,
+    block: Optional[torch.Tensor] = None,
+    replay: Optional[Callable[[torch.Tensor, Any], Any]] = None,
 ) -> None:
-    """Roll the target KV cache back to ``prev_start + committed`` in place.
+    """Restore a partial verify and replay its committed prefix exactly."""
+    if committed < 0 or committed > block_size:
+        raise ValueError(
+            f"committed must be in [0, {block_size}], got {committed}"
+        )
+    if committed == block_size:
+        return
 
-    Slice-only rollback (``DynamicCache.crop``) is WRONG for sliding-window
-    layers: ``DynamicSlidingWindowLayer.update`` retains only the last
-    ``sliding_window - 1`` tokens, so the verify forward evicts prefix tokens
-    that a partial accept must restore (and ``crop`` itself raises once the
-    cumulative length reaches the window). Instead the sliding layers are
-    snapshotted before the verify forward (see ``generate``) and rebuilt here
-    as ``snapshot prefix ++ kept block tokens``, re-truncated to the window;
-    full-attention layers retain every token and crop cleanly. ``kv_offset``
-    is recomputed from ``cumulative_length``, so only ``keys`` / ``values`` /
-    ``cumulative_length`` are touched.
-    """
-    from transformers.cache_utils import DynamicSlidingWindowLayer
-
-    new_len = prev_start + committed
-    for i, layer in enumerate(target_kv.layers):
-        if isinstance(layer, DynamicSlidingWindowLayer):
-            old_k, old_v, old_len = sliding_snaps[i]
-            assert old_len == prev_start
+    # Legacy full/sliding-only callers (the batched path) remain slice based.
+    # Hybrid linear attention cannot use this branch because its recurrent
+    # state is not croppable; batch-1 callers provide replay below.
+    if replay is None:
+        if snapshot.linear:
+            raise RuntimeError(
+                "hybrid linear-attention cache rollback requires committed-"
+                "prefix replay; no replay callback was provided"
+            )
+        new_len = prev_start + committed
+        for index, layer in enumerate(target_kv.layers):
+            sliding = snapshot.sliding.get(index)
+            if sliding is None:
+                layer.crop(new_len)
+                continue
             block_k = layer.keys[:, :, -block_size:, :]
             block_v = layer.values[:, :, -block_size:, :]
-            keep_k = block_k[:, :, :committed, :]
-            keep_v = block_v[:, :, :committed, :]
-            full_k = torch.cat([old_k, keep_k], dim=-2)
-            full_v = torch.cat([old_v, keep_v], dim=-2)
+            full_k = torch.cat(
+                [sliding.keys, block_k[:, :, :committed, :]], dim=-2
+            )
+            full_v = torch.cat(
+                [sliding.values, block_v[:, :, :committed, :]], dim=-2
+            )
             layer.keys = full_k[:, :, -layer.sliding_window + 1 :, :]
             layer.values = full_v[:, :, -layer.sliding_window + 1 :, :]
             layer.cumulative_length = new_len
+        return
+
+    if block is None or block.ndim != 2 or int(block.shape[1]) != block_size:
+        raise ValueError(
+            "partial cache replay requires block with shape "
+            f"[batch, {block_size}]"
+        )
+
+    for index, layer in enumerate(target_kv.layers):
+        linear = snapshot.linear.get(index)
+        if linear is not None:
+            for field in ("conv_states", "recurrent_states"):
+                saved = getattr(linear, field)
+                if saved is None:
+                    setattr(layer, field, None)
+                else:
+                    # Reassign a fresh clone rather than in-place copy_: the
+                    # GatedDeltaNet state is an inference tensor (the target
+                    # forward runs under inference/no_grad), and an in-place
+                    # copy_ on it raises a version-counter bump error, silently
+                    # aborting the restore and breaking greedy losslessness.
+                    setattr(layer, field, saved.clone())
+            layer.is_conv_states_initialized = (
+                linear.is_conv_states_initialized
+            )
+            layer.is_recurrent_states_initialized = (
+                linear.is_recurrent_states_initialized
+            )
+            layer.has_previous_state = linear.has_previous_state
+
+        sliding = snapshot.sliding.get(index)
+        if sliding is not None:
+            if sliding.cumulative_length != prev_start:
+                raise RuntimeError(
+                    f"sliding cache layer {index} snapshot length "
+                    f"{sliding.cumulative_length} != expected {prev_start}"
+                )
+            layer.keys = sliding.keys.clone()
+            layer.values = sliding.values.clone()
+            layer.cumulative_length = sliding.cumulative_length
         else:
-            layer.crop(new_len)
+            crop = getattr(layer, "crop", None)
+            if callable(crop):
+                crop(prev_start)
+            elif linear is None:
+                raise RuntimeError(
+                    "unsupported transformers cache layer for DFlash rollback: "
+                    f"layer {index} is {type(layer).__name__}"
+                )
+
+    replayed_cache = replay(block[:, :committed], target_kv)
+    if replayed_cache is not None and replayed_cache is not target_kv:
+        raise RuntimeError(
+            "target replay replaced the DynamicCache object; in-place hybrid "
+            "rollback requires the original cache instance"
+        )
 
 
 class NativeStepTrace(NamedTuple):
@@ -347,6 +521,7 @@ class DFlashSpeculator:
         if config is None:
             config = read_dflash_config(_get(self.draft, "config"))
         self.config = config
+        validate_pairing(self.config, self.target.config)
         validate_drafter_module(self.draft, self.config)
         self.embed_tokens, self.lm_head = bind_shared_weights(
             self.draft, self.target
@@ -432,7 +607,18 @@ class DFlashSpeculator:
                 else SimpleNamespace(is_prefill=False)
             )
             token_ids = [int(t) for t in input_ids[0].tolist()]
-            return rich(token_ids, metadata, logits_to_keep=logits_to_keep)
+            result = rich(
+                token_ids, metadata, logits_to_keep=logits_to_keep
+            )
+            if not isinstance(result, tuple) or len(result) != 3:
+                raise RuntimeError(
+                    "_native_model_forward_rich must return "
+                    "(logits, hidden_states, past_key_values)"
+                )
+            logits, hidden_states, past_key_values = result
+            if not isinstance(logits, torch.Tensor):
+                raise RuntimeError("native rich forward logits must be a Tensor")
+            return logits, hidden_states, past_key_values
         kwargs: dict[str, Any] = {
             "past_key_values": past_key_values,
             "use_cache": True,
@@ -544,7 +730,7 @@ class DFlashSpeculator:
             return drafter_out
         return self.draft(block, context_feature)
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def generate(
         self,
         input_ids: torch.Tensor,
@@ -638,7 +824,7 @@ class DFlashSpeculator:
             attention_mask=attention_mask,
         )
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def _generate_single(
         self,
         input_ids: torch.Tensor,
@@ -652,7 +838,6 @@ class DFlashSpeculator:
         sampled = float(temperature) > 0
 
         from transformers import DynamicCache
-        from transformers.cache_utils import DynamicSlidingWindowLayer
 
         input_ids = input_ids.to(self.device)
         self._configure_target_hooks(input_ids)
@@ -674,7 +859,7 @@ class DFlashSpeculator:
             )
         else:
             anchor = int(logits[:, -1, :].argmax(dim=-1).item())
-        context_feature = extract_context_feature(hidden_states, layer_ids).to(
+        context_feature = _extract_context_feature(hidden_states, layer_ids).to(
             self.device
         )
 
@@ -721,19 +906,7 @@ class DFlashSpeculator:
             else:
                 block[:, 1:] = draft_logits.argmax(dim=-1)
 
-            # Snapshot sliding layers BEFORE the verify forward: its update
-            # evicts all but the last ``sliding_window - 1`` tokens, so the
-            # prefix must be captured here to rebuild after a partial accept.
-            sliding_snaps: dict[
-                int, tuple[torch.Tensor, torch.Tensor, int]
-            ] = {}
-            for i, layer in enumerate(target_kv.layers):
-                if isinstance(layer, DynamicSlidingWindowLayer):
-                    sliding_snaps[i] = (
-                        layer.keys.clone(),
-                        layer.values.clone(),
-                        int(layer.cumulative_length),
-                    )
+            cache_snapshot = snapshot_target_cache(target_kv)
 
             logits, hidden_states, target_kv = self._verify_target_block(
                 block, target_kv
@@ -780,10 +953,22 @@ class DFlashSpeculator:
             start = prev_start + cache_committed
             rollback_target_cache(
                 target_kv,
-                sliding_snaps,
+                cache_snapshot,
                 prev_start=prev_start,
                 committed=cache_committed,
                 block_size=block_size,
+                block=block,
+                replay=(
+                    (
+                        lambda prefix, cache: self._forward_target(
+                            prefix,
+                            past_key_values=cache,
+                            logits_to_keep=0,
+                        )[2]
+                    )
+                    if cache_snapshot.linear
+                    else None
+                ),
             )
             assert int(target_kv.get_seq_length()) == start
 
@@ -809,7 +994,7 @@ class DFlashSpeculator:
             if stop:
                 break
 
-            suffix = extract_context_feature(hidden_states, layer_ids).to(
+            suffix = _extract_context_feature(hidden_states, layer_ids).to(
                 self.device
             )[:, : accept + 1, :]
             if self._drafter_has_kv_cache:
@@ -829,7 +1014,7 @@ class DFlashSpeculator:
         )
         return torch.cat([input_ids, new_ids], dim=1)
 
-    @torch.inference_mode()
+    @torch.no_grad()
     def _generate_batched(
         self,
         input_ids: torch.Tensor,
@@ -866,7 +1051,6 @@ class DFlashSpeculator:
         under this uniform-length scheme, so sliding-window masks stay exact.
         """
         from transformers import DynamicCache
-        from transformers.cache_utils import DynamicSlidingWindowLayer
 
         batch, padded_prompt = int(input_ids.shape[0]), int(input_ids.shape[1])
         block_size = int(self.config.block_size)
@@ -923,7 +1107,7 @@ class DFlashSpeculator:
             position_ids=prefill_position_ids,
         )
         anchors = logits[:, -1, :].argmax(dim=-1)
-        context_feature = extract_context_feature(hidden_states, layer_ids).to(
+        context_feature = _extract_context_feature(hidden_states, layer_ids).to(
             self.device
         )
         stop_ids = set(_resolve_stop_ids(self.target, stop_token_ids))
@@ -963,21 +1147,7 @@ class DFlashSpeculator:
                         b, pendings[b] - 1 :
                     ].argmax(dim=-1)
 
-            # Snapshot sliding layers BEFORE the verify forward (see
-            # _generate_single); the rebuild in rollback_target_cache is
-            # per-row inside the batched [batch, ...] tensors.
-            sliding_snaps: dict[
-                int, tuple[torch.Tensor, torch.Tensor, int]
-            ] = {}
-            for i, layer in enumerate(target_kv.layers):
-                if isinstance(layer, DynamicSlidingWindowLayer):
-                    keys, values = layer.keys, layer.values
-                    assert keys is not None and values is not None
-                    sliding_snaps[i] = (
-                        keys.clone(),
-                        values.clone(),
-                        int(layer.cumulative_length),
-                    )
+            cache_snapshot = snapshot_target_cache(target_kv)
 
             block_attention = torch.cat(
                 [
@@ -1045,7 +1215,7 @@ class DFlashSpeculator:
             )
             rollback_target_cache(
                 target_kv,
-                sliding_snaps,
+                cache_snapshot,
                 prev_start=prev_start,
                 committed=min_cc,
                 block_size=block_size,
@@ -1074,7 +1244,7 @@ class DFlashSpeculator:
             if not continuing:
                 break
 
-            suffix = extract_context_feature(hidden_states, layer_ids).to(
+            suffix = _extract_context_feature(hidden_states, layer_ids).to(
                 self.device
             )[:, :min_cc, :]
             if self._drafter_has_kv_cache:

--- a/moe_infinity/spec_decode/glm_mtp.py
+++ b/moe_infinity/spec_decode/glm_mtp.py
@@ -29,7 +29,9 @@ def _infer_dtype(model: Any) -> torch.dtype:
     return torch.bfloat16
 
 
-def _resolve_stop_ids(model: Any, stop_token_ids: Optional[List[int]]) -> List[int]:
+def _resolve_stop_ids(
+    model: Any, stop_token_ids: Optional[List[int]]
+) -> List[int]:
     if stop_token_ids is not None:
         return list(stop_token_ids)
     cfg = getattr(model, "config", None)
@@ -118,7 +120,9 @@ class GlmMtpSpeculator:
             mtp_cfg.indexer_types = orig
 
         torch.manual_seed(42)
-        self.mtp_layer = _GlmMtpLayer(mtp_cfg, mtp_layer_idx, self.dtype).to(self.device)
+        self.mtp_layer = _GlmMtpLayer(mtp_cfg, mtp_layer_idx, self.dtype).to(
+            self.device
+        )
         self.mtp_layer.eval()
 
     def _greedy_token(self, logits: torch.Tensor) -> torch.Tensor:
@@ -182,17 +186,26 @@ class GlmMtpSpeculator:
 
             tok_embed = embed_tokens(next_tok)
             seq_len = seq.shape[1] + 1
-            pos_ids = torch.tensor([[seq_len - 1]], device=self.device, dtype=torch.long)
-            mtp_hidden = self.mtp_layer(last_hidden[:, -1:, :], tok_embed, pos_ids, rotary_emb)
+            pos_ids = torch.tensor(
+                [[seq_len - 1]], device=self.device, dtype=torch.long
+            )
+            mtp_hidden = self.mtp_layer(
+                last_hidden[:, -1:, :], tok_embed, pos_ids, rotary_emb
+            )
             proposed_logits = lm_head(mtp_hidden)
-            proposed_tok = proposed_logits[:, -1, :].argmax(dim=-1, keepdim=True)
+            proposed_tok = proposed_logits[:, -1, :].argmax(
+                dim=-1, keepdim=True
+            )
 
             verify_seq = torch.cat([seq, next_tok], dim=1)
             verify_logits, _ = self._forward(verify_seq)
             verify_tok = self._greedy_token(verify_logits)
 
             _steps += 1
-            if int(proposed_tok.item()) == int(verify_tok.item()) and generated + 2 <= max_new_tokens:
+            if (
+                int(proposed_tok.item()) == int(verify_tok.item())
+                and generated + 2 <= max_new_tokens
+            ):
                 seq = torch.cat([seq, next_tok, proposed_tok], dim=1)
                 generated += 2
                 _accepted += 1
@@ -208,10 +221,13 @@ class GlmMtpSpeculator:
         if os.environ.get("MOE_INFINITY_PROFILE_IO") == "1":
             try:
                 from moe_infinity.profiling.io_profiler import IOProfiler
+
                 profiler = IOProfiler.instance()
                 _expert_fetch_events = {
                     "cpu_to_gpu": getattr(profiler, "cpu_to_gpu_count", None),
-                    "expert_compute": getattr(profiler, "expert_compute_count", None),
+                    "expert_compute": getattr(
+                        profiler, "expert_compute_count", None
+                    ),
                 }
             except Exception:
                 pass
@@ -219,7 +235,8 @@ class GlmMtpSpeculator:
         self.last_stats = {
             "steps": _steps,
             "accepted": _accepted,
-            "mean_accept_len": 1.0 + (_accepted / _steps if _steps > 0 else 0.0),
+            "mean_accept_len": 1.0
+            + (_accepted / _steps if _steps > 0 else 0.0),
             "per_step_accepted": _per_step_accepted,
             "expert_fetch_events": _expert_fetch_events,
         }

--- a/moe_infinity/utils/config.py
+++ b/moe_infinity/utils/config.py
@@ -115,9 +115,7 @@ class ArcherConfig:
                 stacklevel=2,
             )
             config_json = {
-                k: v
-                for k, v in config_json.items()
-                if k != "glm_fp8_in_store"
+                k: v for k, v in config_json.items() if k != "glm_fp8_in_store"
             }
         parser = HfArgumentParser(cls)
         config = parser.parse_dict(config_json)[0]

--- a/moe_infinity/utils/fp8_store.py
+++ b/moe_infinity/utils/fp8_store.py
@@ -5,7 +5,9 @@ from typing import Dict
 import torch
 
 
-def extract_fp8_scales(state_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+def extract_fp8_scales(
+    state_dict: Dict[str, torch.Tensor],
+) -> Dict[str, torch.Tensor]:
     scales = {}
     for k in list(state_dict.keys()):
         if k.endswith("_scale_inv"):

--- a/moe_infinity/utils/hf_config.py
+++ b/moe_infinity/utils/hf_config.py
@@ -194,7 +194,9 @@ def parse_expert_id(
         layer_type = "decoder"
 
         # example "model.layers.10.mlp.experts.3.gate_proj.weight"
-        result = re.findall(r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.", param_name)
+        result = re.findall(
+            r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\.", param_name
+        )
         if result:
             layer_id, expert_id = result[0]
             layer_id = int(layer_id)

--- a/tests/python/dflash/fixtures_tiny.py
+++ b/tests/python/dflash/fixtures_tiny.py
@@ -110,7 +110,9 @@ def make_tiny_drafter_config(
         hidden_size=hidden_size if hidden_size is not None else TINY_HIDDEN,
         vocab_size=vocab_size if vocab_size is not None else TINY_VOCAB,
         num_target_layers=(
-            num_target_layers if num_target_layers is not None else TINY_NUM_LAYERS
+            num_target_layers
+            if num_target_layers is not None
+            else TINY_NUM_LAYERS
         ),
         dflash_config={
             "mask_token_id": mask_token_id,
@@ -153,7 +155,9 @@ class _NonCausalBlock(nn.Module):
         self.down_proj = nn.Linear(hidden_size, hidden_size, bias=False)
 
     def _heads(self, x: torch.Tensor, batch: int, length: int) -> torch.Tensor:
-        return x.view(batch, length, self.num_heads, self.head_dim).transpose(1, 2)
+        return x.view(batch, length, self.num_heads, self.head_dim).transpose(
+            1, 2
+        )
 
     def forward(self, noise: torch.Tensor, ctx: torch.Tensor) -> torch.Tensor:
         batch, block, hidden = noise.shape
@@ -167,9 +171,16 @@ class _NonCausalBlock(nn.Module):
         v = self._heads(self.v_proj(kv_source), batch, ctx_len + block)
         scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(self.head_dim)
         weights = torch.softmax(scores, dim=-1)
-        attended = torch.matmul(weights, v).transpose(1, 2).reshape(batch, block, hidden)
+        attended = (
+            torch.matmul(weights, v)
+            .transpose(1, 2)
+            .reshape(batch, block, hidden)
+        )
         noise = noise + self.o_proj(attended)
-        gated = self.down_proj(F.silu(self.gate_proj(self.mlp_norm(noise))) * self.up_proj(self.mlp_norm(noise)))
+        gated = self.down_proj(
+            F.silu(self.gate_proj(self.mlp_norm(noise)))
+            * self.up_proj(self.mlp_norm(noise))
+        )
         return noise + gated
 
 
@@ -194,7 +205,9 @@ class TinyDFlashDrafter(nn.Module):
         # drafter submodules (they belong to, and are placed by, the target).
         object.__setattr__(self, "embed_tokens", embed_tokens)
         object.__setattr__(self, "lm_head", lm_head)
-        self.fc = nn.Linear(len(self.target_layer_ids) * hidden, hidden, bias=False)
+        self.fc = nn.Linear(
+            len(self.target_layer_ids) * hidden, hidden, bias=False
+        )
         self.hidden_norm = _RMSNorm(hidden)
         self.layers = nn.ModuleList(
             [_NonCausalBlock(hidden, num_heads) for _ in range(num_layers)]
@@ -238,7 +251,11 @@ def build_tiny_drafter(
 
     set_determinism(seed)
     drafter = TinyDFlashDrafter(
-        config, embed_tokens, lm_head, num_layers=num_layers, num_heads=num_heads
+        config,
+        embed_tokens,
+        lm_head,
+        num_layers=num_layers,
+        num_heads=num_heads,
     )
     return drafter.to(torch.float32).eval()
 
@@ -259,7 +276,9 @@ def plain_greedy_decode(
     generated = torch.cat([generated, next_token], dim=1)
 
     for _ in range(max_new_tokens - 1):
-        if eos_token_id is not None and int(next_token.item()) == int(eos_token_id):
+        if eos_token_id is not None and int(next_token.item()) == int(
+            eos_token_id
+        ):
             break
         output = model(next_token, past_key_values=past, use_cache=True)
         past = output.past_key_values

--- a/tests/python/dflash/test_accept_rule.py
+++ b/tests/python/dflash/test_accept_rule.py
@@ -73,7 +73,9 @@ def test_build_block_mask_count_is_block_size_minus_one():
     assert (block[0] == MASK).sum().item() == BLOCK_SIZE - 1
 
 
-@pytest.mark.parametrize("anchor", [ANCHOR, _row([ANCHOR]), torch.tensor([[ANCHOR]])])
+@pytest.mark.parametrize(
+    "anchor", [ANCHOR, _row([ANCHOR]), torch.tensor([[ANCHOR]])]
+)
 def test_build_block_accepts_int_and_tensor_anchor(anchor):
     block = build_block(anchor, MASK, BLOCK_SIZE)
     assert block.shape == (1, BLOCK_SIZE)

--- a/tests/python/dflash/test_batched_spec.py
+++ b/tests/python/dflash/test_batched_spec.py
@@ -1,0 +1,560 @@
+"""Track C: batch > 1 support for native DFlash (greedy, bare-HF target).
+
+Pins the Track-C contract on the tiny CPU fixtures:
+
+(a) batched == per-sequence-looped greedy, token-identical, for prompts of
+    DIFFERENT lengths (left-padded, ``attention_mask``) and for equal-length
+    prompts with no mask; both also equal ``plain_greedy_decode`` (the
+    absolute oracle). Batching is a throughput change, never a correctness
+    change.
+(b) mixed accept lengths in ONE block: a scripted drafter makes row 0
+    full-accept (``accept == 9``) and row 1 full-reject (``accept == 0``) in
+    the same steps, forcing the lockstep-min rollback (cache advances by 1)
+    and the known-prefix re-feed (row 0's block saturates to all-known
+    tokens). Both rows still equal plain greedy.
+(c) per-sequence EOS mid-block (row 0 stops at EOS, inclusive; row 1 runs to
+    budget) and per-sequence ``max_new_tokens`` budgets -- ragged completion.
+(d) batch==1 through the BATCHED path (``_generate_batched`` directly) is
+    token-identical to the legacy single path (``generate`` dispatch) and to
+    plain greedy.
+
+Plus the C0 batched pure ops (``acceptance_lengths`` /
+``committed_tokens_ragged`` / ``build_block_with_prefixes``) against their
+per-row v1 counterparts, and the dispatch guard rails (sampled batch>1 and
+MoE-rich batch>1 raise ``NotImplementedError``; right-padded/non-monotone
+masks raise ``ValueError``).
+
+Trace convention (batched): one ``NativeStepTrace`` per ACTIVE row per step;
+``accept`` is that row's effective accept (``cc_b - 1``) and ``start`` the
+uniform post-rollback cache length, so per step ``start == prev_start +
+min(accept over the step's rows) + 1``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections import defaultdict
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    TINY_BLOCK_SIZE,
+    TINY_HIDDEN,
+    TINY_VOCAB,
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+)
+
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+from moe_infinity.spec_decode._dflash_ops import (  # noqa: E402
+    acceptance_length,
+    acceptance_lengths,
+    build_block_with_prefixes,
+    committed_tokens,
+    committed_tokens_ragged,
+)
+
+PROMPT_A = [3, 7, 11, 2, 5]
+PROMPT_B = [1, 2, 3]
+PROMPT_C = [10, 20, 30, 40]
+EOS_ID = 62  # absent from the tiny target's greedy continuations used here
+
+_TARGET = None
+_DRAFTER = None
+
+
+def _tiny_spec():
+    """Fresh speculator per test (cheap ``from_models``) over shared models."""
+    global _TARGET, _DRAFTER
+    if _TARGET is None:
+        _TARGET = build_tiny_target(seed=0)
+        _DRAFTER = build_tiny_drafter(_TARGET, seed=1)
+    config = read_dflash_config(make_tiny_drafter_config(_TARGET.config))
+    spec = DFlashSpeculator.from_models(_TARGET, _DRAFTER, config=config, device="cpu")
+    return spec, _TARGET
+
+
+def _left_pad(prompts, pad_id=0):
+    width = max(len(p) for p in prompts)
+    ids = torch.tensor([[pad_id] * (width - len(p)) + list(p) for p in prompts])
+    mask = torch.tensor([[0] * (width - len(p)) + [1] * len(p) for p in prompts])
+    return ids, mask, width
+
+
+def _batched_new_tokens(out, spec, width):
+    lengths = spec.last_generated_lengths
+    assert lengths is not None
+    return [out[b, width : width + lengths[b]].tolist() for b in range(out.shape[0])]
+
+
+def _plain_new(target, prompt, max_new):
+    return plain_greedy_decode(
+        target, torch.tensor([prompt]), max_new_tokens=max_new
+    )[0, len(prompt) :].tolist()
+
+
+def _greedy_streams(target, prompts, max_new):
+    """Absolute (prompt ++ greedy) ids per row, long enough for draft scripting."""
+    return [
+        plain_greedy_decode(
+            target,
+            torch.tensor([p]),
+            max_new_tokens=max_new + TINY_BLOCK_SIZE + 1,
+        )[0].tolist()
+        for p in prompts
+    ]
+
+
+class _ScriptedBatchedHead:
+    """Per-row scripted drafter argmax: ``draft_fn(start, row)`` returns the
+    ``block_size - 1`` draft ids for block positions 1..9 of that row."""
+
+    def __init__(self, draft_fn) -> None:
+        self.draft_fn = draft_fn
+        self.start = None
+
+    def __call__(self, hidden: torch.Tensor) -> torch.Tensor:
+        assert self.start is not None
+        batch, length = hidden.shape[0], hidden.shape[1]
+        logits = torch.zeros(
+            batch, length, TINY_VOCAB, dtype=hidden.dtype, device=hidden.device
+        )
+        for b in range(batch):
+            drafts = [int(t) for t in self.draft_fn(self.start, b)]
+            assert len(drafts) == TINY_BLOCK_SIZE - 1
+            for i, tok in enumerate(drafts):
+                logits[b, length - (TINY_BLOCK_SIZE - 1) + i, tok] = 1.0
+        return logits
+
+
+def _install_scripted_batched_drafter(monkeypatch, spec, draft_fn, batch):
+    """Bypass drafter compute; feed per-row scripted drafts into the accept
+    rule. The verify forward stays REAL (the genuine target)."""
+    head = _ScriptedBatchedHead(draft_fn)
+
+    def fake_run(block, context_feature, start, draft_kv):
+        head.start = start
+        return torch.zeros(batch, TINY_BLOCK_SIZE, TINY_HIDDEN)
+
+    monkeypatch.setattr(spec, "_run_drafter", fake_run)
+    monkeypatch.setattr(spec, "lm_head", head)
+
+
+def _true_continuation_drafts(streams, pads):
+    """Draft the row's true greedy token at every block position (full accept).
+
+    Block position ``s`` sits at absolute stream index ``start - pads[b] + s``.
+    """
+
+    def draft_fn(start, b):
+        base = start - int(pads[b])
+        stream = streams[b]
+        return [
+            stream[base + s] if base + s < len(stream) else 0
+            for s in range(1, TINY_BLOCK_SIZE)
+        ]
+
+    return draft_fn
+
+
+def _force_target_argmax_rows(monkeypatch, spec, verify_rows):
+    """One-hot override of the verify posterior: ``{row: {position: token}}``."""
+    orig = spec._forward_target
+
+    def wrapped(
+        input_ids,
+        past_key_values=None,
+        logits_to_keep=0,
+        attention_mask=None,
+        position_ids=None,
+    ):
+        logits, hidden, kv = orig(
+            input_ids,
+            past_key_values=past_key_values,
+            logits_to_keep=logits_to_keep,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+        if int(logits_to_keep) == 0 and verify_rows:
+            logits = logits.clone()
+            for row, rowspec in verify_rows.items():
+                for pos, tok in rowspec.items():
+                    logits[row, pos, :] = -1e9
+                    logits[row, pos, int(tok)] = 1e9
+        return logits, hidden, kv
+
+    monkeypatch.setattr(spec, "_forward_target", wrapped)
+
+
+def _grouped_trace(spec):
+    by_step = defaultdict(list)
+    for rec in spec.step_trace:
+        by_step[rec.prev_start].append(rec)
+    return by_step
+
+
+def _assert_batched_trace_invariants(spec):
+    by_step = _grouped_trace(spec)
+    for prev_start, records in by_step.items():
+        advance = records[0].start - prev_start
+        assert all(rec.start == records[0].start for rec in records)
+        # The uniform cache advance is the SMALLEST per-row commit among the
+        # rows that CONTINUE past this step (a row that stops here is excluded
+        # -- its cache row is never read again). The continuing set is a
+        # subset of the step's records, hence the two-sided bound; when no row
+        # stops mid-step it collapses to advance == min(accepts) + 1.
+        assert min(rec.accept for rec in records) + 1 <= advance
+        assert advance <= max(rec.accept for rec in records) + 1
+        assert advance >= 1
+        for rec in records:
+            assert rec.target_cache_len == rec.start
+
+
+# ---------------------------------------------------------------------------
+# C0: batched pure ops
+# ---------------------------------------------------------------------------
+
+
+def _accept_case_row(k: int):
+    """One block/posterior row pair with hand-checked accept ``k``."""
+    block = [100] + [11 + i for i in range(TINY_BLOCK_SIZE - 1)]
+    posterior = [0] * TINY_BLOCK_SIZE
+    for i in range(k):
+        posterior[i] = 11 + i
+    if k < TINY_BLOCK_SIZE - 1:
+        posterior[k] = 900 + k
+        for i in range(k + 1, TINY_BLOCK_SIZE - 1):
+            posterior[i] = 800 + i
+    posterior[TINY_BLOCK_SIZE - 1] = 999
+    return block, posterior
+
+
+def test_acceptance_lengths_matches_per_row_v1_op():
+    ks = [0, 4, TINY_BLOCK_SIZE - 1]
+    rows, posts = zip(*[_accept_case_row(k) for k in ks])
+    block = torch.tensor(list(rows), dtype=torch.long)
+    posterior = torch.tensor(list(posts), dtype=torch.long)
+    accepts = acceptance_lengths(block, posterior)
+    assert accepts == ks
+    for b, k in enumerate(ks):
+        assert acceptance_length(block[b : b + 1], posterior[b : b + 1]) == k
+
+
+def test_committed_tokens_ragged_matches_per_row_v1_op():
+    ks = [0, 3, TINY_BLOCK_SIZE - 1]
+    rows, posts = zip(*[_accept_case_row(k) for k in ks])
+    block = torch.tensor(list(rows), dtype=torch.long)
+    posterior = torch.tensor(list(posts), dtype=torch.long)
+    ragged = committed_tokens_ragged(block, posterior, ks)
+    assert len(ragged) == 3
+    for b, k in enumerate(ks):
+        ref = committed_tokens(block[b : b + 1], posterior[b : b + 1], k)
+        assert ragged[b].emitted.shape == (1, k + 1)
+        assert torch.equal(ragged[b].emitted, ref.emitted)
+        assert torch.equal(ragged[b].block_prefix, ref.block_prefix)
+        assert torch.equal(ragged[b].bonus, ref.bonus)
+    # Raggedness a dense Committed cannot express:
+    assert ragged[0].emitted.shape[1] != ragged[2].emitted.shape[1]
+
+
+def test_committed_tokens_ragged_rejects_row_count_mismatch():
+    block = torch.tensor([_accept_case_row(1)[0]] * 2, dtype=torch.long)
+    posterior = torch.tensor([_accept_case_row(1)[1]] * 2, dtype=torch.long)
+    with pytest.raises(ValueError, match="rows"):
+        committed_tokens_ragged(block, posterior, [1])
+
+
+def test_build_block_with_prefixes_contents_and_shape():
+    block = build_block_with_prefixes(
+        [[5], [1, 2, 3], []], mask_token_id=200, block_size=TINY_BLOCK_SIZE
+    )
+    assert block.shape == (3, TINY_BLOCK_SIZE)
+    assert block.dtype == torch.long
+    assert block[0].tolist() == [5] + [200] * (TINY_BLOCK_SIZE - 1)
+    assert block[1].tolist() == [1, 2, 3] + [200] * (TINY_BLOCK_SIZE - 3)
+    assert block[2].tolist() == [200] * TINY_BLOCK_SIZE
+
+
+def test_build_block_with_prefixes_rejects_overlong_prefix():
+    with pytest.raises(ValueError, match="exceeds block_size"):
+        build_block_with_prefixes(
+            [[1] * (TINY_BLOCK_SIZE + 1)], mask_token_id=200, block_size=TINY_BLOCK_SIZE
+        )
+
+
+# ---------------------------------------------------------------------------
+# (a) batched == looped singles == plain greedy (token-identical)
+# ---------------------------------------------------------------------------
+
+
+def test_batched_matches_looped_singles_token_identical():
+    spec, target = _tiny_spec()
+    # Six prompts of differing lengths (the test_native_e2e set), left-padded.
+    prompts = [
+        PROMPT_A,
+        PROMPT_B,
+        PROMPT_C,
+        [5],
+        [8, 16, 24, 32, 40, 48],
+        [42, 17, 33, 9],
+    ]
+    ids, mask, width = _left_pad(prompts)
+    max_new = 24
+
+    out = spec.generate(ids, max_new_tokens=max_new, attention_mask=mask)
+    batched = _batched_new_tokens(out, spec, width)
+    assert spec.last_generated_lengths == [max_new] * len(prompts)
+
+    for b, prompt in enumerate(prompts):
+        single = spec.generate(torch.tensor([prompt]), max_new_tokens=max_new)[
+            0, len(prompt) :
+        ].tolist()
+        plain = _plain_new(target, prompt, max_new)
+        assert batched[b] == single == plain, (
+            f"row {b} diverged:\n  batched={batched[b]}\n  single ={single}\n"
+            f"  plain  ={plain}"
+        )
+
+    _assert_batched_trace_invariants(spec)
+    # Non-degenerate: the real drafter is genuinely exercised in batched mode
+    # (accepted drafts somewhere in the batch -- not a trivial accept-0 loop).
+    accepts = [rec.accept for rec in spec.step_trace]
+    assert sum(accepts) > 0
+
+
+def test_batched_equal_length_prompts_without_mask():
+    spec, target = _tiny_spec()
+    prompts = [PROMPT_A, [42, 17, 33, 9, 21]]
+    ids = torch.tensor(prompts)
+    max_new = 16
+
+    out = spec.generate(ids, max_new_tokens=max_new)
+    batched = _batched_new_tokens(out, spec, len(prompts[0]))
+    for b, prompt in enumerate(prompts):
+        assert batched[b] == _plain_new(target, prompt, max_new)
+
+
+# ---------------------------------------------------------------------------
+# (b) mixed accept lengths in one block (lockstep-min rollback + re-feed)
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_accept_lengths_in_one_block(monkeypatch):
+    spec, target = _tiny_spec()
+    prompts = [PROMPT_A, PROMPT_B]
+    pads = [0, len(PROMPT_A) - len(PROMPT_B)]
+    max_new = 21
+    streams = _greedy_streams(target, prompts, max_new)
+    true_drafts = _true_continuation_drafts(streams, pads)
+
+    def draft_fn(start, b):
+        if b == 0:
+            return true_drafts(start, b)  # full accept every step
+        # Full reject: first draft mismatches the target's argmax.
+        base = start - pads[1]
+        wrong = (streams[1][base + 1] + 1) % TINY_VOCAB
+        return [wrong] * (TINY_BLOCK_SIZE - 1)
+
+    _install_scripted_batched_drafter(monkeypatch, spec, draft_fn, batch=2)
+    ids, mask, width = _left_pad(prompts)
+
+    out = spec.generate(ids, max_new_tokens=max_new, attention_mask=mask)
+    batched = _batched_new_tokens(out, spec, width)
+    for b, prompt in enumerate(prompts):
+        assert batched[b] == _plain_new(target, prompt, max_new)
+
+    by_step = _grouped_trace(spec)
+    # Row 0 accepts 9 (cc 10) while row 1 accepts 0 (cc 1): every cache
+    # advance is the lockstep minimum of 1, so row 0's un-cached accepted
+    # tokens are re-fed as the known prefix of its next block.
+    two_row_steps = [recs for recs in by_step.values() if len(recs) == 2]
+    assert two_row_steps, "expected steps with both rows active"
+    for records in two_row_steps:
+        assert sorted(rec.accept for rec in records) == [0, TINY_BLOCK_SIZE - 1]
+    assert all(
+        recs[0].start - prev == 1 for prev, recs in by_step.items()
+    )
+    _assert_batched_trace_invariants(spec)
+
+
+# ---------------------------------------------------------------------------
+# (c) per-sequence EOS mid-block + ragged completion
+# ---------------------------------------------------------------------------
+
+
+def test_per_seq_eos_mid_block_ragged_completion(monkeypatch):
+    spec, target = _tiny_spec()
+    prompts = [PROMPT_A, PROMPT_B]
+    pads = [0, len(PROMPT_A) - len(PROMPT_B)]
+    max_new = 20
+    streams = _greedy_streams(target, prompts, max_new)
+
+    # Row 0 drafts its true continuation; the verify posterior at block
+    # position 2 is forced to EOS, so accept == 2 and the bonus IS the stop
+    # token (emitted, never cached). Row 1 is left untouched.
+    _install_scripted_batched_drafter(
+        monkeypatch, spec, _true_continuation_drafts(streams, pads), batch=2
+    )
+    _force_target_argmax_rows(monkeypatch, spec, {0: {2: EOS_ID}})
+    ids, mask, width = _left_pad(prompts)
+
+    out = spec.generate(
+        ids, max_new_tokens=max_new, attention_mask=mask, stop_token_ids=[EOS_ID]
+    )
+    batched = _batched_new_tokens(out, spec, width)
+
+    stream0 = streams[0]
+    expected0 = [stream0[5], stream0[6], stream0[7], EOS_ID]
+    assert batched[0] == expected0
+    assert spec.last_generated_lengths == [4, max_new]
+    # Row 1 never saw the override: full budget, token-identical to plain.
+    assert batched[1] == _plain_new(target, prompts[1], max_new)
+    # Row 0 stopped at step 1, so the step-1 cache advance is the CONTINUING
+    # row's commit (row 1 full-accepted: cc == block_size), not the finishing
+    # row's smaller one -- the lockstep minimum is taken over live rows only.
+    step1 = _grouped_trace(spec)[width]
+    assert len(step1) == 2
+    assert step1[0].start - width == TINY_BLOCK_SIZE
+    _assert_batched_trace_invariants(spec)
+
+
+def test_per_seq_eos_as_accepted_draft_stops_only_that_row(monkeypatch):
+    spec, target = _tiny_spec()
+    prompts = [PROMPT_A, PROMPT_B]
+    pads = [0, len(PROMPT_A) - len(PROMPT_B)]
+    max_new = 20
+    streams = _greedy_streams(target, prompts, max_new)
+
+    def draft_fn(start, b):
+        if b == 0:
+            base = start - pads[0]
+            stream = streams[0]
+            # d1, d2 true; d3 = EOS (accepted via the forced posterior).
+            drafts = [stream[base + 1], stream[base + 2], EOS_ID]
+            drafts += [0] * (TINY_BLOCK_SIZE - 1 - len(drafts))
+            return drafts
+        return _true_continuation_drafts(streams, pads)(start, b)
+
+    _install_scripted_batched_drafter(monkeypatch, spec, draft_fn, batch=2)
+    _force_target_argmax_rows(monkeypatch, spec, {0: {2: EOS_ID, 3: 40}})
+    ids, mask, width = _left_pad(prompts)
+
+    out = spec.generate(
+        ids, max_new_tokens=max_new, attention_mask=mask, stop_token_ids=[EOS_ID]
+    )
+    batched = _batched_new_tokens(out, spec, width)
+
+    stream0 = streams[0]
+    assert batched[0] == [stream0[5], stream0[6], stream0[7], EOS_ID]
+    assert spec.last_generated_lengths == [4, max_new]
+    assert batched[1] == _plain_new(target, prompts[1], max_new)
+
+
+def test_per_sequence_max_new_tokens_ragged_completion():
+    spec, target = _tiny_spec()
+    prompts = [PROMPT_A, PROMPT_B]
+    ids, mask, width = _left_pad(prompts)
+    budgets = [6, 14]
+
+    out = spec.generate(ids, max_new_tokens=budgets, attention_mask=mask)
+    batched = _batched_new_tokens(out, spec, width)
+
+    assert spec.last_generated_lengths == budgets
+    for b, prompt in enumerate(prompts):
+        assert batched[b] == _plain_new(target, prompt, budgets[b])
+    _assert_batched_trace_invariants(spec)
+
+
+# ---------------------------------------------------------------------------
+# (d) batch==1 through the batched path == legacy single path
+# ---------------------------------------------------------------------------
+
+
+def test_batch_one_via_batched_path_equals_legacy():
+    spec, target = _tiny_spec()
+    prompt = torch.tensor([PROMPT_A])
+    max_new = 32
+
+    legacy = spec.generate(prompt, max_new_tokens=max_new)
+    batched = spec._generate_batched(
+        prompt, max_new_tokens=max_new, stop_token_ids=None, attention_mask=None
+    )
+    plain = plain_greedy_decode(target, prompt, max_new_tokens=max_new)
+
+    assert torch.equal(batched, legacy)
+    assert torch.equal(batched, plain)
+    assert spec.last_generated_lengths == [max_new]
+
+
+def test_batch_one_via_batched_path_with_stop_ids_equals_legacy():
+    spec, _ = _tiny_spec()
+    prompt = torch.tensor([PROMPT_A])
+    max_new = 24
+
+    legacy = spec.generate(prompt, max_new_tokens=max_new, stop_token_ids=[EOS_ID])
+    batched = spec._generate_batched(
+        prompt,
+        max_new_tokens=max_new,
+        stop_token_ids=[EOS_ID],
+        attention_mask=torch.ones_like(prompt),
+    )
+    assert torch.equal(batched, legacy)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch guard rails
+# ---------------------------------------------------------------------------
+
+
+def test_batched_sampled_raises_not_implemented():
+    spec, _ = _tiny_spec()
+    ids = torch.tensor([PROMPT_A, PROMPT_A])
+    with pytest.raises(NotImplementedError, match="greedy-only"):
+        spec.generate(ids, max_new_tokens=4, temperature=0.7)
+
+
+def test_batched_moe_rich_target_raises_not_implemented():
+    from moe_infinity.entrypoints.big_modeling import MoE
+
+    spec, target = _tiny_spec()
+    shell = MoE.__new__(MoE)
+    shell.model = target
+    spec = DFlashSpeculator.from_models(
+        shell, spec.draft, config=spec.config, device="cpu"
+    )
+
+    ids = torch.tensor([PROMPT_A, PROMPT_A])
+    with pytest.raises(NotImplementedError, match="bare HF target"):
+        spec.generate(ids, max_new_tokens=4)
+
+
+def test_right_padded_attention_mask_rejected():
+    spec, _ = _tiny_spec()
+    ids = torch.tensor([[1, 2, 3], [4, 5, 0]])
+    mask = torch.tensor([[1, 1, 1], [1, 1, 0]])
+    with pytest.raises(ValueError, match="LEFT-padded"):
+        spec.generate(ids, max_new_tokens=4, attention_mask=mask)
+
+
+def test_nonmonotone_attention_mask_rejected():
+    spec, _ = _tiny_spec()
+    ids = torch.tensor([[1, 2, 3], [4, 5, 6]])
+    mask = torch.tensor([[1, 1, 1], [1, 0, 1]])
+    with pytest.raises(ValueError, match="LEFT-padded"):
+        spec.generate(ids, max_new_tokens=4, attention_mask=mask)
+
+
+def test_per_sequence_budget_length_mismatch_rejected():
+    spec, _ = _tiny_spec()
+    ids = torch.tensor([PROMPT_A, PROMPT_A])
+    with pytest.raises(ValueError, match="batch size"):
+        spec.generate(ids, max_new_tokens=[4])

--- a/tests/python/dflash/test_batched_spec.py
+++ b/tests/python/dflash/test_batched_spec.py
@@ -79,21 +79,27 @@ def _tiny_spec():
         _TARGET = build_tiny_target(seed=0)
         _DRAFTER = build_tiny_drafter(_TARGET, seed=1)
     config = read_dflash_config(make_tiny_drafter_config(_TARGET.config))
-    spec = DFlashSpeculator.from_models(_TARGET, _DRAFTER, config=config, device="cpu")
+    spec = DFlashSpeculator.from_models(
+        _TARGET, _DRAFTER, config=config, device="cpu"
+    )
     return spec, _TARGET
 
 
 def _left_pad(prompts, pad_id=0):
     width = max(len(p) for p in prompts)
     ids = torch.tensor([[pad_id] * (width - len(p)) + list(p) for p in prompts])
-    mask = torch.tensor([[0] * (width - len(p)) + [1] * len(p) for p in prompts])
+    mask = torch.tensor(
+        [[0] * (width - len(p)) + [1] * len(p) for p in prompts]
+    )
     return ids, mask, width
 
 
 def _batched_new_tokens(out, spec, width):
     lengths = spec.last_generated_lengths
     assert lengths is not None
-    return [out[b, width : width + lengths[b]].tolist() for b in range(out.shape[0])]
+    return [
+        out[b, width : width + lengths[b]].tolist() for b in range(out.shape[0])
+    ]
 
 
 def _plain_new(target, prompt, max_new):
@@ -287,7 +293,9 @@ def test_build_block_with_prefixes_contents_and_shape():
 def test_build_block_with_prefixes_rejects_overlong_prefix():
     with pytest.raises(ValueError, match="exceeds block_size"):
         build_block_with_prefixes(
-            [[1] * (TINY_BLOCK_SIZE + 1)], mask_token_id=200, block_size=TINY_BLOCK_SIZE
+            [[1] * (TINY_BLOCK_SIZE + 1)],
+            mask_token_id=200,
+            block_size=TINY_BLOCK_SIZE,
         )
 
 
@@ -380,9 +388,7 @@ def test_mixed_accept_lengths_in_one_block(monkeypatch):
     assert two_row_steps, "expected steps with both rows active"
     for records in two_row_steps:
         assert sorted(rec.accept for rec in records) == [0, TINY_BLOCK_SIZE - 1]
-    assert all(
-        recs[0].start - prev == 1 for prev, recs in by_step.items()
-    )
+    assert all(recs[0].start - prev == 1 for prev, recs in by_step.items())
     _assert_batched_trace_invariants(spec)
 
 
@@ -408,7 +414,10 @@ def test_per_seq_eos_mid_block_ragged_completion(monkeypatch):
     ids, mask, width = _left_pad(prompts)
 
     out = spec.generate(
-        ids, max_new_tokens=max_new, attention_mask=mask, stop_token_ids=[EOS_ID]
+        ids,
+        max_new_tokens=max_new,
+        attention_mask=mask,
+        stop_token_ids=[EOS_ID],
     )
     batched = _batched_new_tokens(out, spec, width)
 
@@ -449,7 +458,10 @@ def test_per_seq_eos_as_accepted_draft_stops_only_that_row(monkeypatch):
     ids, mask, width = _left_pad(prompts)
 
     out = spec.generate(
-        ids, max_new_tokens=max_new, attention_mask=mask, stop_token_ids=[EOS_ID]
+        ids,
+        max_new_tokens=max_new,
+        attention_mask=mask,
+        stop_token_ids=[EOS_ID],
     )
     batched = _batched_new_tokens(out, spec, width)
 
@@ -500,7 +512,9 @@ def test_batch_one_via_batched_path_with_stop_ids_equals_legacy():
     prompt = torch.tensor([PROMPT_A])
     max_new = 24
 
-    legacy = spec.generate(prompt, max_new_tokens=max_new, stop_token_ids=[EOS_ID])
+    legacy = spec.generate(
+        prompt, max_new_tokens=max_new, stop_token_ids=[EOS_ID]
+    )
     batched = spec._generate_batched(
         prompt,
         max_new_tokens=max_new,

--- a/tests/python/dflash/test_dflash_contract.py
+++ b/tests/python/dflash/test_dflash_contract.py
@@ -43,13 +43,17 @@ def test_read_dflash_config_missing_fields_raises():
 
 def test_validate_pairing_accepts_matching_target():
     cfg = read_dflash_config(_draft_config_stub())
-    target = SimpleNamespace(hidden_size=2880, vocab_size=201088, num_hidden_layers=36)
+    target = SimpleNamespace(
+        hidden_size=2880, vocab_size=201088, num_hidden_layers=36
+    )
     validate_pairing(cfg, target)
 
 
 def test_validate_pairing_rejects_hidden_mismatch():
     cfg = read_dflash_config(_draft_config_stub())
-    target = SimpleNamespace(hidden_size=4096, vocab_size=201088, num_hidden_layers=36)
+    target = SimpleNamespace(
+        hidden_size=4096, vocab_size=201088, num_hidden_layers=36
+    )
     with pytest.raises(ValueError):
         validate_pairing(cfg, target)
 
@@ -63,7 +67,9 @@ def test_validate_pairing_rejects_mask_outside_vocab():
         hidden_size=2880,
         vocab_size=201088,
     )
-    target = SimpleNamespace(hidden_size=2880, vocab_size=1000, num_hidden_layers=36)
+    target = SimpleNamespace(
+        hidden_size=2880, vocab_size=1000, num_hidden_layers=36
+    )
     with pytest.raises(ValueError):
         validate_pairing(cfg, target)
 
@@ -77,7 +83,9 @@ def test_validate_pairing_rejects_layer_out_of_range():
         hidden_size=2880,
         vocab_size=201088,
     )
-    target = SimpleNamespace(hidden_size=2880, vocab_size=201088, num_hidden_layers=36)
+    target = SimpleNamespace(
+        hidden_size=2880, vocab_size=201088, num_hidden_layers=36
+    )
     with pytest.raises(ValueError):
         validate_pairing(cfg, target)
 
@@ -86,8 +94,12 @@ def test_validate_pairing_rejects_layer_out_of_range():
 def test_checkpoint_config_matches_expected():
     transformers = pytest.importorskip("transformers")
     try:
-        draft_cfg = transformers.AutoConfig.from_pretrained(DRAFT, trust_remote_code=True)
-        target_cfg = transformers.AutoConfig.from_pretrained(TARGET, trust_remote_code=True)
+        draft_cfg = transformers.AutoConfig.from_pretrained(
+            DRAFT, trust_remote_code=True
+        )
+        target_cfg = transformers.AutoConfig.from_pretrained(
+            TARGET, trust_remote_code=True
+        )
     except Exception as exc:
         pytest.skip(f"checkpoint configs unavailable: {exc}")
 

--- a/tests/python/dflash/test_drafter_load.py
+++ b/tests/python/dflash/test_drafter_load.py
@@ -53,7 +53,9 @@ def _fake_drafter(*, fc_in_features=14400, **cfg_kwargs):
     )
 
 
-def _fake_target_config(*, hidden_size=2880, vocab_size=201088, num_hidden_layers=36):
+def _fake_target_config(
+    *, hidden_size=2880, vocab_size=201088, num_hidden_layers=36
+):
     return SimpleNamespace(
         hidden_size=hidden_size,
         vocab_size=vocab_size,
@@ -73,7 +75,9 @@ def test_validate_drafter_accepts_when_config_precomputed():
 
 def test_validate_drafter_rejects_fc_in_features_mismatch():
     with pytest.raises(ValueError, match="in_features"):
-        validate_drafter(_fake_drafter(fc_in_features=9999), _fake_target_config())
+        validate_drafter(
+            _fake_drafter(fc_in_features=9999), _fake_target_config()
+        )
 
 
 def test_validate_drafter_requires_fc_projection():
@@ -108,7 +112,9 @@ def test_validate_pairing_rejects_block_size_below_two():
 
 
 def test_validate_pairing_rejects_target_layer_ids_out_of_range():
-    cfg = read_dflash_config(_fake_draft_config(target_layer_ids=[1, 9, 17, 25, 40]))
+    cfg = read_dflash_config(
+        _fake_draft_config(target_layer_ids=[1, 9, 17, 25, 40])
+    )
     with pytest.raises(ValueError, match="target has only"):
         validate_pairing(cfg, _fake_target_config(num_hidden_layers=36))
 

--- a/tests/python/dflash/test_drafter_load.py
+++ b/tests/python/dflash/test_drafter_load.py
@@ -94,16 +94,23 @@ def test_validate_pairing_rejects_mask_ge_vocab():
         validate_pairing(cfg, _fake_target_config())
 
 
-def test_validate_pairing_rejects_block_size_mismatch():
-    cfg = read_dflash_config(_fake_draft_config(block_size=8))
+def test_validate_pairing_accepts_non_120b_contract():
+    cfg = read_dflash_config(
+        _fake_draft_config(block_size=8, target_layer_ids=[1, 6, 11, 16, 21])
+    )
+    validate_pairing(cfg, _fake_target_config(num_hidden_layers=24))
+
+
+def test_validate_pairing_rejects_block_size_below_two():
+    cfg = read_dflash_config(_fake_draft_config(block_size=1))
     with pytest.raises(ValueError, match="block_size"):
         validate_pairing(cfg, _fake_target_config())
 
 
-def test_validate_pairing_rejects_target_layer_ids_mismatch():
-    cfg = read_dflash_config(_fake_draft_config(target_layer_ids=[1, 9, 17, 25, 34]))
-    with pytest.raises(ValueError, match="target_layer_ids"):
-        validate_pairing(cfg, _fake_target_config())
+def test_validate_pairing_rejects_target_layer_ids_out_of_range():
+    cfg = read_dflash_config(_fake_draft_config(target_layer_ids=[1, 9, 17, 25, 40]))
+    with pytest.raises(ValueError, match="target has only"):
+        validate_pairing(cfg, _fake_target_config(num_hidden_layers=36))
 
 
 def test_validate_pairing_rejects_vocab_mismatch():

--- a/tests/python/dflash/test_edge_cases.py
+++ b/tests/python/dflash/test_edge_cases.py
@@ -18,8 +18,9 @@ target-argmax overrides:
     overshoot is truncated to the remaining budget and the loop stops; the
     return is exactly ``max_new_tokens`` new tokens and the cache is cropped
     to the truncated ``start``.
-(f) batch > 1 — raises ``NotImplementedError`` naming the batch==1
-    constraint (v1 is single-sequence).
+(f) batch > 1 — supported since Track C: a two-row batch produces the
+    single-sequence result row by row (token-identical to plain greedy).
+    Batched raggedness edge cases live in ``test_batched_spec.py``.
 
 State accounting: ``committed.emitted = [d_1 .. d_accept, bonus]`` while the
 verify-forward KV covers ``[anchor, d_1 .. d_accept]`` only. Keeping ``k``
@@ -326,10 +327,18 @@ def test_max_new_tokens_truncates_at_block_boundary(monkeypatch):
     assert int(spec.last_target_cache.get_seq_length()) == PROMPT_LEN + max_new
 
 
-# (f) batch > 1 guard
-def test_batch_greater_than_one_raises_not_implemented():
-    spec, _ = _tiny_spec()
+# (f) batch > 1 -- supported since Track C; the guard is gone. The batched
+# result must equal the single-sequence runs row by row (and plain greedy).
+def test_batch_greater_than_one_matches_single_sequence_path():
+    spec, target = _tiny_spec()
     batched = torch.cat([PROMPT, PROMPT], dim=0)
     assert batched.shape[0] == 2
-    with pytest.raises(NotImplementedError, match="batch==1"):
-        spec.generate(batched, max_new_tokens=4)
+
+    out = spec.generate(batched, max_new_tokens=4)
+    single = spec.generate(PROMPT, max_new_tokens=4)
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=4)
+
+    assert tuple(out.shape) == (2, PROMPT_LEN + 4)
+    for b in range(2):
+        assert torch.equal(out[b : b + 1], single)
+        assert torch.equal(out[b : b + 1], plain)

--- a/tests/python/dflash/test_edge_cases.py
+++ b/tests/python/dflash/test_edge_cases.py
@@ -70,7 +70,9 @@ def _tiny_spec():
         _TARGET = build_tiny_target(seed=0)
         _DRAFTER = build_tiny_drafter(_TARGET, seed=1)
     config = read_dflash_config(make_tiny_drafter_config(_TARGET.config))
-    spec = DFlashSpeculator.from_models(_TARGET, _DRAFTER, config=config, device="cpu")
+    spec = DFlashSpeculator.from_models(
+        _TARGET, _DRAFTER, config=config, device="cpu"
+    )
     return spec, _TARGET
 
 
@@ -132,7 +134,9 @@ def _force_target_argmax(monkeypatch, spec, *, prefill=None, verify=None):
 
     def wrapped(input_ids, past_key_values=None, logits_to_keep=0):
         logits, hidden, kv = orig(
-            input_ids, past_key_values=past_key_values, logits_to_keep=logits_to_keep
+            input_ids,
+            past_key_values=past_key_values,
+            logits_to_keep=logits_to_keep,
         )
         rows = prefill if int(logits_to_keep) == 1 else verify
         if rows:
@@ -225,7 +229,12 @@ def test_eos_mid_block_accepted_draft_truncates_and_stops(monkeypatch):
     other = 40  # forced posterior at the position after EOS (never emitted)
     # d1, d2 = greedy (accepted); d3 = EOS (accepted via forced posterior);
     # d4 forced to mismatch so accept == 3.
-    drafts = [full[PROMPT_LEN + 1], full[PROMPT_LEN + 2], EOS_ID, (other + 1) % TINY_VOCAB]
+    drafts = [
+        full[PROMPT_LEN + 1],
+        full[PROMPT_LEN + 2],
+        EOS_ID,
+        (other + 1) % TINY_VOCAB,
+    ]
     drafts += [0] * (TINY_BLOCK_SIZE - 1 - len(drafts))
     _install_scripted_drafter(monkeypatch, spec, lambda step: drafts)
     _force_target_argmax(monkeypatch, spec, verify={2: EOS_ID, 3: other})
@@ -240,7 +249,12 @@ def test_eos_mid_block_accepted_draft_truncates_and_stops(monkeypatch):
     # Emitted ends exactly at EOS: the forced bonus and further blocks are
     # never emitted despite the large max_new_tokens budget.
     new_ids = out[0, PROMPT_LEN:].tolist()
-    assert new_ids == [full[PROMPT_LEN], full[PROMPT_LEN + 1], full[PROMPT_LEN + 2], EOS_ID]
+    assert new_ids == [
+        full[PROMPT_LEN],
+        full[PROMPT_LEN + 1],
+        full[PROMPT_LEN + 2],
+        EOS_ID,
+    ]
     assert other not in new_ids
 
     # cache length == start_at_EOS: anchor + 3 drafts (the EOS draft DID go
@@ -271,7 +285,12 @@ def test_eos_bonus_token_truncates_and_stops(monkeypatch):
     assert rec.accept == 2
 
     new_ids = out[0, PROMPT_LEN:].tolist()
-    assert new_ids == [full[PROMPT_LEN], full[PROMPT_LEN + 1], full[PROMPT_LEN + 2], EOS_ID]
+    assert new_ids == [
+        full[PROMPT_LEN],
+        full[PROMPT_LEN + 1],
+        full[PROMPT_LEN + 2],
+        EOS_ID,
+    ]
 
     # The bonus is never forwarded, so the cache covers anchor + 2 accepted
     # drafts only: exactly one behind the emitted sequence.

--- a/tests/python/dflash/test_engine_wire.py
+++ b/tests/python/dflash/test_engine_wire.py
@@ -200,9 +200,7 @@ def test_no_drafter_uses_standard_path():
 
     engine._generate_standard = standard_spy
 
-    out = _moe_generate(
-        shell, do_sample=False, max_new_tokens=MAX_NEW_TOKENS
-    )
+    out = _moe_generate(shell, do_sample=False, max_new_tokens=MAX_NEW_TOKENS)
 
     assert engine.spec_strategy is None
     assert len(standard_calls) == 1

--- a/tests/python/dflash/test_gpu_20b_dflash.py
+++ b/tests/python/dflash/test_gpu_20b_dflash.py
@@ -1,0 +1,101 @@
+"""GPU-gated real-model DFlash validation on the gpt-oss-20b pair.
+
+Opt-in via ``MOE_DFLASH_GPU=1`` with ``openai/gpt-oss-20b`` +
+``z-lab/gpt-oss-20b-DFlash`` present in the HF cache. Asserts the drafter-driven
+contract loads (block_size=8, not the 120b default of 10), that native DFlash
+greedy is token-identical to plain greedy (losslessness), and that acceptance
+length + speedup are positive. Without the flag this collects and skips cleanly
+(no CUDA, no filesystem, no model load).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+import pytest
+import torch
+
+TARGET_REPO = "openai/gpt-oss-20b"
+DRAFTER_REPO = "z-lab/gpt-oss-20b-DFlash"
+CONTINUATION_TOKENS = 32
+PROMPT = "Explain in one paragraph why the sky appears blue."
+
+
+def _hf_home() -> Path:
+    for var in ("HF_HOME", "HUGGINGFACE_HUB_CACHE", "XDG_CACHE_HOME"):
+        val = os.environ.get(var)
+        if val:
+            base = Path(val)
+            return base / "hub" if var == "XDG_CACHE_HOME" else base
+    return Path.home() / ".cache" / "huggingface"
+
+
+def _checkpoint_present(repo: str) -> bool:
+    hub = _hf_home()
+    hub = hub if hub.name == "hub" else hub / "hub"
+    return (hub / f"models--{repo.replace('/', '--')}").is_dir()
+
+
+def _skip_reason() -> Optional[str]:
+    if not os.environ.get("MOE_DFLASH_GPU"):
+        return "MOE_DFLASH_GPU unset (GPU-gated 20B DFlash harness)"
+    if not torch.cuda.is_available():
+        return "CUDA unavailable (GPU-gated 20B DFlash harness)"
+    missing = [r for r in (TARGET_REPO, DRAFTER_REPO) if not _checkpoint_present(r)]
+    if missing:
+        return "checkpoints not present in $HF_HOME: " + ", ".join(missing)
+    return None
+
+
+SKIP_REASON = _skip_reason()
+pytestmark = pytest.mark.skipif(SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated")
+
+
+def _greedy(model, input_ids, spec=None) -> list[int]:
+    kwargs: dict = {"do_sample": False, "max_new_tokens": CONTINUATION_TOKENS}
+    if spec is not None:
+        kwargs["speculative_draft"] = spec
+    out = model.generate(input_ids, **kwargs)
+    return [int(t) for t in out[0, input_ids.shape[1]:].tolist()]
+
+
+def test_20b_native_dflash_losslessness() -> None:
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+    from moe_infinity.spec_decode import DFlashSpeculator
+
+    offload = os.environ.get(
+        "MOE_DFLASH_OFFLOAD", "/tmp/opencode/moe-offload/gpt-oss-20b"
+    )
+    os.makedirs(offload, exist_ok=True)
+    ratio = float(os.environ.get("MOE_DFLASH_MEM_RATIO", "0.9"))
+
+    tok = AutoTokenizer.from_pretrained(TARGET_REPO, trust_remote_code=True)
+    model = MoE(TARGET_REPO, {"offload_path": offload, "device_memory_ratio": ratio})
+    spec = DFlashSpeculator(model, DRAFTER_REPO)
+
+    assert spec.config.block_size == 8
+    assert spec.config.target_layer_ids == [1, 6, 11, 16, 21]
+
+    ids = tok(PROMPT, return_tensors="pt").input_ids.to("cuda:0")
+
+    t0 = time.time()
+    plain = _greedy(model, ids)
+    plain_s = time.time() - t0
+
+    spec.step_trace = []
+    t0 = time.time()
+    dfl = _greedy(model, ids, spec=spec)
+    dfl_s = time.time() - t0
+
+    assert dfl == plain, "native DFlash greedy must be token-identical to plain greedy"
+
+    trace = getattr(spec, "step_trace", []) or []
+    accepts = [getattr(tr, "accept", 0) + 1 for tr in trace]
+    mean_accept = sum(accepts) / len(accepts) if accepts else 0.0
+    assert mean_accept >= 1.0
+    assert plain_s > 0 and dfl_s > 0

--- a/tests/python/dflash/test_gpu_20b_dflash.py
+++ b/tests/python/dflash/test_gpu_20b_dflash.py
@@ -44,14 +44,18 @@ def _skip_reason() -> Optional[str]:
         return "MOE_DFLASH_GPU unset (GPU-gated 20B DFlash harness)"
     if not torch.cuda.is_available():
         return "CUDA unavailable (GPU-gated 20B DFlash harness)"
-    missing = [r for r in (TARGET_REPO, DRAFTER_REPO) if not _checkpoint_present(r)]
+    missing = [
+        r for r in (TARGET_REPO, DRAFTER_REPO) if not _checkpoint_present(r)
+    ]
     if missing:
         return "checkpoints not present in $HF_HOME: " + ", ".join(missing)
     return None
 
 
 SKIP_REASON = _skip_reason()
-pytestmark = pytest.mark.skipif(SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated")
+pytestmark = pytest.mark.skipif(
+    SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated"
+)
 
 
 def _greedy(model, input_ids, spec=None) -> list[int]:
@@ -59,7 +63,7 @@ def _greedy(model, input_ids, spec=None) -> list[int]:
     if spec is not None:
         kwargs["speculative_draft"] = spec
     out = model.generate(input_ids, **kwargs)
-    return [int(t) for t in out[0, input_ids.shape[1]:].tolist()]
+    return [int(t) for t in out[0, input_ids.shape[1] :].tolist()]
 
 
 def test_20b_native_dflash_losslessness() -> None:
@@ -75,7 +79,9 @@ def test_20b_native_dflash_losslessness() -> None:
     ratio = float(os.environ.get("MOE_DFLASH_MEM_RATIO", "0.9"))
 
     tok = AutoTokenizer.from_pretrained(TARGET_REPO, trust_remote_code=True)
-    model = MoE(TARGET_REPO, {"offload_path": offload, "device_memory_ratio": ratio})
+    model = MoE(
+        TARGET_REPO, {"offload_path": offload, "device_memory_ratio": ratio}
+    )
     spec = DFlashSpeculator(model, DRAFTER_REPO)
 
     assert spec.config.block_size == 8
@@ -92,7 +98,9 @@ def test_20b_native_dflash_losslessness() -> None:
     dfl = _greedy(model, ids, spec=spec)
     dfl_s = time.time() - t0
 
-    assert dfl == plain, "native DFlash greedy must be token-identical to plain greedy"
+    assert (
+        dfl == plain
+    ), "native DFlash greedy must be token-identical to plain greedy"
 
     trace = getattr(spec, "step_trace", []) or []
     accepts = [getattr(tr, "accept", 0) + 1 for tr in trace]

--- a/tests/python/dflash/test_gpu_serving_dflash.py
+++ b/tests/python/dflash/test_gpu_serving_dflash.py
@@ -36,7 +36,9 @@ def _skip_reason() -> str | None:
         return "MOE_DFLASH_GPU unset (GPU-gated serving DFlash harness)"
     if not torch.cuda.is_available():
         return "CUDA unavailable (GPU-gated serving DFlash harness)"
-    missing = [r for r in (TARGET_REPO, DRAFTER_REPO) if not _checkpoint_present(r)]
+    missing = [
+        r for r in (TARGET_REPO, DRAFTER_REPO) if not _checkpoint_present(r)
+    ]
     if missing:
         return "checkpoints not present in $HF_HOME: " + ", ".join(missing)
     return None
@@ -44,7 +46,11 @@ def _skip_reason() -> str | None:
 
 def _model_int(config: object, *names: str) -> int:
     get_text = getattr(config, "get_text_config", None)
-    text_config = get_text() if callable(get_text) else getattr(config, "text_config", None)
+    text_config = (
+        get_text()
+        if callable(get_text)
+        else getattr(config, "text_config", None)
+    )
     for candidate in (config, text_config):
         if candidate is None:
             continue
@@ -56,7 +62,9 @@ def _model_int(config: object, *names: str) -> int:
 
 
 SKIP_REASON = _skip_reason()
-pytestmark = pytest.mark.skipif(SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated")
+pytestmark = pytest.mark.skipif(
+    SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated"
+)
 
 
 def test_serving_dflash_matches_sync_generate() -> None:
@@ -73,8 +81,12 @@ def test_serving_dflash_matches_sync_generate() -> None:
     os.makedirs(offload, exist_ok=True)
     ratio = float(os.environ.get("MOE_DFLASH_MEM_RATIO", "0.9"))
 
-    tokenizer = AutoTokenizer.from_pretrained(TARGET_REPO, trust_remote_code=True)
-    model = MoE(TARGET_REPO, {"offload_path": offload, "device_memory_ratio": ratio})
+    tokenizer = AutoTokenizer.from_pretrained(
+        TARGET_REPO, trust_remote_code=True
+    )
+    model = MoE(
+        TARGET_REPO, {"offload_path": offload, "device_memory_ratio": ratio}
+    )
     spec = DFlashSpeculator(model, DRAFTER_REPO)
     input_ids = tokenizer(PROMPT, return_tensors="pt").input_ids.to("cuda:0")
 
@@ -96,7 +108,9 @@ def test_serving_dflash_matches_sync_generate() -> None:
         "max_batch_size": 1,
         "max_tokens_per_step": 2048,
         "block_size": block_size,
-        "num_layers": _model_int(model_config, "num_hidden_layers", "num_layers"),
+        "num_layers": _model_int(
+            model_config, "num_hidden_layers", "num_layers"
+        ),
         "num_kv_heads": _model_int(
             model_config,
             "num_key_value_heads",

--- a/tests/python/dflash/test_gpu_serving_dflash.py
+++ b/tests/python/dflash/test_gpu_serving_dflash.py
@@ -1,0 +1,144 @@
+"""GPU-gated serving-vs-sync DFlash losslessness on gpt-oss-20b."""
+
+from __future__ import annotations
+
+import os
+import time
+from math import ceil
+from pathlib import Path
+
+import pytest
+import torch
+
+TARGET_REPO = "openai/gpt-oss-20b"
+DRAFTER_REPO = "z-lab/gpt-oss-20b-DFlash"
+CONTINUATION_TOKENS = 32
+PROMPT = "Explain in one paragraph why the sky appears blue."
+
+
+def _hf_home() -> Path:
+    for var in ("HF_HOME", "HUGGINGFACE_HUB_CACHE", "XDG_CACHE_HOME"):
+        val = os.environ.get(var)
+        if val:
+            base = Path(val)
+            return base / "hub" if var == "XDG_CACHE_HOME" else base
+    return Path.home() / ".cache" / "huggingface"
+
+
+def _checkpoint_present(repo: str) -> bool:
+    hub = _hf_home()
+    hub = hub if hub.name == "hub" else hub / "hub"
+    return (hub / f"models--{repo.replace('/', '--')}").is_dir()
+
+
+def _skip_reason() -> str | None:
+    if not os.environ.get("MOE_DFLASH_GPU"):
+        return "MOE_DFLASH_GPU unset (GPU-gated serving DFlash harness)"
+    if not torch.cuda.is_available():
+        return "CUDA unavailable (GPU-gated serving DFlash harness)"
+    missing = [r for r in (TARGET_REPO, DRAFTER_REPO) if not _checkpoint_present(r)]
+    if missing:
+        return "checkpoints not present in $HF_HOME: " + ", ".join(missing)
+    return None
+
+
+def _model_int(config: object, *names: str) -> int:
+    get_text = getattr(config, "get_text_config", None)
+    text_config = get_text() if callable(get_text) else getattr(config, "text_config", None)
+    for candidate in (config, text_config):
+        if candidate is None:
+            continue
+        for name in names:
+            value = getattr(candidate, name, None)
+            if isinstance(value, int):
+                return value
+    raise RuntimeError(f"unable to resolve any of {names!r} from model config")
+
+
+SKIP_REASON = _skip_reason()
+pytestmark = pytest.mark.skipif(SKIP_REASON is not None, reason=SKIP_REASON or "gpu-gated")
+
+
+def test_serving_dflash_matches_sync_generate() -> None:
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+    from moe_infinity.serving.engine import ContinuousBatchingEngine
+    from moe_infinity.serving.sequence import SamplingParams
+    from moe_infinity.spec_decode import DFlashSpeculator
+
+    offload = os.environ.get(
+        "MOE_DFLASH_OFFLOAD", "/tmp/opencode/moe-offload/gpt-oss-20b"
+    )
+    os.makedirs(offload, exist_ok=True)
+    ratio = float(os.environ.get("MOE_DFLASH_MEM_RATIO", "0.9"))
+
+    tokenizer = AutoTokenizer.from_pretrained(TARGET_REPO, trust_remote_code=True)
+    model = MoE(TARGET_REPO, {"offload_path": offload, "device_memory_ratio": ratio})
+    spec = DFlashSpeculator(model, DRAFTER_REPO)
+    input_ids = tokenizer(PROMPT, return_tensors="pt").input_ids.to("cuda:0")
+
+    sync_output = model.generate(
+        input_ids,
+        do_sample=False,
+        max_new_tokens=CONTINUATION_TOKENS,
+        speculative_draft=spec,
+    )
+    sync_tokens = [
+        int(token) for token in sync_output[0, input_ids.shape[1] :].tolist()
+    ]
+
+    model_config = model.model.config
+    block_size = 16
+    serving_config: dict[str, object] = {
+        "device_memory_ratio": ratio,
+        "kv_cache_ratio": 0.01,
+        "max_batch_size": 1,
+        "max_tokens_per_step": 2048,
+        "block_size": block_size,
+        "num_layers": _model_int(model_config, "num_hidden_layers", "num_layers"),
+        "num_kv_heads": _model_int(
+            model_config,
+            "num_key_value_heads",
+            "num_kv_heads",
+            "num_attention_heads",
+        ),
+        "head_dim": _model_int(model_config, "head_dim"),
+        "dtype": str(getattr(model.model, "dtype", torch.bfloat16)).replace(
+            "torch.", ""
+        ),
+        "eos_token_id": getattr(model_config, "eos_token_id", None),
+        "num_kv_blocks": max(1, ceil(input_ids.shape[1] / block_size)),
+    }
+    serving = ContinuousBatchingEngine(
+        model=model.model,
+        engine=model.engine,
+        config=serving_config,
+        tokenizer=tokenizer,
+        speculative_draft=spec,
+    )
+    serving.add_request(
+        request_id="serving-dflash",
+        prompt_token_ids=[int(token) for token in input_ids[0].tolist()],
+        sampling_params=SamplingParams(
+            temperature=0.0,
+            top_k=0,
+            top_p=1.0,
+            max_tokens=CONTINUATION_TOKENS,
+        ),
+    )
+
+    started = time.perf_counter()
+    serving_result = serving.run_until_done()
+    elapsed = time.perf_counter() - started
+    serving_tokens = serving_result["serving-dflash"]
+    assert isinstance(serving_tokens, list)
+    assert serving_tokens == sync_tokens
+
+    tok_s = len(serving_tokens) / elapsed
+    message = (
+        f"SERVING_DFLASH_TOKEN_IDENTICAL=True tokens={len(serving_tokens)}; "
+        f"elapsed_s={elapsed:.3f}; tok_s={tok_s:.2f}"
+    )
+    print(message, flush=True)
+    assert tok_s > 0

--- a/tests/python/dflash/test_kv_truncate.py
+++ b/tests/python/dflash/test_kv_truncate.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from moe_infinity.serving.kv_cache import PagedKVCache
+
+BLOCK_SIZE = 4
+NUM_BLOCKS = 16
+
+
+def _make_cache() -> PagedKVCache:
+    return PagedKVCache(
+        num_blocks=NUM_BLOCKS,
+        block_size=BLOCK_SIZE,
+        num_layers=2,
+        num_heads=2,
+        head_dim=8,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+
+
+def _blocks_for(num_tokens: int) -> int:
+    return (num_tokens + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+
+def _num_tokens(cache: PagedKVCache, seq_id: int) -> int:
+    return cache._sequence_tables[seq_id].num_computed_tokens()
+
+
+def _num_blocks(cache: PagedKVCache, seq_id: int) -> int:
+    return len(cache.get_block_table(seq_id))
+
+
+def test_partial_block_shrink_frees_no_blocks() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 10)
+    free_before = cache.block_allocator.num_free_blocks
+    assert _num_blocks(cache, 0) == 3
+
+    cache.truncate_tokens(0, 9)
+
+    assert _num_tokens(cache, 0) == 9
+    assert _num_blocks(cache, 0) == 3
+    assert cache.block_allocator.num_free_blocks == free_before
+
+
+def test_full_block_shrink_frees_tail_blocks() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 10)
+    kept_head = cache.get_block_table(0)[:1]
+    free_before = cache.block_allocator.num_free_blocks
+
+    cache.truncate_tokens(0, 4)
+
+    assert _num_tokens(cache, 0) == 4
+    assert _num_blocks(cache, 0) == 1
+    assert cache.get_block_table(0) == kept_head
+    assert cache.block_allocator.num_free_blocks == free_before + 2
+
+
+def test_shrink_to_zero_returns_all_blocks() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 8)
+    cache.truncate_tokens(0, 0)
+
+    assert _num_tokens(cache, 0) == 0
+    assert _num_blocks(cache, 0) == 0
+    assert cache.block_allocator.num_free_blocks == NUM_BLOCKS
+
+
+def test_noop_when_length_unchanged() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 8)
+    blocks_before = cache.get_block_table(0)
+    free_before = cache.block_allocator.num_free_blocks
+
+    cache.truncate_tokens(0, 8)
+
+    assert cache.get_block_table(0) == blocks_before
+    assert cache.block_allocator.num_free_blocks == free_before
+    assert _num_tokens(cache, 0) == 8
+
+
+def test_grow_raises() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 8)
+    with pytest.raises(ValueError, match="cannot grow"):
+        cache.truncate_tokens(0, 9)
+
+
+def test_negative_raises() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 8)
+    with pytest.raises(ValueError, match=">= 0"):
+        cache.truncate_tokens(0, -1)
+
+
+def test_unknown_sequence_raises() -> None:
+    cache = _make_cache()
+    with pytest.raises(KeyError):
+        cache.truncate_tokens(99, 0)
+
+
+def test_other_sequences_unaffected() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 8)
+    cache.allocate_sequence(1, 6)
+    seq1_blocks = cache.get_block_table(1)
+
+    cache.truncate_tokens(0, 2)
+
+    assert cache.get_block_table(1) == seq1_blocks
+    assert _num_tokens(cache, 1) == 6
+    assert _num_tokens(cache, 0) == 2
+
+
+def test_truncate_while_swapped_out_updates_cpu_state() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 8)
+    cache.swap_out(0)
+    cache.free_gpu_blocks(0)
+    free_after_free = cache.block_allocator.num_free_blocks
+
+    cache.truncate_tokens(0, 4)
+
+    assert cache._swapped_num_tokens[0] == 4
+    assert int(cache._swapped_cpu_buffers[0].shape[1]) == 1
+    assert cache.block_allocator.num_free_blocks == free_after_free
+
+    cache.swap_in(0)
+    assert _num_tokens(cache, 0) == 4
+    assert _num_blocks(cache, 0) == 1
+
+
+def test_repeated_truncate_and_free_reconciles_pool() -> None:
+    cache = _make_cache()
+    cache.allocate_sequence(0, 12)
+    cache.truncate_tokens(0, 5)
+    assert _num_blocks(cache, 0) == 2
+    cache.truncate_tokens(0, 1)
+    assert _num_blocks(cache, 0) == 1
+    cache.free_sequence(0)
+    assert cache.block_allocator.num_free_blocks == NUM_BLOCKS

--- a/tests/python/dflash/test_native_e2e.py
+++ b/tests/python/dflash/test_native_e2e.py
@@ -130,7 +130,9 @@ def _decode_all():
     shell, target = _build_engine_shell(seed=0)
     drafter = build_tiny_drafter(target, seed=1).to(DEVICE)
     config = read_dflash_config(make_tiny_drafter_config(target.config))
-    spec = DFlashSpeculator.from_models(shell, drafter, config=config, device=DEVICE)
+    spec = DFlashSpeculator.from_models(
+        shell, drafter, config=config, device=DEVICE
+    )
 
     results = []
     for prompt in PROMPTS:

--- a/tests/python/dflash/test_native_step.py
+++ b/tests/python/dflash/test_native_step.py
@@ -51,7 +51,9 @@ def _tiny_spec(device: str = "cpu"):
     if device != "cpu":
         target = target.to(device)
         drafter = drafter.to(device)
-    spec = DFlashSpeculator.from_models(target, drafter, config=config, device=device)
+    spec = DFlashSpeculator.from_models(
+        target, drafter, config=config, device=device
+    )
     return spec, target, drafter
 
 
@@ -114,7 +116,9 @@ def test_verify_forward_uses_full_logits():
     seam_calls = []
     orig_forward_target = spec._forward_target
 
-    def seam_spy(input_ids, past_key_values=None, logits_to_keep=0, **fwd_kwargs):
+    def seam_spy(
+        input_ids, past_key_values=None, logits_to_keep=0, **fwd_kwargs
+    ):
         seam_calls.append(int(logits_to_keep))
         return orig_forward_target(
             input_ids,
@@ -171,7 +175,10 @@ def test_native_multistep_greedy_matches_plain_greedy():
     # Multi-step actually ran, with consistent emitted-vs-cached accounting.
     assert len(spec.step_trace) >= 2
     _assert_step_invariants(spec)
-    assert int(spec.last_target_cache.get_seq_length()) == spec.step_trace[-1].start
+    assert (
+        int(spec.last_target_cache.get_seq_length())
+        == spec.step_trace[-1].start
+    )
 
     accepts = [rec.accept for rec in spec.step_trace]
     print(f"multistep steps={len(accepts)} accepts={accepts}")
@@ -210,7 +217,9 @@ def test_native_step_routes_through_moe_rich_forward():
                 ),
             }
         )
-        return orig_rich(token_ids, attention_metadata, logits_to_keep=logits_to_keep)
+        return orig_rich(
+            token_ids, attention_metadata, logits_to_keep=logits_to_keep
+        )
 
     shell._native_model_forward_rich = rich_spy
 
@@ -229,7 +238,10 @@ def test_native_step_routes_through_moe_rich_forward():
 
     _assert_step_invariants(spec)
     # The engine-side cache (same object the loop cropped) ends at start.
-    assert int(shell._cached_past_key_values.get_seq_length()) == spec.step_trace[-1].start
+    assert (
+        int(shell._cached_past_key_values.get_seq_length())
+        == spec.step_trace[-1].start
+    )
 
     # Parity against sequential greedy through the SAME rich helper.
     shell._cached_past_key_values = None

--- a/tests/python/dflash/test_native_step.py
+++ b/tests/python/dflash/test_native_step.py
@@ -114,10 +114,13 @@ def test_verify_forward_uses_full_logits():
     seam_calls = []
     orig_forward_target = spec._forward_target
 
-    def seam_spy(input_ids, past_key_values=None, logits_to_keep=0):
+    def seam_spy(input_ids, past_key_values=None, logits_to_keep=0, **fwd_kwargs):
         seam_calls.append(int(logits_to_keep))
         return orig_forward_target(
-            input_ids, past_key_values=past_key_values, logits_to_keep=logits_to_keep
+            input_ids,
+            past_key_values=past_key_values,
+            logits_to_keep=logits_to_keep,
+            **fwd_kwargs,
         )
 
     spec._forward_target = seam_spy

--- a/tests/python/dflash/test_prefetch_route.py
+++ b/tests/python/dflash/test_prefetch_route.py
@@ -120,7 +120,9 @@ def test_mask_union_matches_executor_derivation():
     # Same input, computed the way dispatch_local does it (expert_executor.py:101-111).
     mask = _mask_from_topk(LOGITS, TOP_K)
     num_expert = mask.shape[-1]
-    expert_count = torch.sum(mask.view((-1, num_expert)), dim=0).cpu().numpy().flatten()
+    expert_count = (
+        torch.sum(mask.view((-1, num_expert)), dim=0).cpu().numpy().flatten()
+    )
     executor_list = np.arange(num_expert).astype(int)[expert_count > 0].tolist()
     assert union_experts_from_mask(mask) == executor_list == UNION_TOP2
 
@@ -154,7 +156,9 @@ def test_logits_union_topk1_is_per_token_argmax():
 
 
 def test_logits_union_full_k_is_all_experts():
-    assert union_experts_from_logits(LOGITS, NUM_EXPERTS) == list(range(NUM_EXPERTS))
+    assert union_experts_from_logits(LOGITS, NUM_EXPERTS) == list(
+        range(NUM_EXPERTS)
+    )
 
 
 def test_logits_union_single_token():
@@ -168,10 +172,14 @@ def test_logits_union_zero_tokens_is_empty():
 def test_logits_union_matches_mask_union_when_topk_matches_routing():
     # The plan's core invariant: logits-derived union == mask-derived union.
     mask = _mask_from_topk(LOGITS, TOP_K)
-    assert union_experts_from_logits(LOGITS, TOP_K) == union_experts_from_mask(mask)
+    assert union_experts_from_logits(LOGITS, TOP_K) == union_experts_from_mask(
+        mask
+    )
 
 
-@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float64])
+@pytest.mark.parametrize(
+    "dtype", [torch.float32, torch.bfloat16, torch.float64]
+)
 def test_logits_union_dtype_robust(dtype):
     out = union_experts_from_logits(LOGITS.to(dtype), TOP_K)
     assert out == UNION_TOP2

--- a/tests/python/dflash/test_prefetch_route.py
+++ b/tests/python/dflash/test_prefetch_route.py
@@ -1,0 +1,299 @@
+"""Hand-checked unit tests for the DFlash route-ahead prefetch pure helpers.
+
+Autonomous correctness gate for Track A1 of
+``.sisyphus/plans/dflash-deferred-tracks-plan.md``. Pure, CPU-only set math
+over router outputs -- no model loading, no prefetcher/executor wiring
+(that is A2/A3).
+
+Route-ahead prefetch uses the ACTUAL routed union (model-exact), matching how
+``ExpertExecutor.dispatch_local`` derives ``expert_list`` from ``router_mask``
+(``distributed/expert_executor.py:101-111``) and how the MoE block builds the
+mask from ``topk(softmax(logits))`` (``models/gpt_oss.py:130-147``). Softmax is
+monotonic, so top-k on raw logits selects the same experts as top-k on the
+probabilities -- hence ``union_experts_from_logits`` must agree with
+``union_experts_from_mask`` when ``top_k`` matches the routing.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from moe_infinity.spec_decode._prefetch_route import (
+    prefetch_coverage,
+    rejected_expert_ids,
+    union_experts_from_logits,
+    union_experts_from_mask,
+)
+
+NUM_EXPERTS = 8
+TOP_K = 2
+
+# Hand-checked logits [3 tokens, 8 experts]; per-token top-2:
+#   token 0: experts {0, 3}   (logits 9.0, 8.0)
+#   token 1: experts {3, 5}   (logits 9.0, 8.0)
+#   token 2: experts {0, 7}   (logits 9.0, 8.0)
+LOGITS = torch.tensor(
+    [
+        [9.0, 1.0, 2.0, 8.0, 0.0, 3.0, 4.0, 5.0],
+        [1.0, 0.0, 2.0, 9.0, 3.0, 8.0, 4.0, 5.0],
+        [9.0, 2.0, 0.0, 1.0, 3.0, 4.0, 5.0, 8.0],
+    ]
+)
+TOKEN_TOP2 = [{0, 3}, {3, 5}, {0, 7}]
+UNION_TOP2 = [0, 3, 5, 7]
+
+
+def _mask_from_topk(logits: torch.Tensor, top_k: int) -> torch.Tensor:
+    """Replicate the gpt_oss.py:132-147 routing: softmax -> topk -> scatter bool mask."""
+    probs = torch.softmax(logits, dim=-1, dtype=torch.float32)
+    selected = torch.topk(probs, top_k, dim=-1).indices
+    mask = torch.zeros(logits.shape[0], logits.shape[1], dtype=torch.bool)
+    mask.scatter_(1, selected, True)
+    return mask
+
+
+# ---------------------------------------------------------------------------
+# union_experts_from_mask
+# ---------------------------------------------------------------------------
+
+
+def test_mask_union_overlapping_tokens():
+    mask = torch.tensor(
+        [
+            [True, False, False, True, False, False, False, False],
+            [False, False, False, True, False, True, False, False],
+            [True, False, False, False, False, False, False, True],
+        ]
+    )
+    assert union_experts_from_mask(mask) == UNION_TOP2
+
+
+def test_mask_union_disjoint_tokens():
+    mask = torch.zeros(3, NUM_EXPERTS, dtype=torch.bool)
+    mask[0, 1] = True
+    mask[1, 4] = True
+    mask[2, 6] = True
+    assert union_experts_from_mask(mask) == [1, 4, 6]
+
+
+def test_mask_union_single_token():
+    mask = torch.zeros(1, NUM_EXPERTS, dtype=torch.bool)
+    mask[0, 5] = True
+    mask[0, 2] = True
+    assert union_experts_from_mask(mask) == [2, 5]
+
+
+def test_mask_union_all_false_is_empty():
+    mask = torch.zeros(4, NUM_EXPERTS, dtype=torch.bool)
+    assert union_experts_from_mask(mask) == []
+
+
+def test_mask_union_zero_tokens_is_empty():
+    mask = torch.zeros(0, NUM_EXPERTS, dtype=torch.bool)
+    assert union_experts_from_mask(mask) == []
+
+
+def test_mask_union_all_true_is_all_experts():
+    mask = torch.ones(2, NUM_EXPERTS, dtype=torch.bool)
+    assert union_experts_from_mask(mask) == list(range(NUM_EXPERTS))
+
+
+def test_mask_union_int_mask_treats_nonzero_as_routed():
+    mask = torch.tensor([[0, 1, 0, 2], [0, 0, 0, 0]], dtype=torch.int64)
+    assert union_experts_from_mask(mask) == [1, 3]
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        [[True, False, True], [False, True, False]],  # python nested list
+        np.array([[1, 0, 1], [0, 1, 0]], dtype=np.int64),  # numpy array
+    ],
+)
+def test_mask_union_accepts_list_and_numpy(mask):
+    assert union_experts_from_mask(mask) == [0, 1, 2]
+
+
+def test_mask_union_matches_executor_derivation():
+    # Same input, computed the way dispatch_local does it (expert_executor.py:101-111).
+    mask = _mask_from_topk(LOGITS, TOP_K)
+    num_expert = mask.shape[-1]
+    expert_count = torch.sum(mask.view((-1, num_expert)), dim=0).cpu().numpy().flatten()
+    executor_list = np.arange(num_expert).astype(int)[expert_count > 0].tolist()
+    assert union_experts_from_mask(mask) == executor_list == UNION_TOP2
+
+
+def test_mask_union_returns_sorted_python_ints():
+    mask = torch.zeros(1, NUM_EXPERTS, dtype=torch.bool)
+    mask[0, 7] = True
+    mask[0, 1] = True
+    out = union_experts_from_mask(mask)
+    assert out == [1, 7]
+    assert all(isinstance(i, int) for i in out)
+
+
+def test_mask_union_rejects_non_2d():
+    with pytest.raises(ValueError, match="2-D"):
+        union_experts_from_mask(torch.zeros(NUM_EXPERTS, dtype=torch.bool))
+
+
+# ---------------------------------------------------------------------------
+# union_experts_from_logits
+# ---------------------------------------------------------------------------
+
+
+def test_logits_union_topk2_handchecked():
+    assert union_experts_from_logits(LOGITS, TOP_K) == UNION_TOP2
+
+
+def test_logits_union_topk1_is_per_token_argmax():
+    # token argmaxes: 0, 3, 0 -> union {0, 3}
+    assert union_experts_from_logits(LOGITS, 1) == [0, 3]
+
+
+def test_logits_union_full_k_is_all_experts():
+    assert union_experts_from_logits(LOGITS, NUM_EXPERTS) == list(range(NUM_EXPERTS))
+
+
+def test_logits_union_single_token():
+    assert union_experts_from_logits(LOGITS[:1], TOP_K) == sorted(TOKEN_TOP2[0])
+
+
+def test_logits_union_zero_tokens_is_empty():
+    assert union_experts_from_logits(LOGITS[:0], TOP_K) == []
+
+
+def test_logits_union_matches_mask_union_when_topk_matches_routing():
+    # The plan's core invariant: logits-derived union == mask-derived union.
+    mask = _mask_from_topk(LOGITS, TOP_K)
+    assert union_experts_from_logits(LOGITS, TOP_K) == union_experts_from_mask(mask)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float64])
+def test_logits_union_dtype_robust(dtype):
+    out = union_experts_from_logits(LOGITS.to(dtype), TOP_K)
+    assert out == UNION_TOP2
+
+
+@pytest.mark.parametrize(
+    "logits",
+    [
+        LOGITS.tolist(),  # python nested list
+        LOGITS.numpy(),  # numpy array
+    ],
+)
+def test_logits_union_accepts_list_and_numpy(logits):
+    assert union_experts_from_logits(logits, TOP_K) == UNION_TOP2
+
+
+def test_logits_union_rejects_bad_topk():
+    with pytest.raises(ValueError, match="top_k"):
+        union_experts_from_logits(LOGITS, 0)
+    with pytest.raises(ValueError, match="top_k"):
+        union_experts_from_logits(LOGITS, NUM_EXPERTS + 1)
+
+
+def test_logits_union_rejects_non_2d():
+    with pytest.raises(ValueError, match="2-D"):
+        union_experts_from_logits(LOGITS.flatten(), TOP_K)
+
+
+# ---------------------------------------------------------------------------
+# prefetch_coverage
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_full_when_prediction_is_superset():
+    assert prefetch_coverage([0, 3, 5, 7, 99], [0, 3, 5, 7]) == 1.0
+
+
+def test_coverage_full_when_identical():
+    assert prefetch_coverage([0, 3, 5, 7], [0, 3, 5, 7]) == 1.0
+
+
+def test_coverage_partial():
+    # predicted {0, 3, 4} vs actual {0, 3, 5, 7} -> 2/4
+    assert prefetch_coverage([0, 3, 4], [0, 3, 5, 7]) == 0.5
+
+
+def test_coverage_zero_on_disjoint():
+    assert prefetch_coverage([1, 2], [0, 3, 5, 7]) == 0.0
+
+
+def test_coverage_empty_actual_is_one():
+    assert prefetch_coverage([0, 3], []) == 1.0
+
+
+def test_coverage_both_empty_is_one():
+    assert prefetch_coverage([], []) == 1.0
+
+
+def test_coverage_empty_prediction_nonempty_actual_is_zero():
+    assert prefetch_coverage([], [0, 3, 5, 7]) == 0.0
+
+
+def test_coverage_uses_set_semantics_not_multiset():
+    # duplicates in either side must not change the ratio
+    assert prefetch_coverage([0, 0, 3, 3], [0, 3, 3, 5, 7, 7]) == 0.5
+
+
+def test_coverage_accepts_tensors_and_numpy():
+    predicted = torch.tensor([0, 3, 5])
+    actual = np.array([0, 3, 5, 7], dtype=np.int64)
+    assert prefetch_coverage(predicted, actual) == 0.75
+    assert isinstance(prefetch_coverage(predicted, actual), float)
+
+
+# ---------------------------------------------------------------------------
+# rejected_expert_ids
+# ---------------------------------------------------------------------------
+
+
+def test_rejected_partial_waste():
+    # full block union {0,3,5,7}; kept prefix only routed {0,3} -> waste {5,7}
+    assert rejected_expert_ids(UNION_TOP2, [0, 3]) == [5, 7]
+
+
+def test_rejected_none_when_all_kept():
+    assert rejected_expert_ids(UNION_TOP2, UNION_TOP2) == []
+
+
+def test_rejected_all_when_nothing_kept():
+    assert rejected_expert_ids(UNION_TOP2, []) == UNION_TOP2
+
+
+def test_rejected_empty_full_is_empty():
+    assert rejected_expert_ids([], [0, 3]) == []
+
+
+def test_rejected_both_empty_is_empty():
+    assert rejected_expert_ids([], []) == []
+
+
+def test_rejected_kept_superset_of_full_is_empty():
+    assert rejected_expert_ids([0, 3], [0, 3, 5, 7]) == []
+
+
+def test_rejected_returns_sorted_python_ints():
+    out = rejected_expert_ids(torch.tensor([7, 5, 3, 0]), np.array([3, 0]))
+    assert out == [5, 7]
+    assert all(isinstance(i, int) for i in out)
+
+
+# ---------------------------------------------------------------------------
+# end-to-end purity: mask -> union -> coverage/waste pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_block_union_vs_kept_prefix_pipeline():
+    # Simulate a 3-token block where only the first 2 tokens survive verify:
+    # full union over all 3 tokens, kept union over tokens 0..1.
+    mask = _mask_from_topk(LOGITS, TOP_K)
+    full = union_experts_from_mask(mask)
+    kept = union_experts_from_mask(mask[:2])
+    assert full == UNION_TOP2
+    assert kept == [0, 3, 5]
+    assert prefetch_coverage(kept, full) == 0.75
+    assert rejected_expert_ids(full, kept) == [7]

--- a/tests/python/dflash/test_qwen35_hybrid_rollback.py
+++ b/tests/python/dflash/test_qwen35_hybrid_rollback.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from transformers import Qwen3_5MoeForCausalLM, Qwen3_5MoeTextConfig
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    build_tiny_drafter,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+    set_determinism,
+)
+
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
+
+
+def _tiny_qwen35_target(seed: int = 0) -> Qwen3_5MoeForCausalLM:
+    set_determinism(seed)
+    config = Qwen3_5MoeTextConfig(
+        vocab_size=64,
+        hidden_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        linear_conv_kernel_dim=4,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_num_key_heads=2,
+        linear_num_value_heads=4,
+        moe_intermediate_size=16,
+        shared_expert_intermediate_size=16,
+        num_experts=4,
+        num_experts_per_tok=2,
+        max_position_embeddings=64,
+        layer_types=[
+            "linear_attention",
+            "full_attention",
+            "linear_attention",
+            "full_attention",
+        ],
+        eos_token_id=None,
+        pad_token_id=0,
+        bos_token_id=1,
+        attn_implementation="eager",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        target = Qwen3_5MoeForCausalLM(config)
+    return target.to(torch.float32).eval()
+
+
+def _qwen35_shell() -> MoE:
+    shell = MoE.__new__(MoE)
+    shell.model = MagicMock()
+    shell.model.config = SimpleNamespace(model_type="qwen3_5_moe")
+    shell.model.generate.return_value = torch.tensor([[1, 2, 9]])
+    shell.use_native_engine = True
+    shell._native_generation_engine = MagicMock()
+    shell._native_generation_engine.generate.return_value = SimpleNamespace(
+        output_token_ids=[8]
+    )
+    shell._resolve_spec_strategy = MagicMock()
+    shell._configure_hook = MagicMock()
+    shell._cached_past_key_values = None
+    shell.max_seq_length = 64
+    return shell
+
+
+def test_qwen35_spec_off_generate_stays_on_hf_path() -> None:
+    shell = _qwen35_shell()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        actual = shell.generate(
+            torch.tensor([[1, 2]]), do_sample=False, max_new_tokens=1
+        )
+
+    assert actual.tolist() == [[1, 2, 9]]
+    shell.model.generate.assert_called_once()
+    shell._native_generation_engine.generate.assert_not_called()
+
+
+def test_qwen35_greedy_dflash_uses_native_path() -> None:
+    shell = _qwen35_shell()
+    draft = object()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        actual = shell.generate(
+            torch.tensor([[1, 2]]),
+            do_sample=False,
+            max_new_tokens=1,
+            speculative_draft=draft,
+        )
+
+    assert actual.tolist() == [[1, 2, 8]]
+    shell._resolve_spec_strategy.assert_called_once_with(draft)
+    shell._native_generation_engine.generate.assert_called_once()
+    shell.model.generate.assert_not_called()
+
+
+def test_qwen35_sampled_dflash_is_rejected() -> None:
+    shell = _qwen35_shell()
+
+    with warnings.catch_warnings(), pytest.raises(ValueError, match="greedy"):
+        warnings.simplefilter("ignore", DeprecationWarning)
+        shell.generate(
+            torch.tensor([[1, 2]]),
+            do_sample=True,
+            temperature=0.7,
+            speculative_draft=object(),
+        )
+
+
+def test_qwen35_hybrid_dflash_is_token_identical_to_plain_greedy() -> None:
+    target = _tiny_qwen35_target(seed=1)
+    drafter = build_tiny_drafter(
+        target,
+        seed=21,
+        block_size=4,
+        target_layer_ids=(0, 1, 2, 3),
+    )
+    config = read_dflash_config(
+        make_tiny_drafter_config(
+            target.config,
+            block_size=4,
+            target_layer_ids=(0, 1, 2, 3),
+        )
+    )
+    spec = DFlashSpeculator.from_models(
+        target, drafter, config=config, device="cpu"
+    )
+    prompt = torch.tensor([[3, 7, 11, 2, 5]], dtype=torch.long)
+
+    plain = plain_greedy_decode(target, prompt, max_new_tokens=32)
+    actual = spec.generate(prompt, max_new_tokens=32, temperature=0.0)
+
+    assert actual.tolist() == plain.tolist()

--- a/tests/python/dflash/test_qwen35_hybrid_rollback.py
+++ b/tests/python/dflash/test_qwen35_hybrid_rollback.py
@@ -9,17 +9,10 @@ import pytest
 import torch
 from transformers import Qwen3_5MoeForCausalLM, Qwen3_5MoeTextConfig
 
-from tests.python.dflash.fixtures_tiny import (
-    build_tiny_drafter,
-    make_tiny_drafter_config,
-    plain_greedy_decode,
-    set_determinism,
-)
-
-from moe_infinity.entrypoints.big_modeling import MoE
 from moe_infinity.distributed.expert_executor import (
     DistributedExpertExecutor,
 )
+from moe_infinity.entrypoints.big_modeling import MoE
 from moe_infinity.models import SyncQwen3_5MoeSparseMoeBlock
 from moe_infinity.spec_decode import (
     DFlashSpeculator,
@@ -27,6 +20,12 @@ from moe_infinity.spec_decode import (
 )
 from moe_infinity.spec_decode import dflash as dflash_module
 from moe_infinity.utils import ArcherConfig
+from tests.python.dflash.fixtures_tiny import (
+    build_tiny_drafter,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+    set_determinism,
+)
 
 
 def _tiny_qwen35_target(seed: int = 0) -> Qwen3_5MoeForCausalLM:
@@ -72,9 +71,7 @@ def _qwen35_shell() -> tuple[MoE, MagicMock, MagicMock, MagicMock]:
     shell.model = model
     shell.use_native_engine = True
     engine = MagicMock()
-    engine.generate.return_value = SimpleNamespace(
-        output_token_ids=[8]
-    )
+    engine.generate.return_value = SimpleNamespace(output_token_ids=[8])
     shell._native_generation_engine = engine
     resolve_spec = MagicMock()
     shell._resolve_spec_strategy = resolve_spec

--- a/tests/python/dflash/test_qwen35_hybrid_rollback.py
+++ b/tests/python/dflash/test_qwen35_hybrid_rollback.py
@@ -1,30 +1,32 @@
 from __future__ import annotations
 
-import os
-import sys
 import warnings
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 from transformers import Qwen3_5MoeForCausalLM, Qwen3_5MoeTextConfig
 
-sys.path.insert(0, os.path.dirname(__file__))
-
-from fixtures_tiny import (  # noqa: E402
+from tests.python.dflash.fixtures_tiny import (
     build_tiny_drafter,
     make_tiny_drafter_config,
     plain_greedy_decode,
     set_determinism,
 )
 
-from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
-from moe_infinity.spec_decode import (  # noqa: E402
+from moe_infinity.entrypoints.big_modeling import MoE
+from moe_infinity.distributed.expert_executor import (
+    DistributedExpertExecutor,
+)
+from moe_infinity.models import SyncQwen3_5MoeSparseMoeBlock
+from moe_infinity.spec_decode import (
     DFlashSpeculator,
     read_dflash_config,
 )
-from moe_infinity.spec_decode import dflash as dflash_module  # noqa: E402
+from moe_infinity.spec_decode import dflash as dflash_module
+from moe_infinity.utils import ArcherConfig
 
 
 def _tiny_qwen35_target(seed: int = 0) -> Qwen3_5MoeForCausalLM:
@@ -55,71 +57,142 @@ def _tiny_qwen35_target(seed: int = 0) -> Qwen3_5MoeForCausalLM:
         eos_token_id=None,
         pad_token_id=0,
         bos_token_id=1,
-        attn_implementation="eager",
     )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         target = Qwen3_5MoeForCausalLM(config)
-    return target.to(torch.float32).eval()
+    return target.float().eval()
 
 
-def _qwen35_shell() -> MoE:
+def _qwen35_shell() -> tuple[MoE, MagicMock, MagicMock, MagicMock]:
     shell = MoE.__new__(MoE)
-    shell.model = MagicMock()
-    shell.model.config = SimpleNamespace(model_type="qwen3_5_moe")
-    shell.model.generate.return_value = torch.tensor([[1, 2, 9]])
+    model = MagicMock()
+    model.config = SimpleNamespace(model_type="qwen3_5_moe")
+    model.generate.return_value = torch.tensor([[1, 2, 9]])
+    shell.model = model
     shell.use_native_engine = True
-    shell._native_generation_engine = MagicMock()
-    shell._native_generation_engine.generate.return_value = SimpleNamespace(
+    engine = MagicMock()
+    engine.generate.return_value = SimpleNamespace(
         output_token_ids=[8]
     )
-    shell._resolve_spec_strategy = MagicMock()
+    shell._native_generation_engine = engine
+    resolve_spec = MagicMock()
+    shell._resolve_spec_strategy = resolve_spec
     shell._configure_hook = MagicMock()
     shell._cached_past_key_values = None
     shell.max_seq_length = 64
-    return shell
+    return shell, model, engine, resolve_spec
+
+
+class _LocalObservedExecutor(DistributedExpertExecutor):
+    def __init__(
+        self, module: SyncQwen3_5MoeSparseMoeBlock, prefetcher: object
+    ) -> None:
+        super().__init__(
+            ArcherConfig.load_from_json(
+                {"offload_path": "/tmp/moe-infinity-qwen35-dflash-test"}
+            )
+        )
+        self.module = module
+        self.prefetcher = prefetcher
+        self.output: torch.Tensor | None = None
+
+    def dispatch_local(
+        self,
+        layer_id: int,
+        hidden_states: torch.Tensor,
+        router_mask: torch.Tensor,
+        router_weights: torch.Tensor,
+        router_logits: torch.Tensor | None = None,
+        prefetcher: object | None = None,
+    ) -> None:
+        del router_logits
+        self._maybe_route_ahead_prefetch(
+            layer_id,
+            router_mask,
+            router_mask.shape[-1],
+            prefetcher,
+        )
+        self.output = self.module._local_experts(
+            hidden_states, router_mask, router_weights
+        )
+
+    def wait_dispatch_local(self) -> torch.Tensor:
+        assert self.output is not None
+        output = self.output
+        self.output = None
+        return output
+
+
+def _install_observed_executor_blocks(
+    target: Qwen3_5MoeForCausalLM, prefetcher: object
+) -> None:
+    for layer_id, layer in enumerate(target.model.layers):
+        hf_block = getattr(layer, "mlp")
+        sync_block = SyncQwen3_5MoeSparseMoeBlock(target.config).eval()
+        state = dict(hf_block.state_dict())
+        gate_up = state.pop("experts.gate_up_proj")
+        down = state.pop("experts.down_proj")
+        for expert_id in range(target.config.num_experts):
+            gate, up = gate_up[expert_id].chunk(2, dim=0)
+            state[f"experts.{expert_id}.gate_proj.weight"] = gate.contiguous()
+            state[f"experts.{expert_id}.up_proj.weight"] = up.contiguous()
+            state[f"experts.{expert_id}.down_proj.weight"] = down[
+                expert_id
+            ].contiguous()
+        missing, unexpected = sync_block.load_state_dict(state, strict=False)
+        assert missing == [] and unexpected == []
+        sync_block.layer_id = layer_id
+        setattr(
+            sync_block,
+            "expert_executor",
+            _LocalObservedExecutor(sync_block, prefetcher),
+        )
+        layer.mlp = sync_block
 
 
 def test_qwen35_spec_off_generate_stays_on_hf_path() -> None:
-    shell = _qwen35_shell()
+    shell, model, engine, _ = _qwen35_shell()
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         actual = shell.generate(
-            torch.tensor([[1, 2]]), do_sample=False, max_new_tokens=1
+            cast(torch.LongTensor, torch.tensor([[1, 2]])),
+            do_sample=False,
+            max_new_tokens=1,
         )
 
     assert actual.tolist() == [[1, 2, 9]]
-    shell.model.generate.assert_called_once()
-    shell._native_generation_engine.generate.assert_not_called()
+    model.generate.assert_called_once()
+    engine.generate.assert_not_called()
 
 
 def test_qwen35_greedy_dflash_uses_native_path() -> None:
-    shell = _qwen35_shell()
+    shell, model, engine, resolve_spec = _qwen35_shell()
     draft = object()
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
         actual = shell.generate(
-            torch.tensor([[1, 2]]),
+            cast(torch.LongTensor, torch.tensor([[1, 2]])),
             do_sample=False,
             max_new_tokens=1,
             speculative_draft=draft,
         )
 
     assert actual.tolist() == [[1, 2, 8]]
-    shell._resolve_spec_strategy.assert_called_once_with(draft)
-    shell._native_generation_engine.generate.assert_called_once()
-    shell.model.generate.assert_not_called()
+    resolve_spec.assert_called_once_with(draft)
+    engine.generate.assert_called_once()
+    model.generate.assert_not_called()
 
 
 def test_qwen35_sampled_dflash_is_rejected() -> None:
-    shell = _qwen35_shell()
+    shell, _, _, _ = _qwen35_shell()
 
     with warnings.catch_warnings(), pytest.raises(ValueError, match="greedy"):
         warnings.simplefilter("ignore", DeprecationWarning)
         shell.generate(
-            torch.tensor([[1, 2]]),
+            cast(torch.LongTensor, torch.tensor([[1, 2]])),
             do_sample=True,
             temperature=0.7,
             speculative_draft=object(),
@@ -150,6 +223,29 @@ def test_qwen35_hybrid_dflash_is_token_identical_to_plain_greedy() -> None:
     actual = spec.generate(prompt, max_new_tokens=32, temperature=0.0)
 
     assert actual.tolist() == plain.tolist()
+    assert any(
+        trace.accept + 1 < config.block_size for trace in spec.step_trace
+    )
+
+    cached_length = spec.last_target_cache.get_seq_length()
+    with torch.no_grad():
+        expected_cache = target(
+            actual[:, :cached_length], use_cache=True
+        ).past_key_values
+    assert torch.allclose(
+        spec.last_target_cache.layers[0].conv_states,
+        expected_cache.layers[0].conv_states,
+    )
+    assert torch.allclose(
+        spec.last_target_cache.layers[0].recurrent_states,
+        expected_cache.layers[0].recurrent_states,
+    )
+    assert torch.allclose(
+        spec.last_target_cache.layers[1].keys,
+        expected_cache.layers[1].keys,
+        rtol=1e-5,
+        atol=1e-6,
+    )
 
 
 def test_snapshot_target_cache_copies_qwen35_linear_attention_state() -> None:
@@ -161,6 +257,8 @@ def test_snapshot_target_cache_copies_qwen35_linear_attention_state() -> None:
     snapshot = dflash_module.snapshot_target_cache(cache)
     layer = cache.layers[0]
     saved = snapshot.linear[0]
+    assert saved.conv_states is not None
+    assert saved.recurrent_states is not None
     expected_conv = layer.conv_states.clone()
     expected_recurrent = layer.recurrent_states.clone()
 
@@ -179,3 +277,125 @@ def test_snapshot_target_cache_rejects_partial_linear_cache_contract() -> None:
 
     with pytest.raises(RuntimeError, match="unsupported transformers"):
         dflash_module.snapshot_target_cache(malformed)
+
+
+def test_partial_rollback_replays_exact_qwen35_hybrid_cache_state() -> None:
+    target = _tiny_qwen35_target(seed=3)
+    prompt = torch.tensor([[3, 7, 11, 2, 5]], dtype=torch.long)
+    block = torch.tensor([[13, 17, 19, 23]], dtype=torch.long)
+    committed = 2
+    with torch.no_grad():
+        cache = target(prompt, use_cache=True).past_key_values
+        snapshot = dflash_module.snapshot_target_cache(cache)
+        target(block, past_key_values=cache, use_cache=True)
+
+        replay_calls: list[torch.Tensor] = []
+
+        def replay(prefix: torch.Tensor, replay_cache: object) -> object:
+            replay_calls.append(prefix.clone())
+            return target(
+                prefix, past_key_values=replay_cache, use_cache=True
+            ).past_key_values
+
+        dflash_module.rollback_target_cache(
+            cache,
+            snapshot,
+            prev_start=prompt.shape[1],
+            committed=committed,
+            block_size=block.shape[1],
+            block=block,
+            replay=replay,
+        )
+        expected = target(
+            torch.cat([prompt, block[:, :committed]], dim=1), use_cache=True
+        ).past_key_values
+
+    assert len(replay_calls) == 1
+    assert torch.equal(replay_calls[0], block[:, :committed])
+    assert cache.get_seq_length() == prompt.shape[1] + committed
+    assert torch.allclose(
+        cache.layers[0].conv_states, expected.layers[0].conv_states
+    )
+    assert torch.allclose(
+        cache.layers[0].recurrent_states,
+        expected.layers[0].recurrent_states,
+    )
+    assert torch.allclose(cache.layers[1].keys, expected.layers[1].keys)
+    assert torch.allclose(cache.layers[1].values, expected.layers[1].values)
+
+
+def test_full_accept_does_not_replay_hybrid_cache() -> None:
+    target = _tiny_qwen35_target(seed=4)
+    prompt = torch.tensor([[3, 7, 11, 2, 5]], dtype=torch.long)
+    block = torch.tensor([[13, 17, 19, 23]], dtype=torch.long)
+    with torch.no_grad():
+        cache = target(prompt, use_cache=True).past_key_values
+        snapshot = dflash_module.snapshot_target_cache(cache)
+        target(block, past_key_values=cache, use_cache=True)
+
+    replay = MagicMock()
+    dflash_module.rollback_target_cache(
+        cache,
+        snapshot,
+        prev_start=prompt.shape[1],
+        committed=block.shape[1],
+        block_size=block.shape[1],
+        block=block,
+        replay=replay,
+    )
+
+    replay.assert_not_called()
+    assert cache.get_seq_length() == prompt.shape[1] + block.shape[1]
+
+
+def test_from_models_rejects_target_layer_ids_outside_hybrid_depth() -> None:
+    target = _tiny_qwen35_target()
+    drafter = build_tiny_drafter(
+        target, seed=1, block_size=4, target_layer_ids=(0, 1)
+    )
+    invalid = read_dflash_config(
+        make_tiny_drafter_config(
+            target.config,
+            block_size=4,
+            target_layer_ids=(0, target.config.num_hidden_layers),
+        )
+    )
+
+    with pytest.raises(ValueError, match="target layer 4.*only 4 layers"):
+        DFlashSpeculator.from_models(
+            target, drafter, config=invalid, device="cpu"
+        )
+
+
+def test_qwen35_verify_records_route_ahead_stats() -> None:
+    target = _tiny_qwen35_target(seed=5)
+    prefetcher = MagicMock()
+    _install_observed_executor_blocks(target, prefetcher)
+    drafter = build_tiny_drafter(
+        target,
+        seed=6,
+        block_size=4,
+        target_layer_ids=(0, 1, 2, 3),
+    )
+    config = read_dflash_config(
+        make_tiny_drafter_config(
+            target.config,
+            block_size=4,
+            target_layer_ids=(0, 1, 2, 3),
+        )
+    )
+    spec = DFlashSpeculator.from_models(
+        target, drafter, config=config, device="cpu"
+    )
+    stats = spec.enable_route_ahead_stats()
+
+    spec.generate(
+        torch.tensor([[3, 7, 11, 2, 5]]),
+        max_new_tokens=8,
+        temperature=0.0,
+    )
+
+    report = stats.as_dict()
+    assert report["steps"] > 0
+    assert report["layers_observed"] > 0
+    assert "waste_ratio" in report

--- a/tests/python/dflash/test_qwen35_hybrid_rollback.py
+++ b/tests/python/dflash/test_qwen35_hybrid_rollback.py
@@ -19,11 +19,12 @@ from fixtures_tiny import (  # noqa: E402
     set_determinism,
 )
 
+from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
 from moe_infinity.spec_decode import (  # noqa: E402
     DFlashSpeculator,
     read_dflash_config,
 )
-from moe_infinity.entrypoints.big_modeling import MoE  # noqa: E402
+from moe_infinity.spec_decode import dflash as dflash_module  # noqa: E402
 
 
 def _tiny_qwen35_target(seed: int = 0) -> Qwen3_5MoeForCausalLM:
@@ -149,3 +150,32 @@ def test_qwen35_hybrid_dflash_is_token_identical_to_plain_greedy() -> None:
     actual = spec.generate(prompt, max_new_tokens=32, temperature=0.0)
 
     assert actual.tolist() == plain.tolist()
+
+
+def test_snapshot_target_cache_copies_qwen35_linear_attention_state() -> None:
+    target = _tiny_qwen35_target()
+    prompt = torch.tensor([[3, 7, 11, 2, 5]], dtype=torch.long)
+    with torch.no_grad():
+        cache = target(prompt, use_cache=True).past_key_values
+
+    snapshot = dflash_module.snapshot_target_cache(cache)
+    layer = cache.layers[0]
+    saved = snapshot.linear[0]
+    expected_conv = layer.conv_states.clone()
+    expected_recurrent = layer.recurrent_states.clone()
+
+    layer.conv_states.add_(1)
+    layer.recurrent_states.add_(1)
+
+    assert torch.equal(saved.conv_states, expected_conv)
+    assert torch.equal(saved.recurrent_states, expected_recurrent)
+    assert saved.has_previous_state is True
+
+
+def test_snapshot_target_cache_rejects_partial_linear_cache_contract() -> None:
+    malformed = SimpleNamespace(
+        layers=[SimpleNamespace(conv_states=torch.zeros(1))]
+    )
+
+    with pytest.raises(RuntimeError, match="unsupported transformers"):
+        dflash_module.snapshot_target_cache(malformed)

--- a/tests/python/dflash/test_route_ahead_metrics.py
+++ b/tests/python/dflash/test_route_ahead_metrics.py
@@ -291,7 +291,9 @@ def test_speculator_metrics_default_off():
     target = build_tiny_target(seed=0)
     drafter = build_tiny_drafter(target, seed=1)
     config = read_dflash_config(make_tiny_drafter_config(target.config))
-    spec = DFlashSpeculator.from_models(target, drafter, config=config, device="cpu")
+    spec = DFlashSpeculator.from_models(
+        target, drafter, config=config, device="cpu"
+    )
 
     assert spec.route_ahead_stats is None
     spec.generate(PROMPT, max_new_tokens=4, stop_token_ids=[])
@@ -303,7 +305,9 @@ def test_enable_route_ahead_stats_returns_reset_recorder():
     target = build_tiny_target(seed=0)
     drafter = build_tiny_drafter(target, seed=1)
     config = read_dflash_config(make_tiny_drafter_config(target.config))
-    spec = DFlashSpeculator.from_models(target, drafter, config=config, device="cpu")
+    spec = DFlashSpeculator.from_models(
+        target, drafter, config=config, device="cpu"
+    )
 
     stats = spec.enable_route_ahead_stats()
     assert spec.route_ahead_stats is stats
@@ -342,7 +346,9 @@ def _e2e_masks() -> dict[int, torch.Tensor]:
         [1 if j in (i % 8, (i + 3) % 8) else 0 for j in range(8)]
         for i in range(10)
     ]
-    rows_b = [[1 if j == (2 * i) % 8 else 0 for j in range(8)] for i in range(10)]
+    rows_b = [
+        [1 if j == (2 * i) % 8 else 0 for j in range(8)] for i in range(10)
+    ]
     return {
         0: torch.tensor(rows_a, dtype=torch.bool),
         2: torch.tensor(rows_b, dtype=torch.bool),
@@ -373,7 +379,10 @@ class _OffloadedExecutorShell:
     ):
         input_tensor = torch.tensor([token_ids], dtype=torch.long)
         is_prefill = _attention_metadata is None
-        kwargs: dict[str, Any] = {"use_cache": True, "output_hidden_states": True}
+        kwargs: dict[str, Any] = {
+            "use_cache": True,
+            "output_hidden_states": True,
+        }
         if logits_to_keep:
             kwargs["logits_to_keep"] = int(logits_to_keep)
         if not is_prefill:
@@ -398,7 +407,9 @@ def _offloaded_spec(*, with_stats: bool):
     prefetcher, engine = _make_real_prefetcher()
     executor = _make_executor(prefetcher=prefetcher)
     shell = _OffloadedExecutorShell(target, executor, prefetcher, _e2e_masks())
-    spec = DFlashSpeculator.from_models(shell, drafter, config=config, device="cpu")
+    spec = DFlashSpeculator.from_models(
+        shell, drafter, config=config, device="cpu"
+    )
     if with_stats:
         spec.enable_route_ahead_stats()
     return spec, engine
@@ -431,7 +442,9 @@ def test_generate_offloaded_executor_route_ahead_e2e():
 
     # Route-ahead fired on every layer of every step: perfect coverage.
     masks = _e2e_masks()
-    per_step_actual = sum(len(union_experts_from_mask(m)) for m in masks.values())
+    per_step_actual = sum(
+        len(union_experts_from_mask(m)) for m in masks.values()
+    )
     assert per_step_actual == 12
     assert stats.actual_experts == steps * per_step_actual
     assert stats.predicted_experts == stats.actual_experts
@@ -476,5 +489,7 @@ def test_generate_offloaded_metrics_match_step_trace_accepts():
     expected_kept = 0
     for rec in spec.step_trace:
         for mask in masks.values():
-            expected_kept += len(union_experts_from_mask(mask[: rec.accept + 1]))
+            expected_kept += len(
+                union_experts_from_mask(mask[: rec.accept + 1])
+            )
     assert stats.kept_experts == expected_kept

--- a/tests/python/dflash/test_route_ahead_metrics.py
+++ b/tests/python/dflash/test_route_ahead_metrics.py
@@ -1,0 +1,480 @@
+"""Unit tests for the Track A5 route-ahead coverage/waste metrics.
+
+Autonomous correctness gate for Track A5 of
+``.sisyphus/plans/dflash-deferred-tracks-plan.md`` (A0 section 4 formulas).
+Covers, all CPU-only with mocked dispatcher/archer engine:
+
+(a) coverage accounting 0 / partial / 1, driven through the real executor
+    route-ahead seam, cross-checked against the A1 ``prefetch_coverage``;
+(b) rejected-token waste accounting vs. the kept prefix (A1
+    ``rejected_expert_ids`` semantics), including clamped and vacuous edges;
+(c) default-off / zero-overhead behavior: no stats handle anywhere means no
+    recording and byte-identical legacy dispatch behavior;
+(d) aborted-step isolation (``begin_step`` drops uncommitted records);
+(e) E2E: an offloaded executor-backed MoE shell (DeepSeek/Qwen pattern --
+    rich forward whose MoE blocks call ``dispatch_local``) runs the full
+    DFlash generate loop with route-ahead firing on every verify step,
+    hitting no resident-only block (A4), with token-identical outputs and
+    identical prefetch calls whether metrics are on or off.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+)
+
+from moe_infinity.distributed.expert_executor import (  # noqa: E402
+    DistributedExpertExecutor,
+)
+from moe_infinity.memory.expert_prefetcher import ExpertPrefetcher  # noqa: E402
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+from moe_infinity.spec_decode._prefetch_route import (  # noqa: E402
+    prefetch_coverage,
+    rejected_expert_ids,
+    union_experts_from_mask,
+)
+from moe_infinity.spec_decode._route_ahead_ctx import (  # noqa: E402
+    current_stats,
+    route_ahead_context,
+)
+from moe_infinity.spec_decode._route_ahead_stats import (  # noqa: E402
+    RouteAheadStats,
+    RouteAheadStepSummary,
+)
+from moe_infinity.utils import ArcherConfig  # noqa: E402
+
+LAYER_ID = 3
+# [3 tokens, 8 experts]; the union routed by ANY token is {0, 1, 2, 5, 7};
+# the anchor-only kept prefix routes {0, 1}.
+ROUTER_MASK = torch.tensor(
+    [
+        [1, 1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 1, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 1],
+    ],
+    dtype=torch.bool,
+)
+UNION = [0, 1, 2, 5, 7]
+HIDDEN = torch.zeros(3, 4)
+WEIGHTS = torch.zeros(3, 8)
+LOGITS = torch.zeros(3, 8)
+
+PROMPT = torch.tensor([[3, 7, 11, 2, 5]])
+
+
+@pytest.fixture(autouse=True)
+def _cpu_dispatch_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "moe_infinity.distributed.expert_executor.IOProfiler", None
+    )
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+
+def _make_executor(*, overlap: bool = False, prefetcher=None):
+    config = ArcherConfig.load_from_json(
+        {
+            "offload_path": "/tmp/moe-infinity-route-ahead-metrics-test",
+            "trace_capacity": 16,
+            "prefetch": False,
+            "speculative_prefetch": True,
+            "speculative_prefetch_overlap": overlap,
+        }
+    )
+    executor = DistributedExpertExecutor(config)
+    executor.set_expert_dispatcher(MagicMock(name="ExpertDispatcher"))
+    if prefetcher is not None:
+        executor.set_prefetcher(prefetcher)
+    return executor
+
+
+def _make_real_prefetcher(num_layers: int = 8, num_experts: int = 8):
+    """A2-style real ExpertPrefetcher; tensor id = layer * 100 + expert."""
+    prefetcher = ExpertPrefetcher.__new__(ExpertPrefetcher)
+    prefetcher.num_layers = num_layers
+    prefetcher.num_experts = num_experts
+    engine = MagicMock(name="ArcherEngine")
+    engine.get_node_default_device.return_value = 0
+    prefetcher.archer_engine = engine
+    prefetcher.expert_tensor_map = {
+        (layer, expert): layer * 100 + expert
+        for layer in range(num_layers)
+        for expert in range(num_experts)
+    }
+    prefetcher._last_speculative_prediction = set()
+    return prefetcher, engine
+
+
+def _dispatch(executor, *, router_logits=None, prefetcher=None):
+    executor.dispatch_local(
+        LAYER_ID,
+        HIDDEN,
+        ROUTER_MASK,
+        WEIGHTS,
+        router_logits=router_logits,
+        prefetcher=prefetcher,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) coverage accounting: 0 / partial / 1 through the executor seam
+# ---------------------------------------------------------------------------
+
+
+def test_full_coverage_when_route_ahead_fires():
+    stats = RouteAheadStats()
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    stats.begin_step()
+    with route_ahead_context(prefetcher=prefetcher, stats=stats):
+        _dispatch(_make_executor())
+    summary = stats.commit_step(kept_rows=3)
+
+    prefetcher.fetch_experts_lock_cache.assert_called_once_with(LAYER_ID, UNION)
+    assert summary == RouteAheadStepSummary(
+        layers=1, predicted=5, actual=5, covered=5, kept=5, wasted=0
+    )
+    assert summary.coverage == prefetch_coverage(UNION, UNION) == 1.0
+    assert stats.steps == 1 and stats.layers_observed == 1
+    assert stats.coverage == 1.0
+    assert stats.waste_ratio == 0.0
+
+
+def test_zero_coverage_when_route_ahead_never_fires():
+    stats = RouteAheadStats()
+    executor = _make_executor()  # no prefetcher anywhere -> nothing prefetched
+    stats.begin_step()
+    with route_ahead_context(stats=stats):
+        _dispatch(executor)
+    summary = stats.commit_step(kept_rows=2)
+
+    assert summary.predicted == 0 and summary.actual == len(UNION)
+    assert summary.covered == 0
+    assert prefetch_coverage([], UNION) == 0.0
+    assert stats.coverage == 0.0
+    # Nothing was prefetched, so nothing can be prefetch-wasted.
+    assert stats.wasted_experts == 0 and stats.waste_ratio == 0.0
+    # The dispatch itself is untouched: legacy pending tuple preserved.
+    assert executor._pending_prefetch is not None
+    assert executor._pending_prefetch[1] == LAYER_ID
+
+
+def test_partial_coverage_when_only_some_layers_prefetch():
+    stats = RouteAheadStats()
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor()  # no context/executor prefetcher
+    stats.begin_step()
+    with route_ahead_context(stats=stats):
+        # Layer 3 fires via the per-call prefetcher argument...
+        _dispatch(executor, prefetcher=prefetcher)
+        # ...layer 4 has no prefetcher at all -> predicted set is empty.
+        executor.dispatch_local(LAYER_ID + 1, HIDDEN, ROUTER_MASK, WEIGHTS)
+    summary = stats.commit_step(kept_rows=3)
+
+    assert summary.layers == 2
+    assert summary.covered == 5 and summary.actual == 10
+    # A0 section 4 ratio-of-sums, cross-checked per layer with the A1 helper.
+    per_layer = [
+        prefetch_coverage(UNION, UNION),
+        prefetch_coverage([], UNION),
+    ]
+    assert per_layer == [1.0, 0.0]
+    assert stats.coverage == (5 + 0) / (5 + 5) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# (b) rejected-token waste accounting vs. the kept prefix
+# ---------------------------------------------------------------------------
+
+
+def test_waste_scales_with_rejected_rows():
+    stats = RouteAheadStats()
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+
+    # Full accept: kept == full union -> zero waste.
+    stats.begin_step()
+    with route_ahead_context(prefetcher=prefetcher, stats=stats):
+        _dispatch(_make_executor())
+    full = stats.commit_step(kept_rows=3)
+    assert full.wasted == 0 and stats.coverage == 1.0
+
+    # Anchor-only keep: rows 1..2 rejected -> experts {2, 5, 7} wasted.
+    stats.begin_step()
+    with route_ahead_context(prefetcher=prefetcher, stats=stats):
+        _dispatch(_make_executor())
+    part = stats.commit_step(kept_rows=1)
+    assert rejected_expert_ids(UNION, [0, 1]) == [2, 5, 7]
+    assert part.kept == 2 and part.wasted == 3
+    assert stats.wasted_experts == 3
+    assert stats.waste_ratio == 3 / 10
+    assert stats.coverage == 1.0  # waste does not dent coverage
+
+
+def test_commit_clamps_kept_rows():
+    stats = RouteAheadStats()
+    stats.begin_step()
+    stats.observe_layer(0, UNION, ROUTER_MASK)
+    over = stats.commit_step(kept_rows=99)
+    assert over.kept == len(UNION) and over.wasted == 0
+
+    stats.begin_step()
+    stats.observe_layer(0, UNION, ROUTER_MASK)
+    zero = stats.commit_step(kept_rows=0)
+    assert zero.kept == 0 and zero.wasted == len(UNION)
+
+
+def test_empty_union_dispatch_is_vacuous_noop():
+    stats = RouteAheadStats()
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    stats.begin_step()
+    with route_ahead_context(prefetcher=prefetcher, stats=stats):
+        _make_executor().dispatch_local(
+            LAYER_ID,
+            HIDDEN[:1],
+            torch.zeros(1, 8, dtype=torch.bool),
+            WEIGHTS[:1],
+        )
+    # Empty union: the pin/prefetch no-op is preserved under metrics.
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    prefetcher.speculative_prefetch.assert_not_called()
+    summary = stats.commit_step(kept_rows=1)
+    assert summary.layers == 1
+    assert summary.predicted == summary.actual == summary.wasted == 0
+    assert stats.coverage == 1.0  # nothing to cover, nothing wasted
+
+
+# ---------------------------------------------------------------------------
+# (c) default-off / zero-overhead: no handle, no recording, legacy behavior
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_context_records_and_changes_nothing():
+    stats = RouteAheadStats()
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor(overlap=True, prefetcher=prefetcher)
+
+    _dispatch(executor, router_logits=LOGITS)  # no route_ahead_context
+
+    # Legacy overlap path byte-identical (A3 gate): pooled prefetch fired...
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    assert prefetcher.speculative_prefetch.call_count == 1
+    args, kwargs = prefetcher.speculative_prefetch.call_args
+    assert args[0] == LAYER_ID and args[1] is LOGITS and not kwargs
+    # ...and the stats handle was never consulted.
+    assert stats.as_dict() == RouteAheadStats().as_dict()
+    assert stats.commit_step(kept_rows=3).layers == 0
+    assert stats.steps == 0
+
+
+def test_context_without_stats_handle_records_nothing():
+    with route_ahead_context(prefetcher=MagicMock()):
+        assert current_stats() is None
+    assert current_stats() is None
+
+
+def test_speculator_metrics_default_off():
+    target = build_tiny_target(seed=0)
+    drafter = build_tiny_drafter(target, seed=1)
+    config = read_dflash_config(make_tiny_drafter_config(target.config))
+    spec = DFlashSpeculator.from_models(target, drafter, config=config, device="cpu")
+
+    assert spec.route_ahead_stats is None
+    spec.generate(PROMPT, max_new_tokens=4, stop_token_ids=[])
+    assert spec.route_ahead_stats is None  # never implicitly created
+    assert len(spec.step_trace) >= 1
+
+
+def test_enable_route_ahead_stats_returns_reset_recorder():
+    target = build_tiny_target(seed=0)
+    drafter = build_tiny_drafter(target, seed=1)
+    config = read_dflash_config(make_tiny_drafter_config(target.config))
+    spec = DFlashSpeculator.from_models(target, drafter, config=config, device="cpu")
+
+    stats = spec.enable_route_ahead_stats()
+    assert spec.route_ahead_stats is stats
+    assert stats.as_dict() == RouteAheadStats().as_dict()
+    stats.steps = 99
+    assert spec.enable_route_ahead_stats() is stats
+    assert stats.steps == 0
+
+
+# ---------------------------------------------------------------------------
+# (d) aborted-step isolation
+# ---------------------------------------------------------------------------
+
+
+def test_begin_step_drops_uncommitted_records():
+    stats = RouteAheadStats()
+    stats.begin_step()
+    stats.observe_layer(0, UNION, ROUTER_MASK)
+    stats.begin_step()  # prior step aborted before commit: discarded
+    assert stats.commit_step(kept_rows=1).layers == 0
+    assert stats.as_dict() == RouteAheadStats().as_dict()
+
+
+# ---------------------------------------------------------------------------
+# (e) E2E: offloaded executor-backed shell through the full generate loop
+# ---------------------------------------------------------------------------
+
+
+def _e2e_masks() -> dict[int, torch.Tensor]:
+    """Two synthetic MoE layers, 10 block rows x 8 experts.
+
+    Layer 0 routes rows {i%8, (i+3)%8} (full union = all 8 experts); layer 2
+    routes {(2i)%8} (full union = {0, 2, 4, 6}).
+    """
+    rows_a = [
+        [1 if j in (i % 8, (i + 3) % 8) else 0 for j in range(8)]
+        for i in range(10)
+    ]
+    rows_b = [[1 if j == (2 * i) % 8 else 0 for j in range(8)] for i in range(10)]
+    return {
+        0: torch.tensor(rows_a, dtype=torch.bool),
+        2: torch.tensor(rows_b, dtype=torch.bool),
+    }
+
+
+class _OffloadedExecutorShell:
+    """MoE-engine shell for the offloaded executor-backed path (A4).
+
+    Mirrors ``big_modeling._native_model_forward_rich`` plus the DeepSeek/
+    Qwen/Mixtral MoE-block pattern: on verify forwards each block routes its
+    tokens and calls ``DistributedExpertExecutor.dispatch_local`` with its
+    router mask (with fixed synthetic masks so the A5 accounting is exactly
+    checkable). ``engine.expert_prefetcher`` is a real ExpertPrefetcher over
+    a mocked archer engine -- i.e. the offloaded configuration, the exact
+    setup a resident-only guard would have blocked.
+    """
+
+    def __init__(self, target, executor, prefetcher, layer_masks):
+        self.model = target
+        self.engine = SimpleNamespace(expert_prefetcher=prefetcher)
+        self._executor = executor
+        self._layer_masks = layer_masks
+        self._cached_past_key_values = None
+
+    def _native_model_forward_rich(
+        self, token_ids, _attention_metadata=None, logits_to_keep=0
+    ):
+        input_tensor = torch.tensor([token_ids], dtype=torch.long)
+        is_prefill = _attention_metadata is None
+        kwargs: dict[str, Any] = {"use_cache": True, "output_hidden_states": True}
+        if logits_to_keep:
+            kwargs["logits_to_keep"] = int(logits_to_keep)
+        if not is_prefill:
+            kwargs["past_key_values"] = self._cached_past_key_values
+        outputs = self.model(input_tensor, **kwargs)
+        self._cached_past_key_values = outputs.past_key_values
+        if not is_prefill:
+            num_tokens = len(token_ids)
+            hidden = torch.zeros(num_tokens, 4)
+            for layer_id, mask in self._layer_masks.items():
+                self._executor.dispatch_local(
+                    layer_id, hidden, mask, mask.to(torch.float32)
+                )
+                self._executor.wait_dispatch_local()
+        return outputs.logits, outputs.hidden_states, outputs.past_key_values
+
+
+def _offloaded_spec(*, with_stats: bool):
+    target = build_tiny_target(seed=0)
+    drafter = build_tiny_drafter(target, seed=1)
+    config = read_dflash_config(make_tiny_drafter_config(target.config))
+    prefetcher, engine = _make_real_prefetcher()
+    executor = _make_executor(prefetcher=prefetcher)
+    shell = _OffloadedExecutorShell(target, executor, prefetcher, _e2e_masks())
+    spec = DFlashSpeculator.from_models(shell, drafter, config=config, device="cpu")
+    if with_stats:
+        spec.enable_route_ahead_stats()
+    return spec, engine
+
+
+def test_generate_offloaded_executor_route_ahead_e2e():
+    spec_on, engine_on = _offloaded_spec(with_stats=True)
+    spec_off, engine_off = _offloaded_spec(with_stats=False)
+
+    out_on = spec_on.generate(PROMPT, max_new_tokens=25, stop_token_ids=[])
+    out_off = spec_off.generate(PROMPT, max_new_tokens=25, stop_token_ids=[])
+
+    # Metrics + prefetch are read-only observers: token-identical outputs...
+    assert torch.equal(out_on, out_off)
+    # ...and byte-identical prefetch behavior with metrics on vs. off.
+    assert (
+        engine_on.replace_cache_candidates.call_args_list
+        == engine_off.replace_cache_candidates.call_args_list
+    )
+    assert (
+        engine_on.enqueue_prefetch.call_args_list
+        == engine_off.enqueue_prefetch.call_args_list
+    )
+
+    stats = spec_on.route_ahead_stats
+    assert stats is not None and spec_off.route_ahead_stats is None
+    steps = len(spec_on.step_trace)
+    assert stats.steps == steps and steps >= 2
+    assert stats.layers_observed == steps * 2
+
+    # Route-ahead fired on every layer of every step: perfect coverage.
+    masks = _e2e_masks()
+    per_step_actual = sum(len(union_experts_from_mask(m)) for m in masks.values())
+    assert per_step_actual == 12
+    assert stats.actual_experts == steps * per_step_actual
+    assert stats.predicted_experts == stats.actual_experts
+    assert stats.covered_experts == stats.actual_experts
+    assert stats.coverage == 1.0
+
+    # Rejected-token waste, recomputed independently from the kept prefixes
+    # the accept rule committed (step_trace.accept + 1 block rows).
+    expected_waste = 0
+    for rec in spec_on.step_trace:
+        kept_rows = rec.accept + 1
+        for mask in masks.values():
+            full_union = union_experts_from_mask(mask)
+            kept_union = union_experts_from_mask(mask[:kept_rows])
+            expected_waste += len(rejected_expert_ids(full_union, kept_union))
+    assert stats.wasted_experts == expected_waste
+    assert 0.0 <= stats.waste_ratio <= 1.0
+
+    # A4 guard: every pin targeted exactly ONE layer, alternating between
+    # the shell's two MoE layers -- never a cross-layer batched pin.
+    pin_calls = engine_on.replace_cache_candidates.call_args_list
+    assert len(pin_calls) == steps * 2
+    pinned_layers = []
+    for call in pin_calls:
+        layers = {tensor_id // 100 for tensor_id in call.args[0]}
+        assert len(layers) == 1
+        pinned_layers.append(next(iter(layers)))
+    assert pinned_layers == [0, 2] * steps
+
+
+def test_generate_offloaded_metrics_match_step_trace_accepts():
+    spec, _engine = _offloaded_spec(with_stats=True)
+    spec.generate(PROMPT, max_new_tokens=12, stop_token_ids=[])
+
+    stats = spec.route_ahead_stats
+    assert stats is not None
+    # Every committed verify step was observed exactly once per MoE layer.
+    assert stats.steps == len(spec.step_trace)
+    assert stats.layers_observed == 2 * stats.steps
+    # kept_experts aggregates the kept-prefix union sizes of both layers.
+    masks = _e2e_masks()
+    expected_kept = 0
+    for rec in spec.step_trace:
+        for mask in masks.values():
+            expected_kept += len(union_experts_from_mask(mask[: rec.accept + 1]))
+    assert stats.kept_experts == expected_kept

--- a/tests/python/dflash/test_route_ahead_wire.py
+++ b/tests/python/dflash/test_route_ahead_wire.py
@@ -1,0 +1,465 @@
+"""Unit tests for the Track A3 route-ahead wire (DFlash verify prefetch).
+
+Autonomous correctness gate for Track A3 of
+``.sisyphus/plans/dflash-deferred-tracks-plan.md``. Covers:
+
+(a) context ACTIVE -> ``dispatch_local`` derives the ACTUAL routed union via
+    the A1 helper and invokes the A2 explicit-set
+    ``speculative_prefetch(layer_id, expert_ids=union, prefetch_layer_id=
+    layer_id)``, pinned via ``fetch_experts_lock_cache`` BEFORE any
+    ``enqueue_expert`` read (A0 section 2 ordering), with the legacy
+    mean/topk pooled prefetch suppressed (A0 section 3);
+(b) context INACTIVE -> no pin, no explicit prefetch, and the legacy
+    overlap/deferred paths behave exactly as pre-A3 (byte-identical);
+(c) the context manager resets even when the wrapped verify call raises
+    (try/finally token reset), restores nested handles, and isolates threads;
+(d) ``DFlashSpeculator._verify_target_block`` activates the context around
+    the verify forward and resolves the prefetcher from the MoE offload
+    engine, defaulting to ``None`` (executor fallback / resident no-op);
+(e) Track A4 offload coupling: consecutive dispatches pin exactly ONE layer
+    each (the global ``ReplaceCacheCandidates`` guard), and gpt-oss's
+    resident ``SyncGptOssMLP`` loop never reaches the route-ahead seam at
+    all -- the structural exclusion (model_offload.py:954), not an
+    assertion, is what keeps it force-resident.
+
+Construction mirrors ``test_speculative_prefetch.py`` (A2) and
+``tests/python/unit/test_distributed_smoke.py``: real Python objects with
+mocked dispatcher/archer engine, CPU-only, no native extension.
+"""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from moe_infinity.distributed.expert_executor import DistributedExpertExecutor
+from moe_infinity.memory.expert_prefetcher import ExpertPrefetcher
+from moe_infinity.spec_decode._route_ahead_ctx import (
+    current_prefetcher,
+    is_active,
+    route_ahead_context,
+)
+from moe_infinity.spec_decode.dflash import DFlashSpeculator
+from moe_infinity.utils import ArcherConfig
+
+LAYER_ID = 3
+# [3 tokens, 8 experts]; the union routed by ANY token is {0, 1, 2, 5, 7}.
+ROUTER_MASK = torch.tensor(
+    [
+        [1, 1, 0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 1, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 1],
+    ],
+    dtype=torch.bool,
+)
+UNION = [0, 1, 2, 5, 7]
+HIDDEN = torch.zeros(3, 4)
+WEIGHTS = torch.zeros(3, 8)
+LOGITS = torch.zeros(3, 8)
+
+
+@pytest.fixture(autouse=True)
+def _cpu_dispatch_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        "moe_infinity.distributed.expert_executor.IOProfiler", None
+    )
+    monkeypatch.setattr(torch.cuda, "device_count", lambda: 1)
+
+
+def _make_executor(*, overlap: bool = False, prefetcher=None):
+    config = ArcherConfig.load_from_json(
+        {
+            "offload_path": "/tmp/moe-infinity-route-ahead-test",
+            "trace_capacity": 16,
+            "prefetch": False,
+            "speculative_prefetch": True,
+            "speculative_prefetch_overlap": overlap,
+        }
+    )
+    executor = DistributedExpertExecutor(config)
+    executor.set_expert_dispatcher(MagicMock(name="ExpertDispatcher"))
+    if prefetcher is not None:
+        executor.set_prefetcher(prefetcher)
+    return executor
+
+
+def _make_real_prefetcher(num_layers: int = 8, num_experts: int = 8):
+    """A2-style real ExpertPrefetcher; tensor id = layer * 100 + expert."""
+    prefetcher = ExpertPrefetcher.__new__(ExpertPrefetcher)
+    prefetcher.num_layers = num_layers
+    prefetcher.num_experts = num_experts
+    engine = MagicMock(name="ArcherEngine")
+    engine.get_node_default_device.return_value = 0
+    prefetcher.archer_engine = engine
+    prefetcher.expert_tensor_map = {
+        (layer, expert): layer * 100 + expert
+        for layer in range(num_layers)
+        for expert in range(num_experts)
+    }
+    prefetcher._last_speculative_prediction = set()
+    return prefetcher, engine
+
+
+def _dispatch(executor, *, router_logits=None, prefetcher=None):
+    executor.dispatch_local(
+        LAYER_ID,
+        HIDDEN,
+        ROUTER_MASK,
+        WEIGHTS,
+        router_logits=router_logits,
+        prefetcher=prefetcher,
+    )
+
+
+def _enqueued_experts(executor) -> list[int]:
+    return sorted(
+        c.args[1]
+        for c in executor.expert_dispatcher.enqueue_expert.call_args_list
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) context active -> exact-union pin + prefetch for the current layer
+# ---------------------------------------------------------------------------
+
+
+def test_active_context_prefetches_exact_union_for_current_layer():
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor(overlap=True)
+    events = []
+    prefetcher.fetch_experts_lock_cache.side_effect = (
+        lambda layer, ids: events.append(("lock", layer, list(ids)))
+    )
+    prefetcher.speculative_prefetch.side_effect = (
+        lambda layer, **kw: events.append(("prefetch", layer, kw))
+    )
+    executor.expert_dispatcher.enqueue_expert.side_effect = (
+        lambda layer, expert, gpu, remote: events.append(("enqueue", expert))
+    )
+
+    with route_ahead_context(prefetcher=prefetcher):
+        _dispatch(executor, router_logits=LOGITS)
+    assert not is_active()
+
+    prefetcher.fetch_experts_lock_cache.assert_called_once_with(LAYER_ID, UNION)
+    prefetcher.speculative_prefetch.assert_called_once_with(
+        LAYER_ID, expert_ids=UNION, prefetch_layer_id=LAYER_ID
+    )
+    first_read = next(i for i, e in enumerate(events) if e[0] == "enqueue")
+    assert events.index(("lock", LAYER_ID, UNION)) < first_read
+    assert (
+        next(i for i, e in enumerate(events) if e[0] == "prefetch")
+        < first_read
+    )
+    # Routing untouched: exactly the union experts are dispatched to compute.
+    assert [e[1] for e in events if e[0] == "enqueue"] == UNION
+    # A0 section 3: legacy pooled prediction suppressed for this dispatch.
+    assert executor._pending_prefetch == (None, LAYER_ID, UNION, None)
+
+
+def test_active_context_falls_back_to_executor_prefetcher():
+    prefetcher, engine = _make_real_prefetcher()
+    executor = _make_executor(overlap=True, prefetcher=prefetcher)
+    trigger_spy = MagicMock(wraps=executor.trigger_speculative_prefetch)
+    executor.trigger_speculative_prefetch = trigger_spy
+
+    with route_ahead_context():
+        _dispatch(executor, router_logits=LOGITS)
+
+    engine.replace_cache_candidates.assert_called_once_with(
+        [300, 301, 302, 305, 307]
+    )
+    assert [
+        c.args[0] for c in engine.enqueue_prefetch.call_args_list
+    ] == [300, 301, 302, 305, 307]
+    assert prefetcher._last_speculative_prediction == set(UNION)
+    trigger_spy.assert_not_called()
+    assert executor._pending_prefetch == (prefetcher, LAYER_ID, UNION, None)
+
+    # The pending correct_prefetch(layer+1, expert_list) no-ops because the
+    # recorded prediction IS the actual union; nothing further is enqueued.
+    executor.wait_dispatch_local()
+    engine.replace_cache_candidates.assert_called_once()
+    assert [
+        c.args[0] for c in engine.enqueue_prefetch.call_args_list
+    ] == [300, 301, 302, 305, 307]
+    assert prefetcher._last_speculative_prediction == set()
+
+
+def test_active_context_prefetcher_arg_wins_over_context_handle():
+    arg_prefetcher = MagicMock(name="ArgPrefetcher")
+    ctx_prefetcher = MagicMock(name="CtxPrefetcher")
+    self_prefetcher = MagicMock(name="SelfPrefetcher")
+    executor = _make_executor(prefetcher=self_prefetcher)
+
+    with route_ahead_context(prefetcher=ctx_prefetcher):
+        _dispatch(executor, prefetcher=arg_prefetcher)
+
+    arg_prefetcher.fetch_experts_lock_cache.assert_called_once_with(
+        LAYER_ID, UNION
+    )
+    arg_prefetcher.speculative_prefetch.assert_called_once_with(
+        LAYER_ID, expert_ids=UNION, prefetch_layer_id=LAYER_ID
+    )
+    ctx_prefetcher.fetch_experts_lock_cache.assert_not_called()
+    self_prefetcher.fetch_experts_lock_cache.assert_not_called()
+
+
+def test_active_context_without_any_prefetcher_is_noop():
+    executor = _make_executor(overlap=True)
+
+    with route_ahead_context():
+        _dispatch(executor, router_logits=LOGITS)
+
+    # Resident mode: nothing pinned/prefetched, legacy flow untouched.
+    assert _enqueued_experts(executor) == UNION
+    assert executor._pending_prefetch is not None
+    assert executor._pending_prefetch[3] is LOGITS
+
+
+def test_active_context_empty_union_skips_pin():
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor(prefetcher=prefetcher)
+
+    with route_ahead_context():
+        executor.dispatch_local(
+            LAYER_ID,
+            HIDDEN[:1],
+            torch.zeros(1, 8, dtype=torch.bool),
+            WEIGHTS[:1],
+        )
+
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    prefetcher.speculative_prefetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (b) context inactive -> legacy paths byte-identical to pre-A3
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_context_overlap_path_byte_identical():
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor(overlap=True, prefetcher=prefetcher)
+    trigger_spy = MagicMock(wraps=executor.trigger_speculative_prefetch)
+    executor.trigger_speculative_prefetch = trigger_spy
+
+    _dispatch(executor, router_logits=LOGITS)
+
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    assert prefetcher.speculative_prefetch.call_count == 1
+    args, kwargs = prefetcher.speculative_prefetch.call_args
+    assert args[0] == LAYER_ID and args[1] is LOGITS and not kwargs
+    trigger_spy.assert_called_once()
+    assert executor._pending_prefetch == (prefetcher, LAYER_ID, UNION, None)
+
+
+def test_inactive_context_deferred_legacy_path_byte_identical():
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor(overlap=False, prefetcher=prefetcher)
+
+    _dispatch(executor, router_logits=LOGITS)
+
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    prefetcher.speculative_prefetch.assert_not_called()
+    pending = executor._pending_prefetch
+    assert pending is not None and pending[3] is LOGITS
+
+    executor.wait_dispatch_local()
+    prefetcher.correct_prefetch.assert_called_once_with(LAYER_ID + 1, UNION)
+    assert prefetcher.speculative_prefetch.call_count == 1
+    args, kwargs = prefetcher.speculative_prefetch.call_args
+    assert args[0] == LAYER_ID and args[1] is LOGITS and not kwargs
+
+
+def test_inactive_context_without_router_logits_makes_no_prefetch_calls():
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    executor = _make_executor(overlap=False, prefetcher=prefetcher)
+
+    _dispatch(executor)
+    executor.wait_dispatch_local()
+
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    prefetcher.speculative_prefetch.assert_not_called()
+    # Pre-A3 behavior: correction still fires from the pending tuple.
+    prefetcher.correct_prefetch.assert_called_once_with(LAYER_ID + 1, UNION)
+
+
+# ---------------------------------------------------------------------------
+# (c) context manager semantics: default off, exception-safe, scoped
+# ---------------------------------------------------------------------------
+
+
+def test_context_default_inactive_and_set_clear():
+    handle = object()
+    assert not is_active() and current_prefetcher() is None
+    with route_ahead_context(prefetcher=handle):
+        assert is_active() and current_prefetcher() is handle
+    assert not is_active() and current_prefetcher() is None
+
+
+def test_context_resets_after_exception():
+    with pytest.raises(RuntimeError, match="verify boom"):
+        with route_ahead_context(prefetcher=object()):
+            assert is_active()
+            raise RuntimeError("verify boom")
+    assert not is_active() and current_prefetcher() is None
+
+
+def test_context_nested_restores_outer_handle():
+    outer, inner = object(), object()
+    with route_ahead_context(prefetcher=outer):
+        with route_ahead_context(prefetcher=inner):
+            assert current_prefetcher() is inner
+        assert is_active() and current_prefetcher() is outer
+    assert not is_active() and current_prefetcher() is None
+
+
+def test_context_does_not_leak_into_new_thread():
+    observed = []
+
+    def worker():
+        observed.append(is_active())
+
+    with route_ahead_context():
+        thread = threading.Thread(target=worker)
+        thread.start()
+        thread.join()
+    assert observed == [False]
+
+
+# ---------------------------------------------------------------------------
+# (d) speculator seam: verify forward runs under the context
+# ---------------------------------------------------------------------------
+
+
+def _make_speculator(moe) -> DFlashSpeculator:
+    speculator = DFlashSpeculator.__new__(DFlashSpeculator)
+    speculator.moe = moe
+    return speculator
+
+
+def test_verify_target_block_activates_context_with_engine_prefetcher():
+    handle = object()
+    speculator = _make_speculator(
+        SimpleNamespace(engine=SimpleNamespace(expert_prefetcher=handle))
+    )
+    observed = []
+    logits = torch.zeros(1, 2, 5)
+
+    def fake_forward(
+        input_ids: torch.Tensor,
+        past_key_values: object = None,
+        logits_to_keep: int = 0,
+    ) -> tuple[torch.Tensor, object, object]:
+        observed.append((is_active(), current_prefetcher(), logits_to_keep))
+        return logits, "hidden", past_key_values
+
+    speculator._forward_target = fake_forward
+    block = torch.zeros(1, 2, dtype=torch.long)
+    out = speculator._verify_target_block(block, "kv")
+    assert observed == [(True, handle, 0)]
+    assert out[0] is logits and out[1:] == ("hidden", "kv")
+    assert not is_active() and current_prefetcher() is None
+
+
+def test_verify_target_block_resets_context_on_forward_error():
+    speculator = _make_speculator(SimpleNamespace())
+
+    def boom(
+        input_ids: torch.Tensor,
+        past_key_values: object = None,
+        logits_to_keep: int = 0,
+    ) -> tuple[torch.Tensor, object, object]:
+        assert is_active()
+        raise RuntimeError("verify boom")
+
+    speculator._forward_target = boom
+    with pytest.raises(RuntimeError, match="verify boom"):
+        speculator._verify_target_block(torch.zeros(1, 2, dtype=torch.long), "kv")
+    assert not is_active() and current_prefetcher() is None
+
+
+def test_resolve_route_ahead_prefetcher_without_engine_is_none():
+    speculator = _make_speculator(SimpleNamespace())
+    assert speculator._resolve_route_ahead_prefetcher() is None
+
+
+# ---------------------------------------------------------------------------
+# (e) Track A4 offload coupling: single-layer pin guard + gpt-oss exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_consecutive_dispatches_each_pin_exactly_one_layer():
+    """A4 guard: pins must never batch layers -- ``ReplaceCacheCandidates``
+    is global and clears the background prefetch queues, so a cross-layer pin
+    would evict candidates the next layer's dispatch still needs. Two
+    dispatches in one verify context -> two single-layer pins, in order."""
+    prefetcher, engine = _make_real_prefetcher()
+    executor = _make_executor(prefetcher=prefetcher)
+
+    with route_ahead_context():
+        _dispatch(executor)
+        executor.wait_dispatch_local()
+        executor.dispatch_local(LAYER_ID + 1, HIDDEN, ROUTER_MASK, WEIGHTS)
+        executor.wait_dispatch_local()
+
+    pin_calls = engine.replace_cache_candidates.call_args_list
+    assert len(pin_calls) == 2
+    assert pin_calls[0].args[0] == [300, 301, 302, 305, 307]
+    assert pin_calls[1].args[0] == [400, 401, 402, 405, 407]
+    # No call ever mixes tensor ids from two layers (id = layer * 100 + e).
+    for call in pin_calls:
+        assert len({tensor_id // 100 for tensor_id in call.args[0]}) == 1
+    # Enqueues stay per-layer single-layered as well.
+    assert [
+        call.args[0] for call in engine.enqueue_prefetch.call_args_list
+    ] == [300, 301, 302, 305, 307, 400, 401, 402, 405, 407]
+
+
+def test_gpt_oss_resident_loop_never_reaches_route_ahead_seam():
+    """A4: gpt-oss is excluded STRUCTURALLY, not by a resident-only assert.
+
+    ``model_offload.py:954`` never wires an ``expert_executor`` into
+    ``SyncGptOssMLP`` (and ``parse_expert_id`` yields no per-expert ids for
+    it, hf_config.py:216-223), so its forward runs the resident Python
+    expert loop: even under an active route-ahead context with a bound
+    prefetcher and an A5 stats handle, nothing is pinned, prefetched, or
+    observed. This is the offload-coupling boundary: DeepSeek/Qwen/Mixtral
+    blocks reach the seam through ``dispatch_local``; gpt-oss cannot.
+    """
+    from moe_infinity.models.gpt_oss import SyncGptOssMLP
+    from moe_infinity.spec_decode._route_ahead_stats import RouteAheadStats
+
+    torch.manual_seed(0)
+    module = SyncGptOssMLP(
+        SimpleNamespace(
+            hidden_size=16,
+            intermediate_size=8,
+            num_local_experts=4,
+            num_experts_per_tok=2,
+        )
+    )
+    for param in module.parameters():
+        torch.nn.init.normal_(param, std=0.02)
+    module.eval()
+    # The model_offload wiring gate: gpt-oss is never given an executor.
+    assert module.expert_executor is None
+
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    stats = RouteAheadStats()
+    stats.begin_step()
+    with torch.no_grad():
+        with route_ahead_context(prefetcher=prefetcher, stats=stats):
+            final_hidden, router_logits = module(torch.randn(1, 3, 16))
+
+    assert final_hidden.shape == (1, 3, 16)
+    assert router_logits.shape == (3, 4)
+    prefetcher.fetch_experts_lock_cache.assert_not_called()
+    prefetcher.speculative_prefetch.assert_not_called()
+    assert stats.commit_step(kept_rows=1).layers == 0
+    assert stats.as_dict() == RouteAheadStats().as_dict()

--- a/tests/python/dflash/test_route_ahead_wire.py
+++ b/tests/python/dflash/test_route_ahead_wire.py
@@ -152,8 +152,7 @@ def test_active_context_prefetches_exact_union_for_current_layer():
     first_read = next(i for i, e in enumerate(events) if e[0] == "enqueue")
     assert events.index(("lock", LAYER_ID, UNION)) < first_read
     assert (
-        next(i for i, e in enumerate(events) if e[0] == "prefetch")
-        < first_read
+        next(i for i, e in enumerate(events) if e[0] == "prefetch") < first_read
     )
     # Routing untouched: exactly the union experts are dispatched to compute.
     assert [e[1] for e in events if e[0] == "enqueue"] == UNION
@@ -173,9 +172,13 @@ def test_active_context_falls_back_to_executor_prefetcher():
     engine.replace_cache_candidates.assert_called_once_with(
         [300, 301, 302, 305, 307]
     )
-    assert [
-        c.args[0] for c in engine.enqueue_prefetch.call_args_list
-    ] == [300, 301, 302, 305, 307]
+    assert [c.args[0] for c in engine.enqueue_prefetch.call_args_list] == [
+        300,
+        301,
+        302,
+        305,
+        307,
+    ]
     assert prefetcher._last_speculative_prediction == set(UNION)
     trigger_spy.assert_not_called()
     assert executor._pending_prefetch == (prefetcher, LAYER_ID, UNION, None)
@@ -184,9 +187,13 @@ def test_active_context_falls_back_to_executor_prefetcher():
     # recorded prediction IS the actual union; nothing further is enqueued.
     executor.wait_dispatch_local()
     engine.replace_cache_candidates.assert_called_once()
-    assert [
-        c.args[0] for c in engine.enqueue_prefetch.call_args_list
-    ] == [300, 301, 302, 305, 307]
+    assert [c.args[0] for c in engine.enqueue_prefetch.call_args_list] == [
+        300,
+        301,
+        302,
+        305,
+        307,
+    ]
     assert prefetcher._last_speculative_prediction == set()
 
 
@@ -380,7 +387,9 @@ def test_verify_target_block_resets_context_on_forward_error():
 
     speculator._forward_target = boom
     with pytest.raises(RuntimeError, match="verify boom"):
-        speculator._verify_target_block(torch.zeros(1, 2, dtype=torch.long), "kv")
+        speculator._verify_target_block(
+            torch.zeros(1, 2, dtype=torch.long), "kv"
+        )
     assert not is_active() and current_prefetcher() is None
 
 

--- a/tests/python/dflash/test_route_ahead_wire.py
+++ b/tests/python/dflash/test_route_ahead_wire.py
@@ -17,10 +17,9 @@ Autonomous correctness gate for Track A3 of
     the verify forward and resolves the prefetcher from the MoE offload
     engine, defaulting to ``None`` (executor fallback / resident no-op);
 (e) Track A4 offload coupling: consecutive dispatches pin exactly ONE layer
-    each (the global ``ReplaceCacheCandidates`` guard), and gpt-oss's
-    resident ``SyncGptOssMLP`` loop never reaches the route-ahead seam at
-    all -- the structural exclusion (model_offload.py:954), not an
-    assertion, is what keeps it force-resident.
+    each (the global ``ReplaceCacheCandidates`` guard), while gpt-oss's
+    force-resident ``SyncGptOssMLP`` loop reports read-only route-ahead
+    metrics without pinning or prefetching resident experts.
 
 Construction mirrors ``test_speculative_prefetch.py`` (A2) and
 ``tests/python/unit/test_distributed_smoke.py``: real Python objects with
@@ -362,6 +361,9 @@ def test_verify_target_block_activates_context_with_engine_prefetcher():
         input_ids: torch.Tensor,
         past_key_values: object = None,
         logits_to_keep: int = 0,
+        *,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, object, object]:
         observed.append((is_active(), current_prefetcher(), logits_to_keep))
         return logits, "hidden", past_key_values
@@ -381,6 +383,9 @@ def test_verify_target_block_resets_context_on_forward_error():
         input_ids: torch.Tensor,
         past_key_values: object = None,
         logits_to_keep: int = 0,
+        *,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, object, object]:
         assert is_active()
         raise RuntimeError("verify boom")
@@ -430,19 +435,8 @@ def test_consecutive_dispatches_each_pin_exactly_one_layer():
     ] == [300, 301, 302, 305, 307, 400, 401, 402, 405, 407]
 
 
-def test_gpt_oss_resident_loop_never_reaches_route_ahead_seam():
-    """A4: gpt-oss is excluded STRUCTURALLY, not by a resident-only assert.
-
-    ``model_offload.py:954`` never wires an ``expert_executor`` into
-    ``SyncGptOssMLP`` (and ``parse_expert_id`` yields no per-expert ids for
-    it, hf_config.py:216-223), so its forward runs the resident Python
-    expert loop: even under an active route-ahead context with a bound
-    prefetcher and an A5 stats handle, nothing is pinned, prefetched, or
-    observed. This is the offload-coupling boundary: DeepSeek/Qwen/Mixtral
-    blocks reach the seam through ``dispatch_local``; gpt-oss cannot.
-    """
+def _make_gpt_oss_mlp():
     from moe_infinity.models.gpt_oss import SyncGptOssMLP
-    from moe_infinity.spec_decode._route_ahead_stats import RouteAheadStats
 
     torch.manual_seed(0)
     module = SyncGptOssMLP(
@@ -456,8 +450,16 @@ def test_gpt_oss_resident_loop_never_reaches_route_ahead_seam():
     for param in module.parameters():
         torch.nn.init.normal_(param, std=0.02)
     module.eval()
-    # The model_offload wiring gate: gpt-oss is never given an executor.
+    module.layer_id = LAYER_ID
     assert module.expert_executor is None
+    return module
+
+
+def test_gpt_oss_resident_loop_observes_route_ahead_metrics():
+    """A2: resident gpt-oss reports its exact routed union as already covered."""
+    from moe_infinity.spec_decode._route_ahead_stats import RouteAheadStats
+
+    module = _make_gpt_oss_mlp()
 
     prefetcher = MagicMock(name="ExpertPrefetcher")
     stats = RouteAheadStats()
@@ -470,5 +472,29 @@ def test_gpt_oss_resident_loop_never_reaches_route_ahead_seam():
     assert router_logits.shape == (3, 4)
     prefetcher.fetch_experts_lock_cache.assert_not_called()
     prefetcher.speculative_prefetch.assert_not_called()
+    summary = stats.commit_step(kept_rows=1)
+    assert summary.layers == 1
+    assert stats.steps > 0
+    assert stats.layers_observed > 0
+    assert stats.coverage == 1.0
+
+
+def test_gpt_oss_resident_loop_does_not_observe_when_context_inactive(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Spec-off decode must return before resolving or updating metrics."""
+    from moe_infinity.spec_decode import _route_ahead_ctx as route_ahead_ctx
+    from moe_infinity.spec_decode._route_ahead_stats import RouteAheadStats
+
+    module = _make_gpt_oss_mlp()
+    stats = RouteAheadStats()
+    stats.begin_step()
+    current_stats = MagicMock(return_value=stats)
+    monkeypatch.setattr(route_ahead_ctx, "current_stats", current_stats)
+
+    with torch.no_grad():
+        module(torch.randn(1, 3, 16))
+
+    current_stats.assert_not_called()
     assert stats.commit_step(kept_rows=1).layers == 0
     assert stats.as_dict() == RouteAheadStats().as_dict()

--- a/tests/python/dflash/test_sampled_spec.py
+++ b/tests/python/dflash/test_sampled_spec.py
@@ -1,0 +1,555 @@
+"""Track B: sampled (non-greedy) DFlash -- lossless speculative sampling.
+
+Three autonomous gates, all CPU-only on the tiny fixtures:
+
+(a) Hand-checked unit tests for the pure ops in ``_dflash_sample_ops`` --
+    warp order (temperature -> top-k -> top-p, mirroring the engine sampler),
+    residual renorm, accept/reject boundaries, and seed determinism.
+(b) Distributional parity: over many seeds, the sampled-DFlash token
+    histograms (per position and pooled) match a plain sampled target driven
+    by an INDEPENDENT reference sampler, within KL/TVD tolerance. The seeds
+    are fixed, so the measured values -- and hence the gates -- are
+    deterministic; tolerances carry ~2x headroom over the measured values.
+(c) Greedy regression: ``temperature == 0`` stays token-identical to plain
+    greedy (the v1 contract), even when top_k/top_p are set.
+
+The accept rule under test is per-slot rejection sampling with residual
+correction against the target's true conditionals (see the
+``_dflash_sample_ops`` module docstring for the losslessness proof): the
+block-parallel proposal only needs each draft to be a genuine draw from its
+own warped slot distribution ``Q_i``; the lemma of Leviathan et al. then
+makes every committed token an exact draw from the warped target ``P_i``.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from fixtures_tiny import (  # noqa: E402
+    TinyDFlashDrafter,
+    build_tiny_drafter,
+    build_tiny_target,
+    make_tiny_drafter_config,
+    plain_greedy_decode,
+    set_determinism,
+)
+
+from moe_infinity.spec_decode import (  # noqa: E402
+    DFlashSpeculator,
+    read_dflash_config,
+)
+from moe_infinity.spec_decode._dflash_sample_ops import (  # noqa: E402
+    acceptance_sampled,
+    committed_tokens_sampled,
+    residual_distribution,
+    warped_probs,
+)
+
+PROMPT = torch.tensor([[3, 7, 11, 2, 5]])
+PROMPT_LEN = int(PROMPT.shape[1])
+
+# Parity fixtures use a smaller vocab than the TINY_VOCAB=64 default: the
+# histogram-TV error of a multinomial empirical distribution scales like
+# O(sqrt(vocab / n)), so 16 ids with n~thousands gives sharp tolerances at
+# CPU runtime cost. The mask id must then live inside the small vocab.
+PARITY_VOCAB = 16
+PARITY_MASK_ID = PARITY_VOCAB - 1
+PARITY_MAX_NEW = 8
+
+
+# ---------------------------------------------------------------------------
+# (a) Hand-checked unit tests for the pure ops
+# ---------------------------------------------------------------------------
+
+
+def test_warped_probs_temperature_scales_before_softmax():
+    logits = torch.tensor([[2.0, 1.0, 0.0, -1.0]])
+    probs = warped_probs(logits, temperature=2.0)
+    expected = F.softmax(logits / 2.0, dim=-1)
+    assert torch.allclose(probs, expected, atol=1e-7)
+    assert math.isclose(float(probs.sum()), 1.0, abs_tol=1e-6)
+
+
+def test_warped_probs_top_k_keeps_exactly_k():
+    logits = torch.tensor([[4.0, 3.0, 2.0, 1.0, 0.0]])
+    probs = warped_probs(logits, temperature=1.0, top_k=2)
+    nz = torch.nonzero(probs[0] > 0).flatten().tolist()
+    assert nz == [0, 1]
+    expected = F.softmax(torch.tensor([4.0, 3.0]), dim=-1)
+    assert torch.allclose(probs[0, :2], expected, atol=1e-7)
+    assert math.isclose(float(probs.sum()), 1.0, abs_tol=1e-6)
+
+
+def test_warped_probs_top_p_engine_convention_hand_checked():
+    # Engine convention (``GenerationEngine._sample``): drop every token whose
+    # cumulative mass EXCEEDS top_p, always keeping the top token.
+    logits = torch.tensor([[4.0, 3.0, 2.0, 1.0, 0.0]])
+    z = math.exp(4) + math.exp(3) + math.exp(2) + math.exp(1) + math.exp(0)
+    p0, p1 = math.exp(4) / z, math.exp(3) / z  # 0.6365, 0.2341
+
+    # top_p=0.5: cumsum[0] = 0.6365 > 0.5 already, but the first token is
+    # always kept -> degenerate one-hot on token 0.
+    probs = warped_probs(logits, top_p=0.5)
+    assert probs[0, 0].item() == 1.0
+    assert float(probs[0, 1:].sum()) == 0.0
+
+    # top_p=0.9: cumsum = [0.6365, 0.8706, 0.9567, ...] -> keep {0, 1},
+    # renormalized to p0/(p0+p1), p1/(p0+p1).
+    probs = warped_probs(logits, top_p=0.9)
+    nz = torch.nonzero(probs[0] > 0).flatten().tolist()
+    assert nz == [0, 1]
+    total = p0 + p1
+    assert math.isclose(probs[0, 0].item(), p0 / total, rel_tol=1e-5)
+    assert math.isclose(probs[0, 1].item(), p1 / total, rel_tol=1e-5)
+
+
+def test_warped_probs_temperature_applies_before_top_k_top_p():
+    # Two-stage check vs. explicitly staged math: T=2 softens the gaps, then
+    # top_k=2 keeps the same two ids but with temperature-warped mass.
+    logits = torch.tensor([[4.0, 3.0, 2.0, 1.0]])
+    probs = warped_probs(logits, temperature=2.0, top_k=2)
+    expected = F.softmax(torch.tensor([2.0, 1.5]), dim=-1)
+    assert torch.allclose(probs[0, :2], expected, atol=1e-7)
+    assert float(probs[0, 2:].sum()) == 0.0
+
+
+def test_warped_probs_rejects_nonpositive_temperature():
+    with pytest.raises(ValueError, match="temperature > 0"):
+        warped_probs(torch.zeros(1, 4), temperature=0.0)
+
+
+def test_warped_probs_matches_engine_sampler_warp():
+    # Token-level equivalence with the production sampler's warp: same seed,
+    # same logits, same params -> same draw. Pins warp ORDER against
+    # ``GenerationEngine._sample`` on a case where all three stages bite.
+    from moe_infinity.engine.generation_loop import GenerationEngine
+    from moe_infinity.engine.types import SamplingParams
+    from moe_infinity.memory.kv_cache_manager import KVCacheManager
+    from moe_infinity.runtime.attention_types import KVCacheSpec
+
+    engine = GenerationEngine(
+        kv_cache_manager=KVCacheManager(
+            num_gpu_blocks=8, num_cpu_blocks=2, block_size=4
+        ),
+        kv_spec=KVCacheSpec(
+            num_kv_heads=1, head_dim=8, dtype=torch.float32, block_size=4
+        ),
+        num_layers=1,
+        vocab_size=8,
+    )
+    torch.manual_seed(7)
+    logits = torch.randn(8) * 3.0
+    params = SamplingParams(temperature=0.7, top_k=4, top_p=0.85)
+
+    for seed in range(20):
+        torch.manual_seed(seed)
+        via_engine = engine._sample(logits.unsqueeze(0), params)
+        torch.manual_seed(seed)
+        via_ops = int(
+            torch.multinomial(
+                warped_probs(logits, 0.7, top_k=4, top_p=0.85), 1
+            ).item()
+        )
+        assert via_engine == via_ops
+
+
+def test_residual_distribution_hand_checked():
+    p = torch.tensor([0.5, 0.3, 0.1, 0.1])
+    q = torch.tensor([0.25, 0.5, 0.0, 0.25])
+    # max(0, p - q) = [0.25, 0, 0.1, 0]; mass 0.35 -> [5/7, 0, 2/7, 0].
+    r = residual_distribution(p, q)
+    assert math.isclose(r[0].item(), 5 / 7, rel_tol=1e-5)
+    assert r[1].item() == 0.0
+    assert math.isclose(r[2].item(), 2 / 7, rel_tol=1e-5)
+    assert r[3].item() == 0.0
+    assert math.isclose(float(r.sum()), 1.0, abs_tol=1e-6)
+
+
+def test_residual_distribution_sums_to_one_randomized():
+    torch.manual_seed(0)
+    for _ in range(32):
+        p = F.softmax(torch.randn(16) * 4, dim=-1)
+        q = F.softmax(torch.randn(16) * 4, dim=-1)
+        r = residual_distribution(p, q)
+        assert math.isclose(float(r.sum()), 1.0, abs_tol=1e-6)
+        assert float(r.min()) >= 0.0
+
+
+def test_residual_distribution_falls_back_to_p_when_equal():
+    p = torch.tensor([0.2, 0.3, 0.5])
+    r = residual_distribution(p, p.clone())
+    assert torch.equal(r, p)
+
+
+def _one_hot(idx: int, vocab: int) -> torch.Tensor:
+    row = torch.zeros(vocab)
+    row[idx] = 1.0
+    return row
+
+
+def test_acceptance_sampled_full_accept_draws_bonus_from_last_target_row():
+    # Q_i == P_i everywhere -> ratio 1 -> every draft accepted; the bonus is
+    # drawn from P_B, made one-hot here so the outcome is exact.
+    vocab, num_drafts = 4, 3
+    draft_probs = torch.full((num_drafts, vocab), 0.25)
+    target_probs = torch.full((num_drafts + 1, vocab), 0.25)
+    target_probs[-1] = _one_hot(2, vocab)
+    drafts = torch.tensor([1, 3, 0])
+
+    decision = acceptance_sampled(
+        draft_probs, target_probs, drafts, generator=torch.Generator().manual_seed(0)
+    )
+    assert decision.accept == num_drafts
+    assert decision.final_token == 2
+
+
+def test_acceptance_sampled_immediate_reject_emits_residual_correction():
+    # Slot 1: P is one-hot on 1, Q is one-hot on 0 -> the drafted 0 has
+    # p/q == 0 -> always rejected; residual == P -> correction is exactly 1.
+    vocab = 4
+    draft_probs = torch.stack([_one_hot(0, vocab), torch.full((vocab,), 0.25)])
+    target_probs = torch.stack(
+        [_one_hot(1, vocab), torch.full((vocab,), 0.25), _one_hot(2, vocab)]
+    )
+    drafts = torch.tensor([0, 3])
+
+    decision = acceptance_sampled(
+        draft_probs, target_probs, drafts, generator=torch.Generator().manual_seed(0)
+    )
+    assert decision.accept == 0
+    assert decision.final_token == 1
+
+
+@pytest.mark.parametrize("k", [0, 1, 2, 3])
+def test_acceptance_sampled_boundary_at_k(k: int):
+    # Slots 1..k accept (Q == P), slot k+1 rejects on a one-hot mismatch;
+    # k == 3 = full accept (bonus from the one-hot last row).
+    vocab, num_drafts = 4, 3
+    draft_rows = [torch.full((vocab,), 0.25) for _ in range(num_drafts)]
+    target_rows = [torch.full((vocab,), 0.25) for _ in range(num_drafts + 1)]
+    drafts = torch.zeros(num_drafts, dtype=torch.long)
+    if k < num_drafts:
+        draft_rows[k] = _one_hot(0, vocab)  # drafts[k] == 0 -> p/q == 0
+        target_rows[k] = _one_hot(3, vocab)  # residual one-hot -> final 3
+        expected = (k, 3)
+    else:
+        target_rows[-1] = _one_hot(2, vocab)
+        expected = (num_drafts, 2)
+
+    decision = acceptance_sampled(
+        torch.stack(draft_rows),
+        torch.stack(target_rows),
+        drafts,
+        generator=torch.Generator().manual_seed(0),
+    )
+    assert (decision.accept, decision.final_token) == expected
+
+
+def test_acceptance_sampled_accepts_when_p_exceeds_q():
+    # p/q == 1.8 -> min(1, .) == 1 -> deterministic accept of the draft.
+    draft_probs = torch.tensor([[0.5, 0.5]])
+    target_probs = torch.tensor([[0.9, 0.1], [0.0, 1.0]])
+    decision = acceptance_sampled(
+        draft_probs,
+        target_probs,
+        torch.tensor([0]),
+        generator=torch.Generator().manual_seed(0),
+    )
+    assert decision.accept == 1
+    assert decision.final_token == 1  # bonus row is one-hot on 1
+
+
+def test_acceptance_sampled_seed_determinism():
+    # A genuinely stochastic case (0 < p/q < 1) replayed under equal seeds
+    # must reproduce the exact outcome sequence.
+    draft_probs = torch.tensor([[0.5, 0.5]])
+    target_probs = torch.tensor([[0.6, 0.4], [0.25, 0.75]])
+    drafts = torch.tensor([1])  # p/q == 0.8
+
+    def draw(seed: int, n: int):
+        gen = torch.Generator().manual_seed(seed)
+        return [
+            acceptance_sampled(draft_probs, target_probs, drafts, generator=gen)
+            for _ in range(n)
+        ]
+
+    assert draw(1234, 64) == draw(1234, 64)
+    # Both outcomes occur -> the determinism above is not a degenerate gate.
+    outcomes = {(d.accept, d.final_token) for d in draw(1234, 64)}
+    assert len(outcomes) > 1
+
+
+def test_committed_tokens_sampled_split_matches_greedy_layout():
+    block = torch.tensor([[100, 11, 12, 13]])
+    res = committed_tokens_sampled(block, accept=1, final_token=42)
+    assert res.emitted[0].tolist() == [11, 42]
+    assert res.block_prefix[0].tolist() == [100, 11]
+    assert res.bonus[0].tolist() == [42]
+
+    res = committed_tokens_sampled(block, accept=3, final_token=42)
+    assert res.emitted[0].tolist() == [11, 12, 13, 42]
+    assert res.block_prefix[0].tolist() == [100, 11, 12, 13]
+
+    res = committed_tokens_sampled(block, accept=0, final_token=42)
+    assert res.emitted[0].tolist() == [42]
+    assert res.block_prefix[0].tolist() == [100]
+
+
+# ---------------------------------------------------------------------------
+# Shared tiny-model helpers for (b) and (c)
+# ---------------------------------------------------------------------------
+
+
+def _reference_sample(logits: torch.Tensor, temperature, top_k, top_p) -> int:
+    """Plain-sampler reference: same warp spec as the engine, independent
+    implementation (threshold-free top-k via index scatter, nucleus via
+    cumulative mask) -- deliberately NOT importing ``warped_probs`` so the
+    parity gate compares two separate code paths."""
+    x = logits
+    if temperature != 1.0:
+        x = x / float(temperature)
+    if int(top_k) > 0:
+        k = min(int(top_k), int(x.shape[-1]))
+        idx = torch.topk(x, k).indices
+        kept = torch.full_like(x, float("-inf"))
+        kept[idx] = x[idx]
+        x = kept
+    if float(top_p) < 1.0:
+        s, order = torch.sort(x, descending=True)
+        c = torch.cumsum(F.softmax(s, dim=-1), dim=-1)
+        drop = c > float(top_p)
+        drop[0] = False
+        s = s.masked_fill(drop, float("-inf"))
+        x = torch.full_like(x, float("-inf")).scatter(-1, order, s)
+    return int(torch.multinomial(F.softmax(x, dim=-1), 1).item())
+
+
+@torch.no_grad()
+def _plain_sampled_decode(
+    model, input_ids, max_new_tokens, temperature, top_k=0, top_p=1.0
+):
+    """Autoregressive sampled baseline (mirror of ``plain_greedy_decode``)."""
+    model.eval()
+    out = model(input_ids.clone(), use_cache=True)
+    past = out.past_key_values
+    nxt = _reference_sample(out.logits[0, -1], temperature, top_k, top_p)
+    tokens = [nxt]
+    for _ in range(max_new_tokens - 1):
+        out = model(
+            torch.tensor([[nxt]]), past_key_values=past, use_cache=True
+        )
+        past = out.past_key_values
+        nxt = _reference_sample(out.logits[0, -1], temperature, top_k, top_p)
+        tokens.append(nxt)
+    return tokens
+
+
+def _build_spec(vocab_size=None, mask_token_id=None):
+    set_determinism(0)
+    cfg_kwargs = {} if vocab_size is None else {"vocab_size": vocab_size}
+    target = build_tiny_target(seed=0, **cfg_kwargs)
+    if mask_token_id is None:
+        drafter = build_tiny_drafter(target, seed=1)
+        config = read_dflash_config(make_tiny_drafter_config(target.config))
+    else:
+        # Small-vocab parity fixtures: the default mask id (63) is outside
+        # the vocab, so the drafter is built with an explicit in-vocab mask.
+        ns = make_tiny_drafter_config(target.config, mask_token_id=mask_token_id)
+        config = read_dflash_config(ns)
+        set_determinism(1)
+        drafter = TinyDFlashDrafter(
+            config, target.get_input_embeddings(), target.get_output_embeddings()
+        ).to(torch.float32)
+        drafter.eval()
+    spec = DFlashSpeculator.from_models(target, drafter, config=config, device="cpu")
+    return spec, target
+
+
+# ---------------------------------------------------------------------------
+# (b) Distributional parity: sampled DFlash vs. plain sampled target
+# ---------------------------------------------------------------------------
+
+PARITY_CONFIGS = [
+    {"name": "temp0.8", "temperature": 0.8, "top_k": 0, "top_p": 1.0, "runs": 500},
+    {"name": "top_p0.9", "temperature": 1.0, "top_k": 0, "top_p": 0.9, "runs": 500},
+    {"name": "top_k5", "temperature": 1.2, "top_k": 5, "top_p": 1.0, "runs": 500},
+]
+
+
+def _tvd(p: torch.Tensor, q: torch.Tensor) -> float:
+    return 0.5 * float((p - q).abs().sum())
+
+
+def _kl(p: torch.Tensor, q: torch.Tensor, eps: float = 1e-6) -> float:
+    p = p / p.sum() + eps
+    q = q / q.sum() + eps
+    return float((p * (p / q).log()).sum())
+
+
+def _run_parity(cfg):
+    spec, target = _build_spec(
+        vocab_size=PARITY_VOCAB, mask_token_id=PARITY_MASK_ID
+    )
+    plain_tokens, spec_tokens = [], []
+    total_accept = 0
+    for run in range(cfg["runs"]):
+        torch.manual_seed(10_000 + run)
+        plain_tokens.append(
+            _plain_sampled_decode(
+                target,
+                PROMPT,
+                PARITY_MAX_NEW,
+                cfg["temperature"],
+                top_k=cfg["top_k"],
+                top_p=cfg["top_p"],
+            )
+        )
+        torch.manual_seed(20_000 + run)
+        out = spec.generate(
+            PROMPT,
+            max_new_tokens=PARITY_MAX_NEW,
+            temperature=cfg["temperature"],
+            top_k=cfg["top_k"],
+            top_p=cfg["top_p"],
+        )
+        spec_new = out[0, PROMPT_LEN:].tolist()
+        spec_tokens.append(spec_new)
+        total_accept += sum(rec.accept for rec in spec.step_trace)
+        # The greedy-path cache accounting must hold in sampled mode too:
+        # start advances by accept+1 and the cache ends at start.
+        for rec in spec.step_trace:
+            assert rec.start == rec.prev_start + rec.accept + 1
+            assert rec.target_cache_len == rec.start
+    return {
+        "plain": plain_tokens,
+        "spec": spec_tokens,
+        "total_accept": total_accept,
+    }
+
+
+@pytest.fixture(scope="module")
+def parity():
+    return {cfg["name"]: _run_parity(cfg) for cfg in PARITY_CONFIGS}
+
+
+def _position_histograms(tokens, vocab):
+    n_pos = len(tokens[0])
+    h = torch.zeros(n_pos, vocab)
+    for row in tokens:
+        for j, tok in enumerate(row):
+            h[j, tok] += 1
+    return h / len(tokens)
+
+
+def _pooled_histogram(tokens, vocab):
+    h = torch.zeros(vocab)
+    for row in tokens:
+        for tok in row:
+            h[tok] += 1
+    return h / h.sum()
+
+
+def test_sampled_parity_pooled_tvd_and_kl(parity):
+    """Pooled-over-positions histogram: sharpest statistic (n = runs x 8)."""
+    lines = []
+    for cfg in PARITY_CONFIGS:
+        data = parity[cfg["name"]]
+        hp = _pooled_histogram(data["plain"], PARITY_VOCAB)
+        hs = _pooled_histogram(data["spec"], PARITY_VOCAB)
+        tvd, kl = _tvd(hp, hs), _kl(hp, hs)
+        lines.append(
+            f"{cfg['name']}: pooled TVD={tvd:.4f} KL={kl:.4f} "
+            f"runs={cfg['runs']} total_accept={data['total_accept']}"
+        )
+        # Deterministic at fixed seeds. Measured pooled TVD at 500 runs is
+        # 0.035-0.054 across the configs, matching the multinomial noise
+        # floor 0.5*sum(sqrt(2 p (1-p) / n)) ~= 0.036-0.043; the gate carries
+        # ~2.3x headroom over that floor while remaining far below what a
+        # broken accept rule would show (always-accept / always-reject shift
+        # the pooled TVD well above 0.15 with this weak tiny drafter).
+        assert tvd <= 0.10, f"{cfg['name']} pooled TVD {tvd:.4f} > 0.10"
+        assert kl <= 0.05, f"{cfg['name']} pooled KL {kl:.4f} > 0.05"
+    print("\n".join(lines))
+
+
+def test_sampled_parity_per_position_tvd(parity):
+    """Per-position histograms (n = runs): looser, but every position must
+    match -- a position-localized bug cannot hide in the pooled average.
+    Measured worst-position TVD at 500 runs: 0.124-0.152 (noise floor
+    ~= 0.10-0.12); the 0.25 gate is ~2x that floor."""
+    for cfg in PARITY_CONFIGS:
+        data = parity[cfg["name"]]
+        hp = _position_histograms(data["plain"], PARITY_VOCAB)
+        hs = _position_histograms(data["spec"], PARITY_VOCAB)
+        worst = max(_tvd(hp[j], hs[j]) for j in range(PARITY_MAX_NEW))
+        print(f"{cfg['name']}: worst per-position TVD={worst:.4f}")
+        assert worst <= 0.25, f"{cfg['name']} position TVD {worst:.4f} > 0.25"
+
+
+def test_sampled_parity_drafter_is_exercised(parity):
+    """Non-degeneracy: drafts are accepted somewhere (the parity above is a
+    real draft->verify->accept path, not an accept-0 fallback)."""
+    for cfg in PARITY_CONFIGS:
+        assert parity[cfg["name"]]["total_accept"] > 0
+
+
+def test_sampled_anchor_matches_plain_first_token_exactly():
+    """max_new_tokens=1: only the anchor is drawn, from the same prefill
+    logits and one RNG draw on both paths -> exact token equality per seed."""
+    spec, target = _build_spec(
+        vocab_size=PARITY_VOCAB, mask_token_id=PARITY_MASK_ID
+    )
+    for seed in range(16):
+        torch.manual_seed(seed)
+        plain = _plain_sampled_decode(target, PROMPT, 1, 0.8)
+        torch.manual_seed(seed)
+        out = spec.generate(PROMPT, max_new_tokens=1, temperature=0.8)
+        assert out[0, PROMPT_LEN:].tolist() == plain
+
+
+# ---------------------------------------------------------------------------
+# (c) Greedy regression + sampled determinism
+# ---------------------------------------------------------------------------
+
+
+def test_greedy_path_still_token_identical_to_plain_greedy():
+    spec, target = _build_spec()
+    max_new = 24
+    out = spec.generate(PROMPT, max_new_tokens=max_new, temperature=0.0)
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=max_new)
+    assert torch.equal(out, plain)
+
+
+def test_greedy_path_ignores_top_k_top_p_like_engine_sampler():
+    # Engine semantics (``GenerationEngine._sample``): temperature == 0 is
+    # argmax regardless of top_k/top_p; the speculator must match.
+    spec, target = _build_spec()
+    max_new = 24
+    out = spec.generate(
+        PROMPT, max_new_tokens=max_new, temperature=0.0, top_k=5, top_p=0.7
+    )
+    plain = plain_greedy_decode(target, PROMPT, max_new_tokens=max_new)
+    assert torch.equal(out, plain)
+
+
+def test_sampled_generate_is_seed_deterministic():
+    spec, _ = _build_spec(vocab_size=PARITY_VOCAB, mask_token_id=PARITY_MASK_ID)
+    torch.manual_seed(99)
+    first = spec.generate(PROMPT, max_new_tokens=16, temperature=0.8, top_p=0.9)
+    torch.manual_seed(99)
+    second = spec.generate(PROMPT, max_new_tokens=16, temperature=0.8, top_p=0.9)
+    assert torch.equal(first, second)
+
+
+def test_negative_temperature_rejected():
+    spec, _ = _build_spec()
+    with pytest.raises(ValueError, match="temperature must be >= 0"):
+        spec.generate(PROMPT, max_new_tokens=4, temperature=-0.5)

--- a/tests/python/dflash/test_sampled_spec.py
+++ b/tests/python/dflash/test_sampled_spec.py
@@ -205,7 +205,10 @@ def test_acceptance_sampled_full_accept_draws_bonus_from_last_target_row():
     drafts = torch.tensor([1, 3, 0])
 
     decision = acceptance_sampled(
-        draft_probs, target_probs, drafts, generator=torch.Generator().manual_seed(0)
+        draft_probs,
+        target_probs,
+        drafts,
+        generator=torch.Generator().manual_seed(0),
     )
     assert decision.accept == num_drafts
     assert decision.final_token == 2
@@ -222,7 +225,10 @@ def test_acceptance_sampled_immediate_reject_emits_residual_correction():
     drafts = torch.tensor([0, 3])
 
     decision = acceptance_sampled(
-        draft_probs, target_probs, drafts, generator=torch.Generator().manual_seed(0)
+        draft_probs,
+        target_probs,
+        drafts,
+        generator=torch.Generator().manual_seed(0),
     )
     assert decision.accept == 0
     assert decision.final_token == 1
@@ -343,9 +349,7 @@ def _plain_sampled_decode(
     nxt = _reference_sample(out.logits[0, -1], temperature, top_k, top_p)
     tokens = [nxt]
     for _ in range(max_new_tokens - 1):
-        out = model(
-            torch.tensor([[nxt]]), past_key_values=past, use_cache=True
-        )
+        out = model(torch.tensor([[nxt]]), past_key_values=past, use_cache=True)
         past = out.past_key_values
         nxt = _reference_sample(out.logits[0, -1], temperature, top_k, top_p)
         tokens.append(nxt)
@@ -362,14 +366,20 @@ def _build_spec(vocab_size=None, mask_token_id=None):
     else:
         # Small-vocab parity fixtures: the default mask id (63) is outside
         # the vocab, so the drafter is built with an explicit in-vocab mask.
-        ns = make_tiny_drafter_config(target.config, mask_token_id=mask_token_id)
+        ns = make_tiny_drafter_config(
+            target.config, mask_token_id=mask_token_id
+        )
         config = read_dflash_config(ns)
         set_determinism(1)
         drafter = TinyDFlashDrafter(
-            config, target.get_input_embeddings(), target.get_output_embeddings()
+            config,
+            target.get_input_embeddings(),
+            target.get_output_embeddings(),
         ).to(torch.float32)
         drafter.eval()
-    spec = DFlashSpeculator.from_models(target, drafter, config=config, device="cpu")
+    spec = DFlashSpeculator.from_models(
+        target, drafter, config=config, device="cpu"
+    )
     return spec, target
 
 
@@ -378,9 +388,27 @@ def _build_spec(vocab_size=None, mask_token_id=None):
 # ---------------------------------------------------------------------------
 
 PARITY_CONFIGS = [
-    {"name": "temp0.8", "temperature": 0.8, "top_k": 0, "top_p": 1.0, "runs": 500},
-    {"name": "top_p0.9", "temperature": 1.0, "top_k": 0, "top_p": 0.9, "runs": 500},
-    {"name": "top_k5", "temperature": 1.2, "top_k": 5, "top_p": 1.0, "runs": 500},
+    {
+        "name": "temp0.8",
+        "temperature": 0.8,
+        "top_k": 0,
+        "top_p": 1.0,
+        "runs": 500,
+    },
+    {
+        "name": "top_p0.9",
+        "temperature": 1.0,
+        "top_k": 0,
+        "top_p": 0.9,
+        "runs": 500,
+    },
+    {
+        "name": "top_k5",
+        "temperature": 1.2,
+        "top_k": 5,
+        "top_p": 1.0,
+        "runs": 500,
+    },
 ]
 
 
@@ -545,7 +573,9 @@ def test_sampled_generate_is_seed_deterministic():
     torch.manual_seed(99)
     first = spec.generate(PROMPT, max_new_tokens=16, temperature=0.8, top_p=0.9)
     torch.manual_seed(99)
-    second = spec.generate(PROMPT, max_new_tokens=16, temperature=0.8, top_p=0.9)
+    second = spec.generate(
+        PROMPT, max_new_tokens=16, temperature=0.8, top_p=0.9
+    )
     assert torch.equal(first, second)
 
 

--- a/tests/python/dflash/test_spec_off_regression.py
+++ b/tests/python/dflash/test_spec_off_regression.py
@@ -53,7 +53,24 @@ GPT2_MAX_TOKENS = 16
 # Captured from the pre-refactor GenerationEngine standard loop (seed-7 tiny
 # GPT-2 fixture below). This is the identical baseline pinned by Task 1's
 # ``test_spec_seam.py``; the full DFlash integration must not move it.
-BASELINE_IDS = [61, 61, 108, 108, 108, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]
+BASELINE_IDS = [
+    61,
+    61,
+    108,
+    108,
+    108,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+]
 
 
 def _build_cpu_gpt2_forward():

--- a/tests/python/dflash/test_spec_seam.py
+++ b/tests/python/dflash/test_spec_seam.py
@@ -16,7 +16,24 @@ MAX_TOKENS = 16
 
 # Captured from the pre-refactor GenerationEngine (seed 7 tiny GPT-2 fixture below);
 # the seam refactor must leave the standard path byte-identical to this.
-BASELINE_IDS = [61, 61, 108, 108, 108, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11]
+BASELINE_IDS = [
+    61,
+    61,
+    108,
+    108,
+    108,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+    11,
+]
 
 
 def _build_forward():
@@ -62,11 +79,15 @@ def _make_engine(spec_strategy=None, **engine_kwargs):
 
 
 def _greedy_params():
-    return SamplingParams(temperature=0.0, top_p=1.0, top_k=0, max_tokens=MAX_TOKENS)
+    return SamplingParams(
+        temperature=0.0, top_p=1.0, top_k=0, max_tokens=MAX_TOKENS
+    )
 
 
 class _ExplodingStrategy:
-    def run(self, *, engine, prompt_token_ids, sampling_params, request_id=None):
+    def run(
+        self, *, engine, prompt_token_ids, sampling_params, request_id=None
+    ):
         raise RuntimeError("spec strategy must not be called on this path")
 
 
@@ -75,7 +96,9 @@ class _RecordingStrategy:
         self._ids = ids
         self.calls = []
 
-    def run(self, *, engine, prompt_token_ids, sampling_params, request_id=None):
+    def run(
+        self, *, engine, prompt_token_ids, sampling_params, request_id=None
+    ):
         self.calls.append(
             {
                 "engine": engine,
@@ -125,7 +148,9 @@ def test_nongreedy_params_bypass_spec_strategy():
             prompt_token_ids=list(PROMPT), sampling_params=params
         )
 
-        assert guarded_result.output_token_ids == reference_result.output_token_ids
+        assert (
+            guarded_result.output_token_ids == reference_result.output_token_ids
+        )
         assert guarded_result.finish_reason == reference_result.finish_reason
 
 

--- a/tests/python/dflash/test_spec_state.py
+++ b/tests/python/dflash/test_spec_state.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pytest
+
+from moe_infinity.serving.spec_state import SpecDecodeState
+
+
+def test_initial_cached_len_defaults_to_prompt_len() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=5)
+    assert state.cached_len == 5
+    assert state.emitted_len == 0
+    assert state.invariant_holds()
+
+
+def test_full_accept_advances_by_block_len() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=5)
+    acc = state.record_verify(block_len=9, committed=9)
+    assert acc.committed == 9
+    assert acc.truncate_target == 14
+    assert state.cached_len == 14
+    assert state.emitted_len == 9
+    assert state.invariant_holds()
+
+
+def test_partial_accept_truncate_target_drops_rejected_tail() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=10)
+    acc = state.record_verify(block_len=9, committed=3)
+    assert acc.truncate_target == 13
+    assert state.cached_len == 13
+    assert state.emitted_len == 3
+    assert state.invariant_holds()
+
+
+def test_single_token_commit() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=4)
+    acc = state.record_verify(block_len=9, committed=1)
+    assert acc.truncate_target == 5
+    assert state.invariant_holds()
+
+
+def test_multi_step_accumulates() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=8)
+    state.record_verify(block_len=9, committed=4)
+    state.record_verify(block_len=9, committed=2)
+    acc = state.record_verify(block_len=9, committed=9)
+    assert state.emitted_len == 15
+    assert state.cached_len == 23
+    assert acc.truncate_target == 23
+    assert state.invariant_holds()
+
+
+def test_committed_out_of_range_raises() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=5)
+    with pytest.raises(ValueError, match="committed must be"):
+        state.record_verify(block_len=9, committed=0)
+    with pytest.raises(ValueError, match="committed must be"):
+        state.record_verify(block_len=9, committed=10)
+
+
+def test_bad_block_len_raises() -> None:
+    state = SpecDecodeState(seq_id=0, prompt_len=5)
+    with pytest.raises(ValueError, match="block_len must be"):
+        state.record_verify(block_len=0, committed=1)
+
+
+def test_negative_prompt_len_raises() -> None:
+    with pytest.raises(ValueError, match="prompt_len must be"):
+        SpecDecodeState(seq_id=0, prompt_len=-1)
+
+
+def test_truncate_target_composes_with_kv_truncate() -> None:
+    import torch
+
+    from moe_infinity.serving.kv_cache import PagedKVCache
+
+    cache = PagedKVCache(
+        num_blocks=32,
+        block_size=4,
+        num_layers=1,
+        num_heads=1,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    prompt_len = 6
+    cache.allocate_sequence(0, prompt_len)
+    state = SpecDecodeState(seq_id=0, prompt_len=prompt_len)
+
+    block_len, committed = 9, 3
+    cache.append_tokens(0, block_len)
+    acc = state.record_verify(block_len=block_len, committed=committed)
+    cache.truncate_tokens(0, acc.truncate_target)
+
+    assert cache._sequence_tables[0].num_computed_tokens() == prompt_len + committed
+    assert acc.truncate_target == prompt_len + committed
+    assert state.invariant_holds()

--- a/tests/python/dflash/test_spec_state.py
+++ b/tests/python/dflash/test_spec_state.py
@@ -91,6 +91,9 @@ def test_truncate_target_composes_with_kv_truncate() -> None:
     acc = state.record_verify(block_len=block_len, committed=committed)
     cache.truncate_tokens(0, acc.truncate_target)
 
-    assert cache._sequence_tables[0].num_computed_tokens() == prompt_len + committed
+    assert (
+        cache._sequence_tables[0].num_computed_tokens()
+        == prompt_len + committed
+    )
     assert acc.truncate_target == prompt_len + committed
     assert state.invariant_holds()

--- a/tests/python/dflash/test_spec_verify.py
+++ b/tests/python/dflash/test_spec_verify.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import torch
+
+from moe_infinity.serving.kv_cache import PagedKVCache
+from moe_infinity.serving.spec_state import SpecDecodeState
+from moe_infinity.serving.spec_verify import apply_verify_step
+from moe_infinity.spec_decode._dflash_ops import (
+    acceptance_length,
+    committed_tokens,
+)
+
+BLOCK_SIZE = 4
+
+
+def _make_cache(prompt_len: int) -> PagedKVCache:
+    cache = PagedKVCache(
+        num_blocks=64,
+        block_size=4,
+        num_layers=1,
+        num_heads=1,
+        head_dim=4,
+        dtype=torch.float32,
+        device=torch.device("cpu"),
+    )
+    cache.allocate_sequence(0, prompt_len)
+    return cache
+
+
+def _step(cache: PagedKVCache, state: SpecDecodeState, block, posterior):
+    cache.append_tokens(0, BLOCK_SIZE)
+    return apply_verify_step(
+        kv_cache=cache,
+        seq_id=0,
+        state=state,
+        block=block,
+        posterior=posterior,
+        block_size=BLOCK_SIZE,
+    )
+
+
+def test_partial_accept_matches_canonical_ops() -> None:
+    block = torch.tensor([[10, 11, 12, 99]])
+    posterior = torch.tensor([[11, 12, 50, 7]])
+    expected_accept = acceptance_length(block, posterior)
+    expected = committed_tokens(block, posterior, expected_accept)
+
+    cache = _make_cache(6)
+    state = SpecDecodeState(seq_id=0, prompt_len=6)
+    res = _step(cache, state, block, posterior)
+
+    assert res.accept == 2 == expected_accept
+    assert res.emitted_tokens == [int(t) for t in expected.emitted[0].tolist()]
+    assert res.emitted_tokens == [11, 12, 50]
+    assert res.next_anchor == 50
+    assert res.cache_committed == 3
+    assert cache._sequence_tables[0].num_computed_tokens() == 6 + 3
+    assert res.cached_len == 9
+
+
+def test_accept_zero_emits_only_bonus() -> None:
+    block = torch.tensor([[10, 99, 98, 97]])
+    posterior = torch.tensor([[50, 1, 2, 3]])
+    cache = _make_cache(5)
+    state = SpecDecodeState(seq_id=0, prompt_len=5)
+    res = _step(cache, state, block, posterior)
+
+    assert res.accept == 0
+    assert res.emitted_tokens == [50]
+    assert res.next_anchor == 50
+    assert res.cache_committed == 1
+    assert cache._sequence_tables[0].num_computed_tokens() == 6
+
+
+def test_full_accept_keeps_whole_block() -> None:
+    block = torch.tensor([[10, 11, 12, 13]])
+    posterior = torch.tensor([[11, 12, 13, 77]])
+    cache = _make_cache(4)
+    state = SpecDecodeState(seq_id=0, prompt_len=4)
+    res = _step(cache, state, block, posterior)
+
+    assert res.accept == 3
+    assert res.emitted_tokens == [11, 12, 13, 77]
+    assert res.next_anchor == 77
+    assert res.cache_committed == 4
+    assert cache._sequence_tables[0].num_computed_tokens() == 8
+
+
+def test_multi_step_chains_anchor_and_accumulates_cache() -> None:
+    cache = _make_cache(3)
+    state = SpecDecodeState(seq_id=0, prompt_len=3)
+
+    block1 = torch.tensor([[20, 21, 55, 54]])
+    posterior1 = torch.tensor([[21, 30, 31, 32]])
+    res1 = _step(cache, state, block1, posterior1)
+    assert res1.accept == 1
+    assert res1.next_anchor == 30
+    assert cache._sequence_tables[0].num_computed_tokens() == 3 + 2
+
+    block2 = torch.tensor([[res1.next_anchor, 41, 42, 43]])
+    posterior2 = torch.tensor([[41, 42, 43, 9]])
+    res2 = _step(cache, state, block2, posterior2)
+    assert res2.accept == 3
+    assert cache._sequence_tables[0].num_computed_tokens() == 5 + 4
+    assert res2.cached_len == 9
+    assert state.emitted_len == res1.cache_committed + res2.cache_committed

--- a/tests/python/dflash/test_speculative_prefetch.py
+++ b/tests/python/dflash/test_speculative_prefetch.py
@@ -1,0 +1,150 @@
+"""Unit tests for the Track A2 explicit-set extension of ``speculative_prefetch``.
+
+Autonomous correctness gate for Track A2 of
+``.sisyphus/plans/dflash-deferred-tracks-plan.md``. Covers:
+
+(a) characterization: the legacy positional call
+    ``speculative_prefetch(layer_idx, router_logits)`` still pools via
+    ``mean(0)`` and enqueues exactly ``topk(min(2, E))`` for ``layer_idx + 1``;
+(b) the new explicit mode (``expert_ids=...``, ``prefetch_layer_id=...``)
+    enqueues exactly the given set for the requested layer and never runs
+    the mean/topk path -- this is the seam A3's verify loop will call with
+    the model-exact routed union;
+(c) empty ``expert_ids`` is a safe no-op;
+(d) both arguments ``None`` raises ``ValueError``.
+
+Construction is intentionally light: ``ExpertPrefetcher.__new__`` plus the
+four attributes ``speculative_prefetch`` touches (``num_layers``,
+``num_experts``, ``archer_engine``, ``expert_tensor_map``), with a mocked
+``archer_engine`` -- no config parsing, no native extension, CPU-only.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from moe_infinity.memory.expert_prefetcher import ExpertPrefetcher
+
+# Hand-checked legacy fixture: [2 tokens, 4 experts]
+#   mean over tokens = [2.0, 3.5, 3.0, 0.5] -> top-2 = experts [1, 2]
+LOGITS = torch.tensor(
+    [
+        [1.0, 5.0, 2.0, 0.0],
+        [3.0, 2.0, 4.0, 1.0],
+    ]
+)
+LEGACY_TOP2 = [1, 2]
+
+
+def _make_prefetcher(num_layers: int = 8, num_experts: int = 8):
+    prefetcher = ExpertPrefetcher.__new__(ExpertPrefetcher)
+    prefetcher.num_layers = num_layers
+    prefetcher.num_experts = num_experts
+    engine = MagicMock()
+    engine.get_node_default_device.return_value = 0
+    prefetcher.archer_engine = engine
+    # Readable tensor ids: (layer, expert) -> layer * 100 + expert.
+    prefetcher.expert_tensor_map = {
+        (layer, expert): layer * 100 + expert
+        for layer in range(num_layers)
+        for expert in range(num_experts)
+    }
+    prefetcher._last_speculative_prediction = set()
+    return prefetcher, engine
+
+
+def _enqueued_tensor_ids(engine: MagicMock) -> list[int]:
+    return [call.args[0] for call in engine.enqueue_prefetch.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# (a) legacy characterization -- old call style must behave exactly as before
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_positional_call_enqueues_mean_topk_for_next_layer():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=4)
+    prefetcher.speculative_prefetch(2, LOGITS)
+    assert _enqueued_tensor_ids(engine) == [301, 302]
+    assert prefetcher._last_speculative_prediction == set(LEGACY_TOP2)
+
+
+def test_legacy_numpy_logits_enqueue_same_experts_as_torch_path():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=4)
+    prefetcher.speculative_prefetch(2, LOGITS.numpy())
+    assert _enqueued_tensor_ids(engine) == [301, 302]
+    assert prefetcher._last_speculative_prediction == set(LEGACY_TOP2)
+
+
+def test_legacy_last_layer_is_noop():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=4)
+    prefetcher.speculative_prefetch(7, LOGITS)
+    engine.enqueue_prefetch.assert_not_called()
+
+
+def test_legacy_router_logits_still_accepted_as_keyword():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=4)
+    prefetcher.speculative_prefetch(2, router_logits=LOGITS)
+    assert _enqueued_tensor_ids(engine) == [301, 302]
+
+
+# ---------------------------------------------------------------------------
+# (b) explicit route-ahead mode -- exact set, exact layer, no mean/topk
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_expert_ids_enqueue_exact_set_for_target_layer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    topk_spy = MagicMock(wraps=torch.topk)
+    monkeypatch.setattr(torch, "topk", topk_spy)
+    # Logits that would route to expert 0 if the legacy topk path ran.
+    logits = torch.full((3, 8), -100.0)
+    logits[:, 0] = 100.0
+    prefetcher.speculative_prefetch(
+        1, logits, expert_ids=[3, 1, 7], prefetch_layer_id=5
+    )
+    topk_spy.assert_not_called()
+    assert _enqueued_tensor_ids(engine) == [503, 501, 507]
+    assert prefetcher._last_speculative_prediction == {3, 1, 7}
+
+
+def test_explicit_defaults_to_next_layer():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher.speculative_prefetch(2, expert_ids=[0, 2])
+    assert _enqueued_tensor_ids(engine) == [300, 302]
+
+
+def test_explicit_out_of_range_target_layer_is_noop():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    # Default target = 7 + 1 = 8 >= num_layers.
+    prefetcher.speculative_prefetch(7, expert_ids=[1, 2])
+    engine.enqueue_prefetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (c) empty explicit set is a safe no-op
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_empty_list_is_noop():
+    prefetcher, engine = _make_prefetcher()
+    prefetcher.speculative_prefetch(0, expert_ids=[])
+    engine.enqueue_prefetch.assert_not_called()
+    engine.get_node_default_device.assert_not_called()
+    assert prefetcher._last_speculative_prediction == set()
+
+
+# ---------------------------------------------------------------------------
+# (d) neither argument -> ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_both_none_raises_value_error():
+    prefetcher, _engine = _make_prefetcher()
+    with pytest.raises(ValueError, match="router_logits"):
+        prefetcher.speculative_prefetch(0)

--- a/tests/python/dflash/test_tiny_fixtures.py
+++ b/tests/python/dflash/test_tiny_fixtures.py
@@ -34,8 +34,12 @@ PROMPT = torch.tensor([[3, 7, 11, 2, 5]])
 
 
 def test_tiny_target_greedy_bit_reproducible_across_fresh_builds():
-    g1 = plain_greedy_decode(build_tiny_target(seed=0), PROMPT, max_new_tokens=32)
-    g2 = plain_greedy_decode(build_tiny_target(seed=0), PROMPT, max_new_tokens=32)
+    g1 = plain_greedy_decode(
+        build_tiny_target(seed=0), PROMPT, max_new_tokens=32
+    )
+    g2 = plain_greedy_decode(
+        build_tiny_target(seed=0), PROMPT, max_new_tokens=32
+    )
 
     assert g1.dtype == torch.long
     assert tuple(g1.shape) == (1, PROMPT.shape[1] + 32)
@@ -62,13 +66,17 @@ def test_tiny_drafter_shape_via_target_lm_head():
     feature = torch.randn(batch, ctx_len, feat_dim)
 
     anchor = 4
-    block = torch.tensor([[anchor] + [TINY_MASK_TOKEN_ID] * (TINY_BLOCK_SIZE - 1)])
+    block = torch.tensor(
+        [[anchor] + [TINY_MASK_TOKEN_ID] * (TINY_BLOCK_SIZE - 1)]
+    )
     assert tuple(block.shape) == (batch, TINY_BLOCK_SIZE)
 
     with torch.no_grad():
         drafter_out = drafter(block, feature)
         assert tuple(drafter_out.shape) == (batch, TINY_BLOCK_SIZE, TINY_HIDDEN)
-        draft_logits = target.lm_head(drafter_out)[:, -(TINY_BLOCK_SIZE - 1):, :]
+        draft_logits = target.lm_head(drafter_out)[
+            :, -(TINY_BLOCK_SIZE - 1) :, :
+        ]
 
     assert tuple(draft_logits.shape) == (batch, TINY_BLOCK_SIZE - 1, TINY_VOCAB)
     assert torch.isfinite(draft_logits).all()
@@ -78,7 +86,9 @@ def test_tiny_drafter_deterministic_and_non_causal():
     target = build_tiny_target(seed=0)
     drafter = build_tiny_drafter(target, seed=1)
 
-    feature = torch.randn(1, PROMPT.shape[1], len(TINY_TARGET_LAYER_IDS) * TINY_HIDDEN)
+    feature = torch.randn(
+        1, PROMPT.shape[1], len(TINY_TARGET_LAYER_IDS) * TINY_HIDDEN
+    )
     block = torch.tensor([[4] + [TINY_MASK_TOKEN_ID] * (TINY_BLOCK_SIZE - 1)])
 
     with torch.no_grad():
@@ -98,7 +108,9 @@ def test_target_exposes_five_layer_context_feature():
     # hidden_states[0] is the embedding output; layer i output is index i+1.
     assert len(out.hidden_states) == target.config.num_hidden_layers + 1
 
-    feat = context_feature_from_hidden_states(out.hidden_states, TINY_TARGET_LAYER_IDS)
+    feat = context_feature_from_hidden_states(
+        out.hidden_states, TINY_TARGET_LAYER_IDS
+    )
     assert tuple(feat.shape[:2]) == (1, PROMPT.shape[1])
     assert feat.shape[-1] == len(TINY_TARGET_LAYER_IDS) * TINY_HIDDEN
 

--- a/tests/python/integration/_glm_medium.py
+++ b/tests/python/integration/_glm_medium.py
@@ -10,13 +10,17 @@ import torch
 
 
 def build_medium_glm_fp8(save_dir: str) -> str:
-    os.environ.setdefault("HF_HUB_CACHE", "/mnt/raid0nvme0/public/huggingface/hub")
+    os.environ.setdefault(
+        "HF_HUB_CACHE", "/mnt/raid0nvme0/public/huggingface/hub"
+    )
     from transformers import AutoConfig, AutoTokenizer
     from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
         GlmMoeDsaForCausalLM,
     )
 
-    cfg = AutoConfig.from_pretrained("zai-org/GLM-5.2-FP8", trust_remote_code=True)
+    cfg = AutoConfig.from_pretrained(
+        "zai-org/GLM-5.2-FP8", trust_remote_code=True
+    )
 
     # INVARIANT: do NOT shrink these two — the mis-map needs q_a_layernorm[2048]
     # to collide with a router tensor sized [n_routed_experts]=[256].
@@ -85,7 +89,11 @@ def build_medium_glm_fp8(save_dir: str) -> str:
         q_fp8 = q.to(torch.float8_e4m3fn)
         return q_fp8, scale_inv
 
-    expert_weight_suffixes = ("gate_proj.weight", "up_proj.weight", "down_proj.weight")
+    expert_weight_suffixes = (
+        "gate_proj.weight",
+        "up_proj.weight",
+        "down_proj.weight",
+    )
     for name, param in list(model.named_parameters(recurse=True)):
         if "shared_expert" in name:
             continue
@@ -130,9 +138,9 @@ def _assert_checkpoint_qaln(save_dir: str, expected: int = 2048) -> None:
         for k, meta in hdr.items():
             if k.endswith("q_a_layernorm.weight"):
                 shape = meta.get("shape")
-                assert shape == [expected], (
-                    f"checkpoint {k} has shape {shape}, expected [{expected}]"
-                )
+                assert shape == [
+                    expected
+                ], f"checkpoint {k} has shape {shape}, expected [{expected}]"
                 print(f"[medium] checkpoint {k} shape={shape} OK")
                 return
     raise AssertionError("no q_a_layernorm.weight found in checkpoint shards")

--- a/tests/python/integration/_glm_tiny.py
+++ b/tests/python/integration/_glm_tiny.py
@@ -7,11 +7,17 @@ import torch
 
 
 def build_tiny_glm_fp8(save_dir: str, quantize_shared: bool = False) -> str:
-    os.environ.setdefault("HF_HUB_CACHE", "/mnt/raid0nvme0/public/huggingface/hub")
+    os.environ.setdefault(
+        "HF_HUB_CACHE", "/mnt/raid0nvme0/public/huggingface/hub"
+    )
     from transformers import AutoConfig, AutoTokenizer
-    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaForCausalLM
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaForCausalLM,
+    )
 
-    cfg = AutoConfig.from_pretrained("zai-org/GLM-5.2-FP8", trust_remote_code=True)
+    cfg = AutoConfig.from_pretrained(
+        "zai-org/GLM-5.2-FP8", trust_remote_code=True
+    )
 
     cfg.num_hidden_layers = 4
     cfg.hidden_size = 256
@@ -78,7 +84,11 @@ def build_tiny_glm_fp8(save_dir: str, quantize_shared: bool = False) -> str:
         q_fp8 = q.to(torch.float8_e4m3fn)
         return q_fp8, scale_inv
 
-    expert_weight_suffixes = ("gate_proj.weight", "up_proj.weight", "down_proj.weight")
+    expert_weight_suffixes = (
+        "gate_proj.weight",
+        "up_proj.weight",
+        "down_proj.weight",
+    )
     for name, param in list(model.named_parameters(recurse=True)):
         if "shared_expert" in name and not quantize_shared:
             continue
@@ -114,11 +124,17 @@ def build_tiny_glm_fp8(save_dir: str, quantize_shared: bool = False) -> str:
 
 
 def build_tiny_glm(save_dir: str) -> str:
-    os.environ.setdefault("HF_HUB_CACHE", "/mnt/raid0nvme0/public/huggingface/hub")
+    os.environ.setdefault(
+        "HF_HUB_CACHE", "/mnt/raid0nvme0/public/huggingface/hub"
+    )
     from transformers import AutoConfig, AutoTokenizer
-    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaForCausalLM
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaForCausalLM,
+    )
 
-    cfg = AutoConfig.from_pretrained("zai-org/GLM-5.2-FP8", trust_remote_code=True)
+    cfg = AutoConfig.from_pretrained(
+        "zai-org/GLM-5.2-FP8", trust_remote_code=True
+    )
 
     cfg.num_hidden_layers = 4
     cfg.hidden_size = 256

--- a/tests/python/integration/test_glm_bench.py
+++ b/tests/python/integration/test_glm_bench.py
@@ -1,13 +1,17 @@
 import os
+
 import pytest
 
 pytestmark = pytest.mark.gpu
 
 
-@pytest.mark.skipif(os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1")
+@pytest.mark.skipif(
+    os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1"
+)
 def test_glm_bench_writes_csv(tmp_path):
-    import torch
     import csv
+
+    import torch
 
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")

--- a/tests/python/integration/test_glm_fp8_reload_parity.py
+++ b/tests/python/integration/test_glm_fp8_reload_parity.py
@@ -52,7 +52,9 @@ def test_fp8_reload_parity():
     from tests.python.integration._glm_tiny import build_tiny_glm_fp8
 
     with tempfile.TemporaryDirectory() as tmp:
-        ckpt = build_tiny_glm_fp8(os.path.join(tmp, "tiny"), quantize_shared=True)
+        ckpt = build_tiny_glm_fp8(
+            os.path.join(tmp, "tiny"), quantize_shared=True
+        )
         store = os.path.join(tmp, "store")
 
         fresh = _generate_in_subprocess(ckpt, store)

--- a/tests/python/integration/test_glm_fp8_store_parity.py
+++ b/tests/python/integration/test_glm_fp8_store_parity.py
@@ -52,9 +52,13 @@ def test_fp8_store_reproducible():
     from tests.python.integration._glm_tiny import build_tiny_glm_fp8
 
     with tempfile.TemporaryDirectory() as tmp:
-        ckpt = build_tiny_glm_fp8(os.path.join(tmp, "tiny"), quantize_shared=True)
+        ckpt = build_tiny_glm_fp8(
+            os.path.join(tmp, "tiny"), quantize_shared=True
+        )
 
         out_a = _generate_in_subprocess(ckpt, os.path.join(tmp, "off_a"))
         out_b = _generate_in_subprocess(ckpt, os.path.join(tmp, "off_b"))
 
-        assert out_a == out_b, f"Independent fresh stores diverged: {out_a} vs {out_b}"
+        assert (
+            out_a == out_b
+        ), f"Independent fresh stores diverged: {out_a} vs {out_b}"

--- a/tests/python/integration/test_glm_medium_forward.py
+++ b/tests/python/integration/test_glm_medium_forward.py
@@ -67,6 +67,6 @@ def test_medium_glm_resident_weight_forward(tmp_path):
         "medium GLM forward did not complete; resident-weight mis-map likely.\n"
         f"returncode={proc.returncode}\n{combined[-3000:]}"
     )
-    assert "QALN_LASTDIM=2048" in proc.stdout, (
-        f"q_a_layernorm loaded with wrong last dim.\n{combined[-2000:]}"
-    )
+    assert (
+        "QALN_LASTDIM=2048" in proc.stdout
+    ), f"q_a_layernorm loaded with wrong last dim.\n{combined[-2000:]}"

--- a/tests/python/integration/test_glm_mtp.py
+++ b/tests/python/integration/test_glm_mtp.py
@@ -1,21 +1,31 @@
 import os
+
 import pytest
 
 pytestmark = pytest.mark.gpu
 
 
-@pytest.mark.skipif(os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1")
+@pytest.mark.skipif(
+    os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1"
+)
 def test_glm_mtp_lossless(tmp_path):
     import torch
+
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
-    from tests.python.integration._glm_tiny import build_tiny_glm
     from moe_infinity import MoE
     from moe_infinity.spec_decode.glm_mtp import GlmMtpSpeculator
+    from tests.python.integration._glm_tiny import build_tiny_glm
 
     d = build_tiny_glm(str(tmp_path / "tiny"))
-    model = MoE(d, {"offload_path": str(tmp_path / "off"), "device_memory_ratio": 0.8})
+    model = MoE(
+        d, {"offload_path": str(tmp_path / "off"), "device_memory_ratio": 0.8}
+    )
     ids = torch.tensor([[1, 2, 3, 4, 5]], device="cuda")
     greedy = model.generate(ids, max_new_tokens=12)
-    spec = GlmMtpSpeculator(model).generate(ids, max_new_tokens=12, temperature=0.0)
-    assert torch.equal(greedy, spec), f"MTP spec-decode NOT lossless:\n greedy={greedy}\n spec  ={spec}"
+    spec = GlmMtpSpeculator(model).generate(
+        ids, max_new_tokens=12, temperature=0.0
+    )
+    assert torch.equal(
+        greedy, spec
+    ), f"MTP spec-decode NOT lossless:\n greedy={greedy}\n spec  ={spec}"

--- a/tests/python/integration/test_glm_mtp_stats.py
+++ b/tests/python/integration/test_glm_mtp_stats.py
@@ -1,22 +1,27 @@
 import os
+
 import pytest
 
 pytestmark = pytest.mark.gpu
 
 
-@pytest.mark.skipif(os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1")
+@pytest.mark.skipif(
+    os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1"
+)
 def test_mtp_stats_and_parity(tmp_path):
     import torch
 
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
 
-    from tests.python.integration._glm_tiny import build_tiny_glm
     from moe_infinity import MoE
     from moe_infinity.spec_decode.glm_mtp import GlmMtpSpeculator
+    from tests.python.integration._glm_tiny import build_tiny_glm
 
     d = build_tiny_glm(str(tmp_path / "tiny"))
-    model = MoE(d, {"offload_path": str(tmp_path / "off"), "device_memory_ratio": 0.8})
+    model = MoE(
+        d, {"offload_path": str(tmp_path / "off"), "device_memory_ratio": 0.8}
+    )
     ids = torch.tensor([[1, 2, 3, 4, 5]], device="cuda")
     greedy = model.generate(ids, max_new_tokens=10)
     spec = GlmMtpSpeculator(model)

--- a/tests/python/integration/test_glm_serving.py
+++ b/tests/python/integration/test_glm_serving.py
@@ -84,9 +84,9 @@ def test_glm_serving_completions(tmp_path):
         assert "choices" in result, f"No choices in response: {result}"
         assert len(result["choices"]) > 0
         text = result["choices"][0].get("text", "")
-        assert isinstance(text, str) and len(text) > 0, (
-            f"Expected non-empty text, got: {result}"
-        )
+        assert (
+            isinstance(text, str) and len(text) > 0
+        ), f"Expected non-empty text, got: {result}"
 
         chat_payload = json.dumps(
             {
@@ -103,15 +103,17 @@ def test_glm_serving_completions(tmp_path):
         with urllib.request.urlopen(chat_req, timeout=60) as resp:
             chat_result = json.loads(resp.read())
 
-        assert "choices" in chat_result, f"No choices in chat response: {chat_result}"
+        assert (
+            "choices" in chat_result
+        ), f"No choices in chat response: {chat_result}"
         assert len(chat_result["choices"]) > 0
         msg = chat_result["choices"][0].get("message", {})
-        assert isinstance(msg.get("content"), str) and len(msg["content"]) > 0, (
-            f"Expected non-empty message content, got: {chat_result}"
-        )
-        assert "finish_reason" in chat_result["choices"][0], (
-            f"Missing finish_reason: {chat_result}"
-        )
+        assert (
+            isinstance(msg.get("content"), str) and len(msg["content"]) > 0
+        ), f"Expected non-empty message content, got: {chat_result}"
+        assert (
+            "finish_reason" in chat_result["choices"][0]
+        ), f"Missing finish_reason: {chat_result}"
 
         stream_payload = json.dumps(
             {
@@ -134,11 +136,13 @@ def test_glm_serving_completions(tmp_path):
                     break
                 line = raw_line.decode("utf-8").strip()
                 if line.startswith("data:"):
-                    chunk = line[len("data:"):].strip()
+                    chunk = line[len("data:") :].strip()
                     if chunk and chunk != "[DONE]":
                         data_chunks.append(chunk)
 
-        assert len(data_chunks) > 0, "No SSE data chunks received from streaming endpoint"
+        assert (
+            len(data_chunks) > 0
+        ), "No SSE data chunks received from streaming endpoint"
 
     finally:
         proc.kill()

--- a/tests/python/integration/test_glm_tiny_generate.py
+++ b/tests/python/integration/test_glm_tiny_generate.py
@@ -1,19 +1,26 @@
 import os
+
 import pytest
 
 pytestmark = pytest.mark.gpu
 
 
-@pytest.mark.skipif(os.environ.get("MOE_GLM_TINY") != "1", reason="set MOE_GLM_TINY=1 to run tiny-GLM GPU harness")
+@pytest.mark.skipif(
+    os.environ.get("MOE_GLM_TINY") != "1",
+    reason="set MOE_GLM_TINY=1 to run tiny-GLM GPU harness",
+)
 def test_tiny_glm_generates(tmp_path):
     import torch
+
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
-    from tests.python.integration._glm_tiny import build_tiny_glm
     from moe_infinity import MoE
+    from tests.python.integration._glm_tiny import build_tiny_glm
 
     d = build_tiny_glm(str(tmp_path / "tiny"))
-    model = MoE(d, {"offload_path": str(tmp_path / "off"), "device_memory_ratio": 0.8})
+    model = MoE(
+        d, {"offload_path": str(tmp_path / "off"), "device_memory_ratio": 0.8}
+    )
     ids = torch.tensor([[1, 2, 3, 4]], device="cuda")
     out = model.generate(ids, max_new_tokens=8)
     assert out.shape[1] >= ids.shape[1] + 1

--- a/tests/python/perf_model/test_glm_report.py
+++ b/tests/python/perf_model/test_glm_report.py
@@ -1,9 +1,10 @@
 import csv
 import io
 import math
-import pytest
-from benchmarks.performance_model.report_glm import summarize
 
+import pytest
+
+from benchmarks.performance_model.report_glm import summarize
 
 FIXTURE_CSV = """\
 model,batch,seq_len,gen_len,decode_tok_s,mtp_tok_s,mean_accept_len,peak_mem_bytes,pred_flops_per_token,pred_hbm_bytes_per_token,pred_bound
@@ -24,8 +25,12 @@ def test_summarize_arithmetic_intensity(tmp_path):
     p.write_text(FIXTURE_CSV)
     s = summarize(str(p))
     rows = s["rows"]
-    assert math.isclose(rows[0]["arithmetic_intensity"], 4000000 / 2000000, rel_tol=1e-6)
-    assert math.isclose(rows[1]["arithmetic_intensity"], 8000000 / 2000000, rel_tol=1e-6)
+    assert math.isclose(
+        rows[0]["arithmetic_intensity"], 4000000 / 2000000, rel_tol=1e-6
+    )
+    assert math.isclose(
+        rows[1]["arithmetic_intensity"], 8000000 / 2000000, rel_tol=1e-6
+    )
 
 
 def test_summarize_mtp_speedup(tmp_path):
@@ -41,7 +46,9 @@ def test_summarize_averages(tmp_path):
     p = tmp_path / "bench.csv"
     p.write_text(FIXTURE_CSV)
     s = summarize(str(p))
-    assert math.isclose(s["avg_decode_tok_s"], (200.0 + 400.0) / 2, rel_tol=1e-6)
+    assert math.isclose(
+        s["avg_decode_tok_s"], (200.0 + 400.0) / 2, rel_tol=1e-6
+    )
     assert math.isclose(s["avg_mtp_tok_s"], (100.0 + 600.0) / 2, rel_tol=1e-6)
     assert math.isclose(s["avg_mean_accept_len"], (1.5 + 2.0) / 2, rel_tol=1e-6)
 
@@ -54,12 +61,14 @@ def test_summarize_bounds(tmp_path):
 
 
 @pytest.mark.skipif(
-    pytest.importorskip("matplotlib", reason="matplotlib not available") is None,
+    pytest.importorskip("matplotlib", reason="matplotlib not available")
+    is None,
     reason="matplotlib not available",
 )
 def test_make_plots_creates_pngs(tmp_path):
     matplotlib = pytest.importorskip("matplotlib")
     from benchmarks.performance_model.report_glm import make_plots
+
     p = tmp_path / "bench.csv"
     p.write_text(FIXTURE_CSV)
     out_dir = tmp_path / "plots"

--- a/tests/python/perf_model/test_glm_roofline.py
+++ b/tests/python/perf_model/test_glm_roofline.py
@@ -1,14 +1,15 @@
 import os
+
 import pytest
 
-from benchmarks.performance_model.types import ModelParams, WorkloadPoint
 from benchmarks.performance_model.roofline import (
+    classify_bound,
     decode_flops_per_token,
     decode_hbm_bytes_per_token,
     dtype_bytes,
-    classify_bound,
     predict_decode,
 )
+from benchmarks.performance_model.types import ModelParams, WorkloadPoint
 
 GLM_SYNTHETIC = ModelParams(
     name="glm-synthetic",

--- a/tests/python/serving/test_api_routes.py
+++ b/tests/python/serving/test_api_routes.py
@@ -153,6 +153,46 @@ def test_list_models(client: TestClient) -> None:
     assert payload["data"][0]["object"] == "model"
 
 
+def test_initialize_with_model_forwards_speculative_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _capture_engine(**kwargs: Any) -> MagicMock:
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(srv, "ContinuousBatchingEngine", _capture_engine)
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            hidden_size=32,
+            head_dim=8,
+            max_position_embeddings=128,
+            eos_token_id=2,
+            dtype="float32",
+        ),
+        dtype="float32",
+    )
+    offload_engine = object()
+    moe_model = SimpleNamespace(model=model, engine=offload_engine)
+    speculator = object()
+
+    srv.initialize_with_model(
+        moe_model=moe_model,
+        model_name="test-model",
+        tok=None,
+        max_seq_length=128,
+        speculative_draft=speculator,
+    )
+
+    assert captured["model"] is model
+    assert captured["engine"] is offload_engine
+    assert captured["speculative_draft"] is speculator
+
+
 def test_list_models_engine_not_ready(client: TestClient) -> None:
     srv.engine = None
 

--- a/tests/python/serving/test_engine.py
+++ b/tests/python/serving/test_engine.py
@@ -162,6 +162,33 @@ class MockTokenizer:
         return "".join(f"tok-{token_id}" for token_id in ids)
 
 
+class MockSpeculator:
+    calls: int
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        max_new_tokens: int,
+        temperature: float = 0.0,
+        stop_token_ids: list[int] | None = None,
+        top_k: int = 0,
+        top_p: float = 1.0,
+    ) -> torch.Tensor:
+        _ = (temperature, stop_token_ids, top_k, top_p)
+        self.calls += 1
+        last_token = int(input_ids[0, -1].item())
+        continuation = torch.arange(
+            last_token + 1,
+            last_token + max_new_tokens + 1,
+            dtype=input_ids.dtype,
+            device=input_ids.device,
+        ).unsqueeze(0)
+        return torch.cat([input_ids, continuation], dim=1)
+
+
 def _make_config() -> dict[str, object]:
     return {
         "device_memory_ratio": 0.75,
@@ -215,6 +242,97 @@ def test_engine_single_request_run_until_done() -> None:
         "total_tokens": 4,
     }
     assert engine.has_pending_requests() is False
+
+
+def test_engine_delegates_single_greedy_request_to_speculator() -> None:
+    speculator = MockSpeculator()
+    engine = ContinuousBatchingEngine(
+        model=MockModel(),
+        engine=MockOffloadEngine(),
+        config=_make_config(),
+        tokenizer=MockTokenizer(),
+        speculative_draft=speculator,
+    )
+    callback_outputs: list[RequestOutput] = []
+    engine.add_request(
+        request_id="req-spec",
+        prompt_token_ids=[10],
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=3),
+        on_token=callback_outputs.append,
+    )
+
+    step_outputs = engine.step()
+
+    assert speculator.calls == 1
+    assert [output.token_id for output in step_outputs] == [11, 12, 13]
+    assert [output.token_id for output in callback_outputs] == [11, 12, 13]
+    assert step_outputs[-1].finished is True
+    assert step_outputs[-1].finish_reason == "length"
+    assert engine.get_request_n_outputs("req-spec") == [[11, 12, 13]]
+    assert engine.has_pending_requests() is False
+
+
+def test_engine_does_not_delegate_sampled_request_to_speculator() -> None:
+    speculator = MockSpeculator()
+    engine = ContinuousBatchingEngine(
+        model=MockModel(),
+        engine=MockOffloadEngine(),
+        config=_make_config(),
+        speculative_draft=speculator,
+    )
+    engine.add_request(
+        request_id="req-sampled",
+        prompt_token_ids=[10],
+        sampling_params=SamplingParams(temperature=1.0, max_tokens=1),
+    )
+
+    _ = engine.run_until_done()
+
+    assert speculator.calls == 0
+
+
+def test_engine_does_not_delegate_stop_string_request() -> None:
+    speculator = MockSpeculator()
+    engine = ContinuousBatchingEngine(
+        model=MockModel(),
+        engine=MockOffloadEngine(),
+        config=_make_config(),
+        speculative_draft=speculator,
+    )
+    engine.add_request(
+        request_id="req-stop",
+        prompt_token_ids=[10],
+        sampling_params=SamplingParams(
+            temperature=0.0,
+            max_tokens=1,
+            stop=["tok-11"],
+        ),
+    )
+
+    _ = engine.run_until_done()
+
+    assert speculator.calls == 0
+
+
+def test_engine_does_not_delegate_past_step_token_budget() -> None:
+    speculator = MockSpeculator()
+    config = _make_config()
+    config["max_tokens_per_step"] = 2
+    engine = ContinuousBatchingEngine(
+        model=MockModel(),
+        engine=MockOffloadEngine(),
+        config=config,
+        speculative_draft=speculator,
+    )
+    engine.add_request(
+        request_id="req-large",
+        prompt_token_ids=[10],
+        sampling_params=SamplingParams(temperature=0.0, max_tokens=3),
+    )
+
+    _ = engine.run_until_done()
+
+    assert speculator.calls == 0
 
 
 def test_engine_multiple_requests() -> None:

--- a/tests/python/unit/test_fp8_utils.py
+++ b/tests/python/unit/test_fp8_utils.py
@@ -1,7 +1,7 @@
-import torch
 import pytest
+import torch
 
-from moe_infinity.utils.fp8 import dequant_fp8_blockwise, FP8_BLOCK
+from moe_infinity.utils.fp8 import FP8_BLOCK, dequant_fp8_blockwise
 
 
 def test_fp8_block_constant():
@@ -11,7 +11,9 @@ def test_fp8_block_constant():
 def test_dequant_known_4x4_block():
     weight = torch.ones(4, 4, dtype=torch.float32)
     scale = torch.tensor([[2.0]], dtype=torch.float32)
-    result = dequant_fp8_blockwise(weight, scale, dtype=torch.bfloat16, block_size=4)
+    result = dequant_fp8_blockwise(
+        weight, scale, dtype=torch.bfloat16, block_size=4
+    )
     expected = torch.full((4, 4), 2.0, dtype=torch.bfloat16)
     assert result.shape == (4, 4)
     assert result.dtype == torch.bfloat16
@@ -23,7 +25,9 @@ def test_dequant_non_divisible_block_boundary():
     block_size = 4
     weight = torch.ones(n, k, dtype=torch.float32)
     scale = torch.ones(2, 2, dtype=torch.float32) * 3.0
-    result = dequant_fp8_blockwise(weight, scale, dtype=torch.bfloat16, block_size=block_size)
+    result = dequant_fp8_blockwise(
+        weight, scale, dtype=torch.bfloat16, block_size=block_size
+    )
     expected = torch.full((n, k), 3.0, dtype=torch.bfloat16)
     assert result.shape == (n, k)
     assert torch.allclose(result.float(), expected.float(), atol=1e-3)
@@ -33,24 +37,35 @@ def test_dequant_per_block_scale_values():
     block_size = 2
     weight = torch.ones(4, 4, dtype=torch.float32)
     scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
-    result = dequant_fp8_blockwise(weight, scale, dtype=torch.float32, block_size=block_size)
-    expected = torch.tensor([
-        [1.0, 1.0, 2.0, 2.0],
-        [1.0, 1.0, 2.0, 2.0],
-        [3.0, 3.0, 4.0, 4.0],
-        [3.0, 3.0, 4.0, 4.0],
-    ], dtype=torch.float32)
+    result = dequant_fp8_blockwise(
+        weight, scale, dtype=torch.float32, block_size=block_size
+    )
+    expected = torch.tensor(
+        [
+            [1.0, 1.0, 2.0, 2.0],
+            [1.0, 1.0, 2.0, 2.0],
+            [3.0, 3.0, 4.0, 4.0],
+            [3.0, 3.0, 4.0, 4.0],
+        ],
+        dtype=torch.float32,
+    )
     assert torch.allclose(result, expected, atol=1e-3)
 
 
 def test_back_compat_import_from_fp8_expert():
-    from moe_infinity.models.deepseek_v4.fp8_expert import dequant_fp8_blockwise as fn
     from moe_infinity.models.deepseek_v4.fp8_expert import FP8_BLOCK as blk
+    from moe_infinity.models.deepseek_v4.fp8_expert import (
+        dequant_fp8_blockwise as fn,
+    )
+
     assert blk == 128
     assert callable(fn)
 
 
 def test_back_compat_same_function():
+    from moe_infinity.models.deepseek_v4.fp8_expert import (
+        dequant_fp8_blockwise as fn_expert,
+    )
     from moe_infinity.utils.fp8 import dequant_fp8_blockwise as fn_utils
-    from moe_infinity.models.deepseek_v4.fp8_expert import dequant_fp8_blockwise as fn_expert
+
     assert fn_utils is fn_expert

--- a/tests/python/unit/test_glm_base_contract.py
+++ b/tests/python/unit/test_glm_base_contract.py
@@ -36,7 +36,7 @@ def test_glm_parse_moe_param_and_expert_id():
 
 
 def test_glm_wrapper_and_offload_importable():
-    from moe_infinity.models import SyncGlmMoeDsaMoEBlock
     import moe_infinity.runtime.model_offload  # noqa: F401
+    from moe_infinity.models import SyncGlmMoeDsaMoEBlock
 
     assert SyncGlmMoeDsaMoEBlock is not None

--- a/tests/python/unit/test_glm_budget.py
+++ b/tests/python/unit/test_glm_budget.py
@@ -2,20 +2,23 @@ import pytest
 
 
 class _Props96:
-    total_memory = 96 * 1024 ** 3
+    total_memory = 96 * 1024**3
     multi_processor_count = 188
 
 
 class _Props80:
-    total_memory = 80 * 1024 ** 3
+    total_memory = 80 * 1024**3
     multi_processor_count = 108
 
 
 def _patch_cuda(monkeypatch, props):
     import torch
+
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True, raising=True)
     monkeypatch.setattr(torch.cuda, "device_count", lambda: 1, raising=True)
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda d: props, raising=True)
+    monkeypatch.setattr(
+        torch.cuda, "get_device_properties", lambda d: props, raising=True
+    )
 
 
 def test_expert_and_kv_budget_within_total(monkeypatch):
@@ -24,14 +27,18 @@ def test_expert_and_kv_budget_within_total(monkeypatch):
     total = _Props96.total_memory
     _patch_cuda(monkeypatch, _Props96())
 
-    coord = MemoryCoordinator(device_memory_ratio=0.5, kv_cache_memory_ratio=0.15)
+    coord = MemoryCoordinator(
+        device_memory_ratio=0.5, kv_cache_memory_ratio=0.15
+    )
     got = coord.total_gpu_memory_bytes(0)
     assert got == total
 
     prev_ec = None
     for dmr in (0.2, 0.5, 0.9):
         kvr = min(0.05, 1.0 - dmr)
-        coord2 = MemoryCoordinator(device_memory_ratio=dmr, kv_cache_memory_ratio=kvr)
+        coord2 = MemoryCoordinator(
+            device_memory_ratio=dmr, kv_cache_memory_ratio=kvr
+        )
         ec = coord2.expert_cache_bytes(0)
         kv = coord2.kv_cache_bytes(0)
         assert 0 <= ec <= total
@@ -48,7 +55,9 @@ def test_remaining_bytes_non_negative(monkeypatch):
     total = _Props80.total_memory
     _patch_cuda(monkeypatch, _Props80())
 
-    coord = MemoryCoordinator(device_memory_ratio=0.4, kv_cache_memory_ratio=0.25)
+    coord = MemoryCoordinator(
+        device_memory_ratio=0.4, kv_cache_memory_ratio=0.25
+    )
     rem = coord.remaining_bytes(0)
     assert rem >= 0
     assert rem == total - coord.expert_cache_bytes(0) - coord.kv_cache_bytes(0)
@@ -68,10 +77,15 @@ def test_from_config_glm_seq4k(monkeypatch):
     _patch_cuda(monkeypatch, _Props96())
 
     import warnings
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         coord = MemoryCoordinator.from_config(
-            {"device_memory_ratio": 0.7, "kv_cache_memory_ratio": 0.15, "use_native_engine": True}
+            {
+                "device_memory_ratio": 0.7,
+                "kv_cache_memory_ratio": 0.15,
+                "use_native_engine": True,
+            }
         )
     assert coord.device_memory_ratio == pytest.approx(0.7)
     assert coord.kv_cache_memory_ratio == pytest.approx(0.15)
@@ -87,10 +101,15 @@ def test_from_config_glm_seq32k(monkeypatch):
     _patch_cuda(monkeypatch, _Props96())
 
     import warnings
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
         coord = MemoryCoordinator.from_config(
-            {"device_memory_ratio": 0.4, "kv_cache_memory_ratio": 0.25, "use_native_engine": True}
+            {
+                "device_memory_ratio": 0.4,
+                "kv_cache_memory_ratio": 0.25,
+                "use_native_engine": True,
+            }
         )
     assert coord.device_memory_ratio == pytest.approx(0.4)
     assert coord.kv_cache_memory_ratio == pytest.approx(0.25)

--- a/tests/python/unit/test_glm_fp8_native_dequant.py
+++ b/tests/python/unit/test_glm_fp8_native_dequant.py
@@ -16,7 +16,10 @@ def test_native_fp8_dequant_matches_python():
     torch.manual_seed(0)
     N, K = 256, 512
     w = torch.randn(N, K, device="cuda").to(torch.float8_e4m3fn)
-    s = torch.rand((N // 128, K // 128), device="cuda", dtype=torch.float32) + 0.5
+    s = (
+        torch.rand((N // 128, K // 128), device="cuda", dtype=torch.float32)
+        + 0.5
+    )
     ref = dequant_fp8_blockwise(w, s, dtype=torch.bfloat16, block_size=128)
     got = fp8_dequant_blockwise(w, s).to(torch.bfloat16)
     assert torch.allclose(got.float(), ref.float(), atol=1e-2, rtol=1e-2)

--- a/tests/python/unit/test_glm_indexshare.py
+++ b/tests/python/unit/test_glm_indexshare.py
@@ -1,5 +1,10 @@
 import pytest
-from moe_infinity.models.glm_dsa import num_owned_indexers, indexer_owner_map, owns_indexer
+
+from moe_infinity.models.glm_dsa import (
+    indexer_owner_map,
+    num_owned_indexers,
+    owns_indexer,
+)
 
 _GLM_LOCAL = "/mnt/raid0nvme0/public/huggingface/hub/models--zai-org--GLM-5.2-FP8/snapshots/ba978f7d347eaf65d22f1a86833408afdb953541"
 
@@ -7,10 +12,15 @@ _GLM_LOCAL = "/mnt/raid0nvme0/public/huggingface/hub/models--zai-org--GLM-5.2-FP
 def _real_cfg():
     try:
         from transformers import AutoConfig
+
         try:
-            return AutoConfig.from_pretrained("zai-org/GLM-5.2-FP8", trust_remote_code=True)
+            return AutoConfig.from_pretrained(
+                "zai-org/GLM-5.2-FP8", trust_remote_code=True
+            )
         except Exception:
-            return AutoConfig.from_pretrained(_GLM_LOCAL, trust_remote_code=True)
+            return AutoConfig.from_pretrained(
+                _GLM_LOCAL, trust_remote_code=True
+            )
     except Exception:
         pytest.skip("GLM config unavailable offline")
 
@@ -26,4 +36,6 @@ def test_shared_layers_map_to_full_owner():
     m = indexer_owner_map(cfg)
     for layer, owner in m.items():
         if owner is not None:
-            assert owns_indexer(cfg, owner), f"layer {layer} owner {owner} must be a 'full' layer"
+            assert owns_indexer(
+                cfg, owner
+            ), f"layer {layer} owner {owner} must be a 'full' layer"

--- a/tests/python/unit/test_glm_mla.py
+++ b/tests/python/unit/test_glm_mla.py
@@ -1,5 +1,6 @@
-import pytest
 from types import SimpleNamespace
+
+import pytest
 
 pytest.importorskip(
     "transformers.models.glm_moe_dsa.modeling_glm_moe_dsa",
@@ -31,9 +32,10 @@ _MLA_NAMES = [
 
 @pytest.mark.parametrize("name", _MLA_NAMES)
 def test_mla_and_indexer_not_experts(name):
-    assert parse_expert_id(name, GLM) == (None, None), (
-        f"MLA tensor misrouted as expert: {name}"
-    )
+    assert parse_expert_id(name, GLM) == (
+        None,
+        None,
+    ), f"MLA tensor misrouted as expert: {name}"
 
 
 def test_shared_expert_not_routed():
@@ -42,11 +44,15 @@ def test_shared_expert_not_routed():
 
 
 def test_real_expert_still_routed():
-    assert parse_expert_id("model.layers.5.mlp.experts.7.gate_proj.weight", GLM) == (5, 7)
+    assert parse_expert_id(
+        "model.layers.5.mlp.experts.7.gate_proj.weight", GLM
+    ) == (5, 7)
 
 
 def test_real_expert_layer_0():
-    assert parse_expert_id("model.layers.0.mlp.experts.0.up_proj.weight", GLM) == (0, 0)
+    assert parse_expert_id(
+        "model.layers.0.mlp.experts.0.up_proj.weight", GLM
+    ) == (0, 0)
 
 
 def test_real_expert_last_layer():

--- a/tests/python/unit/test_glm_offload_wiring.py
+++ b/tests/python/unit/test_glm_offload_wiring.py
@@ -6,32 +6,39 @@ import pytest
 
 def test_glm_patch_replaces_moe_class():
     import transformers.models.glm_moe_dsa.modeling_glm_moe_dsa as glm_mod
+
     from moe_infinity.models import SyncGlmMoeDsaMoEBlock
 
     original = glm_mod.GlmMoeDsaMoE
 
     import transformers.models.glm_moe_dsa.modeling_glm_moe_dsa as _glm_mod
+
     _glm_mod._old_glm_moe_dsa_moe = _glm_mod.GlmMoeDsaMoE
     _glm_mod.GlmMoeDsaMoE = SyncGlmMoeDsaMoEBlock
 
-    assert glm_mod.GlmMoeDsaMoE is SyncGlmMoeDsaMoEBlock, (
-        "Patch did not replace GlmMoeDsaMoE with SyncGlmMoeDsaMoEBlock"
-    )
+    assert (
+        glm_mod.GlmMoeDsaMoE is SyncGlmMoeDsaMoEBlock
+    ), "Patch did not replace GlmMoeDsaMoE with SyncGlmMoeDsaMoEBlock"
 
     if hasattr(_glm_mod, "_old_glm_moe_dsa_moe"):
         _glm_mod.GlmMoeDsaMoE = _glm_mod._old_glm_moe_dsa_moe
 
-    assert glm_mod.GlmMoeDsaMoE is original, (
-        "Unpatch did not restore original GlmMoeDsaMoE"
-    )
+    assert (
+        glm_mod.GlmMoeDsaMoE is original
+    ), "Unpatch did not restore original GlmMoeDsaMoE"
 
 
 def test_sync_glm_moe_block_importable():
     from moe_infinity.models import SyncGlmMoeDsaMoEBlock
+
     assert SyncGlmMoeDsaMoEBlock is not None
 
 
 def test_model_offload_imports_sync_glm():
     import moe_infinity.runtime.model_offload as mo
     from moe_infinity.models import SyncGlmMoeDsaMoEBlock
-    assert hasattr(mo, "SyncGlmMoeDsaMoEBlock") or SyncGlmMoeDsaMoEBlock is not None
+
+    assert (
+        hasattr(mo, "SyncGlmMoeDsaMoEBlock")
+        or SyncGlmMoeDsaMoEBlock is not None
+    )

--- a/tests/python/unit/test_glm_registry.py
+++ b/tests/python/unit/test_glm_registry.py
@@ -33,9 +33,9 @@ def test_glmmoedsa_class_not_none():
 
     cls = MODEL_MAPPING_NAMES["glmmoedsa"]
     assert cls is not None, "MODEL_MAPPING_NAMES['glmmoedsa'] must not be None"
-    assert hasattr(cls, "__name__"), (
-        "MODEL_MAPPING_NAMES['glmmoedsa'] must have __name__"
-    )
+    assert hasattr(
+        cls, "__name__"
+    ), "MODEL_MAPPING_NAMES['glmmoedsa'] must have __name__"
     assert cls.__name__ == "GlmMoeDsaForCausalLM"
 
 
@@ -45,13 +45,14 @@ def test_parse_expert_type_glmmoedsa():
 
     config = SimpleNamespace(architectures=["GlmMoeDsaForCausalLM"])
     result = parse_expert_type(cast(Any, config))
-    assert result == 5, (
-        f"parse_expert_type with GlmMoeDsaForCausalLM expected 5, got {result}"
-    )
+    assert (
+        result == 5
+    ), f"parse_expert_type with GlmMoeDsaForCausalLM expected 5, got {result}"
 
 
 def test_guarded_import_does_not_crash_when_unavailable():
     import importlib
+
     import moe_infinity.common.constants as _mod
 
     with patch.dict(sys.modules, {"transformers": None}):
@@ -61,15 +62,17 @@ def test_guarded_import_does_not_crash_when_unavailable():
     import transformers as _tf
 
     if not hasattr(_tf, glm_cls_name):
-        pytest.skip(f"transformers does not export {glm_cls_name} — guard path not reachable in this env")
+        pytest.skip(
+            f"transformers does not export {glm_cls_name} — guard path not reachable in this env"
+        )
 
-    assert hasattr(_mod, "GlmMoeDsaForCausalLM"), (
-        "constants module must expose GlmMoeDsaForCausalLM (or None) at module level"
-    )
+    assert hasattr(
+        _mod, "GlmMoeDsaForCausalLM"
+    ), "constants module must expose GlmMoeDsaForCausalLM (or None) at module level"
 
 
 def test_glmmoedsa_substring_match():
     arch_lower = "GlmMoeDsaForCausalLM".lower()
-    assert "glmmoedsa" in arch_lower, (
-        f"Key 'glmmoedsa' is not a substring of '{arch_lower}'"
-    )
+    assert (
+        "glmmoedsa" in arch_lower
+    ), f"Key 'glmmoedsa' is not a substring of '{arch_lower}'"

--- a/tests/python/unit/test_glm_routing.py
+++ b/tests/python/unit/test_glm_routing.py
@@ -10,7 +10,9 @@ pytest.importorskip(
 
 
 def _tiny_config():
-    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaConfig
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaConfig,
+    )
 
     return GlmMoeDsaConfig(
         n_routed_experts=8,
@@ -34,15 +36,18 @@ def test_no_handrolled_softmax():
 
 
 def test_exported():
-    from moe_infinity.models import SyncGlmMoeDsaMoEBlock
     import moe_infinity.models as m
+    from moe_infinity.models import SyncGlmMoeDsaMoEBlock
 
     assert SyncGlmMoeDsaMoEBlock is not None
     assert "SyncGlmMoeDsaMoEBlock" in m.__all__
 
 
 def test_routing_parity():
-    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import GlmMoeDsaMoE
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaMoE,
+    )
+
     from moe_infinity.models.glm_moe_dsa import SyncGlmMoeDsaMoEBlock
 
     cfg = _tiny_config()


### PR DESCRIPTION
Extends the native DFlash speculator (stacks on `feat/dflash-spec-decode`) with the deferred tracks A-D plus a drafter-driven contract. 5 atomic commits:

1. **feat(dflash): route-ahead expert prefetch (A1-A5)** — during DFlash verify, pin/prefetch the per-token *union* of the block's routed experts via the `dispatch_local` seam (executor-backed MoE). Pure union/coverage/waste helpers, a contextvars route-ahead context, opt-in coverage/waste metrics, and an explicit-set mode on `ExpertPrefetcher.speculative_prefetch` (legacy path byte-identical).
2. **feat(dflash): sampled (non-greedy) accept ops** — distribution-preserving block-diffusion accept for temperature/top-k/top-p; greedy stays byte-identical.
3. **feat(serving): DFlash in the continuous-batching engine** — spec branch in `ContinuousBatchingEngine.step()` for greedy batch==1: paged-KV rollback (`kv_cache.truncate_tokens`), per-seq cached-vs-emitted accounting (`SpecDecodeState`), verify-commit orchestration (`spec_verify.apply_verify_step`), variable-commit scheduler accounting (default byte-identical). Spec-off unchanged.
4. **feat(dflash): speculator core** — batch>1 generalization (batched accept + per-seq rollback), sampled/route-ahead wiring in `generate()`, and **drafter-driven `validate_pairing`** (reads block_size/target_layer_ids from the drafter config instead of hardcoding the gpt-oss-120b contract) so any z-lab DFlash pair loads.
5. **test(dflash): GPU-gated harnesses** — `MOE_DFLASH_GPU`-gated 20b losslessness + serving-vs-sync parity.

**Validation:** `pytest tests/python/dflash` = 253 passed / GPU-gated skips; serving suite green (spec-off byte-identical). GPU-verified: gpt-oss-20b native DFlash == plain greedy (token-identical, ~8.2x decode speedup, offloaded); serving-path DFlash == sync DFlash (token-identical). No wheel rebuild required for these Python paths.