### PR TITLE
docs: add repository-wide feature and operations guides

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,35 @@ If it fixes an issue, link it (e.g., `close #123`).
 - [ ] Breaking change
 - [ ] Documentation update
 
+## Documentation impact
+Check every item that applies.
+
+- [ ] README discovery updated for any user-facing feature or behavior change.
+- [ ] Authoritative feature, config, or API guide updated.
+- [ ] Model compatibility, examples, architecture, or benchmark docs updated if this change touches them.
+- [ ] CHANGELOG `Unreleased` updated.
+- [ ] No docs impact. Explain why in the description or motivation.
+
+Do not check `No docs impact` if any of the update boxes above are checked unless the description explains why the existing docs already cover the change.
+
+## Performance / support evidence
+Use this section for any change that affects performance, supportability, or model behavior. A checked box alone is not enough.
+
+- [ ] Not applicable — explain in the PR description why no performance/support evidence is needed.
+
+| Field | Fill in when applicable |
+| --- | --- |
+| Model / checkpoint | <!-- e.g. `deepseek-ai/DeepSeek-V2-Lite-Chat` --> |
+| Hardware | <!-- e.g. `1× RTX 4090, 24 GB` --> |
+| Software versions | <!-- e.g. `Python 3.12`, `torch 2.8.0+cu128`, `transformers 5.12` --> |
+| Workload | <!-- e.g. `128 prompts`, `batch size 8`, `4K context` --> |
+| Baseline | <!-- e.g. `main@<sha>`, previous release, or alternate path --> |
+| Measured result (if applicable) | <!-- e.g. `TTFT 1.8s → 1.2s`, `throughput 210 tok/s → 256 tok/s` --> |
+| Limitations / validation scope | <!-- e.g. `single GPU only`, `no multi-node validation` --> |
+
+If this change is applicable, fill every row with concrete values. Do not leave the section satisfied by the checkbox alone.
+
 ## Checklist
 - [ ] I have read the [CONTRIBUTION](https://github.com/EfficientMoE/MoE-Infinity/blob/main/CONTRIBUTING.md) guide.
 - [ ] I have updated the tests (if applicable).
-- [ ] I have updated the documentation (if applicable).
+- [ ] I have filled out the documentation impact section above.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # MoE-Infinity Architecture
 
 This document is a map for new contributors. Read it first, then dive into the
-code. Everything in this doc should remain true as the codebase evolves — if
-you change architectural layout, update this file in the same commit.
+code. Everything in this doc should remain true as the codebase evolves. If you
+change the architectural layout, update this file in the same commit.
 
 ## 1. What MoE-Infinity Does
 
@@ -15,7 +15,9 @@ inference on memory-constrained GPUs. Its core trick is **expert offloading**:
   touch slow storage.
 
 On top of the runtime there are two serving paths:
-1. A synchronous HuggingFace-compatible `MoE` class (`MoE.generate(...)`).
+1. The current synchronous HuggingFace-compatible path through the deprecated
+   `MoE.generate(..., speculative_draft=...)` method. It emits
+   `DeprecationWarning` and is scheduled for removal.
 2. An async OpenAI-compatible HTTP server (`api_server_v2.py`) with continuous
    batching, paged KV cache, and streaming.
 
@@ -23,9 +25,9 @@ On top of the runtime there are two serving paths:
 
 All Python source lives under `moe_infinity/`. Two native source trees support
 it:
-- `core/` — the C++/CUDA offload engine (C++ in `core/**/*.cpp`, CUDA in
+- `core/`, the C++/CUDA offload engine (C++ in `core/**/*.cpp`, CUDA in
   `core/**/*.cu`, pybind bindings under `core/python/`).
-- `extensions/kernel/` — standalone CUDA kernels (fused MoE MLP, activation,
+- `extensions/kernel/`, standalone CUDA kernels (fused MoE MLP, activation,
   top-k softmax, paged attention, and the `v4_fp4/` FP4 dequant path).
 
 These compile into the extension modules you see as `_engine.so`,
@@ -45,7 +47,7 @@ moe_infinity/
 │   │                          block classes with Sync* wrappers, sets up
 │   │                          expert tracing
 │   ├── attention_backend.py   Attention backend dispatch (SDPA, FlashAttention,
-│   │                          FlashInfer, placeholder)
+│   │                          FlashInfer, fallback backend)
 │   ├── hooks.py               Forward-pass hooks for tracing and prefetching
 │   └── compile.py             Optional torch.jit compilation of expert MLPs
 │
@@ -57,8 +59,8 @@ moe_infinity/
 │   │                          upstream `transformers`.
 │   └── model_utils.py         Rotary embedding helpers
 │
-├── engine/              Synchronous generation path (powers MoE.generate)
-│   ├── generation_loop.py     GenerationEngine: token-by-token loop
+├── engine/              Deprecated synchronous generation path (powers MoE.generate)
+│   ├── generation_loop.py     GenerationEngine, spec_strategy seam, standard fallback
 │   ├── scheduler.py           Request scheduler with block-level KV allocation
 │   ├── request_manager.py     Thread-safe request lifecycle
 │   ├── types.py               Request, Sequence, SamplingParams, status enums
@@ -67,11 +69,13 @@ moe_infinity/
 │   └── kv_cache_offload_coordinator.py  Orchestrates KV offload to CPU/SSD
 │
 ├── serving/             Async continuous-batching path (powers api_server_v2)
-│   ├── engine.py              ContinuousBatchingEngine: async request loop
+│   ├── engine.py              ContinuousBatchingEngine, async request loop, DFlash gate
 │   ├── scheduler.py           SequenceGroup-level scheduler with paged KV
 │   ├── model_runner.py        Runs a prefill/decode step for a batch
 │   ├── batch.py               BatchBuilder + SchedulerOutput
 │   ├── kv_cache.py            PagedKVCache, BlockAllocator, BlockTable
+│   ├── spec_state.py          SpecDecodeState and committed-count bookkeeping
+│   ├── spec_verify.py         apply_verify_step rollback helper
 │   ├── memory_manager.py      GPU memory budget coordination
 │   ├── sequence.py            SequenceData, SequenceStatus, SamplingParams
 │   ├── sampler.py             Token sampling (temperature, top_p, top_k, stop)
@@ -84,6 +88,14 @@ moe_infinity/
 │   ├── expert_prefetch_coordinator.py   Cross-request prefetch hints
 │   ├── eviction_sync.py       Request-termination → ContextPilot eviction
 │   └── contextpilot_*.py      Optional prompt-optimization middleware
+│
+├── spec_decode/         DFlash speculative decoding and route-ahead support
+│   ├── dflash.py              DFlashSpeculator, config readers, validators,
+│   │                          route-ahead hook
+│   ├── _route_ahead_ctx.py    Verify-time route-ahead contextvars and
+│   │                          prefetch handle
+│   ├── _route_ahead_stats.py  Opt-in route-ahead coverage/waste metrics
+│   └── _prefetch_route.py     Exact expert-set math for route-ahead
 │
 ├── memory/              Expert cache + KV cache memory management
 │   ├── expert_tracer.py       Records expert activation history
@@ -124,69 +136,63 @@ moe_infinity/
 
 ## 3. Two Execution Paths
 
-MoE-Infinity currently has **two separate scheduling paths**. This is
-intentional today but should be unified in a future refactor (see
-[Future Work](#6-future-work)).
+MoE-Infinity has two runtime paths. The deprecated sync path currently owns
+`MoE.generate(..., speculative_draft=...)`. The recommended continuous-batching
+path is the async HTTP service started by `MoE.serve()` or `api_server_v2.py`;
+it is not a drop-in in-process return API.
 
-### Path A — Synchronous (`engine/`)
+### Path A - Deprecated synchronous path (`MoE.generate()`)
 
-Used by `MoE.generate()`. Token-by-token generation, one request at a time.
-
-```
-User code
-   │
-   ▼
-MoE.generate()                            (entrypoints/big_modeling.py)
-   │
-   ▼
-GenerationEngine.generate()               (engine/generation_loop.py)
-   │
-   ├─► Scheduler.schedule_step()          (engine/scheduler.py)
-   │      allocates KV blocks
-   │      produces SchedulerOutput
-   │
-   ├─► model.forward(...)                 HuggingFace model with Sync* MoE blocks
-   │      Sync* block calls
-   │      DistributedExpertExecutor       (distributed/expert_executor.py)
-   │            ↓
-   │      native ExpertDispatcher         (_engine.so, core/)
-   │            ↓
-   │      fetches experts, runs MLPs, merges
-   │
-   └─► Sampler picks next token           (serving/sampler.py — shared)
+```mermaid
+flowchart TD
+  U[User code] --> M[MoE.generate(..., speculative_draft=...)]
+  M --> R[_resolve_spec_strategy()]
+  R -->|None / False / non-greedy / batch>1| S[GenerationEngine._generate_standard()]
+  R -->|attach| E[GenerationEngine.spec_strategy]
+  E --> D[DFlashSpeculator.generate()]
+  D --> F[MoE._native_model_forward_rich()]
+  F --> G[Sync* MoE blocks]
+  G --> X[DistributedExpertExecutor.dispatch_local()]
+  D --> K[accept, rollback, cache rewind]
+  D --> C[route_ahead_context()]
+  C --> P[DistributedExpertExecutor._maybe_route_ahead_prefetch()]
+  C --> O[SyncGptOssMLP._observe_resident_route_ahead()]
 ```
 
-### Path B — Async Continuous Batching (`serving/`)
+Notes:
+- `MoE.generate()` emits `DeprecationWarning` and is scheduled for removal. This
+  diagram records the current transition path rather than a stable method contract.
+- `_resolve_spec_strategy()` attaches a speculator per call. Passing `None` or `False` detaches it and the standard path runs.
+- The greedy gate lives in `GenerationEngine.generate()` and `_spec_strategy_applies()`. If the request is not a singleton greedy decode, the engine uses `_generate_standard()` and the output stays on the pre-DFlash baseline.
+- `DFlashSpeculator._forward_target()` uses `moe._native_model_forward_rich()` when available, so expert dispatch and any configured prefetch hook stay intact.
+- The route-ahead context is verify-only. `DistributedExpertExecutor._maybe_route_ahead_prefetch()` reads the active context, computes the exact expert union from the router mask, and pins that exact set. If the context is inactive, no prefetcher is bound, or the union is empty, the legacy path is unchanged.
+- `SyncGptOssMLP` stays resident. When no executor seam exists, it only records read-only route-ahead stats.
 
-Used by `api_server_v2` and `MoE.serve()`. Many requests in flight, paged KV
-cache, preemption, streaming.
+### Path B - Async continuous batching (`MoE.serve()`)
 
+```mermaid
+flowchart TD
+  R[HTTP request] --> H[api_server_v2 route]
+  H --> A[ContinuousBatchingEngine.add_request()]
+  A --> S[Scheduler.schedule()]
+  S --> B[BatchBuilder.from_scheduler_output()]
+  B --> C{ContinuousBatchingEngine.step()\n_can_delegate_speculative(batch)?}
+  C -->|yes| D[ContinuousBatchingEngine._step_speculative()]
+  C -->|no| E[ContinuousBatchingEngine._execute_batch()]
+  E --> N[Sampler.sample()]
+  D --> G[DFlashSpeculator.generate()]
+  D --> U[Scheduler.update_after_step(... committed_counts=...)]
+  U --> Q[SequenceData + PagedKVCache]
+  R --> X[StreamManager.push_token + SSE]
+  X --> Y[abort_request() on disconnect or cleanup]
 ```
-HTTP request
-   │
-   ▼
-FastAPI handler                           (entrypoints/openai/api_server_v2.py)
-   │
-   ▼
-ContinuousBatchingEngine.add_request()    (serving/engine.py)
-   │
-   ▼  (async loop)
-Scheduler.schedule()                      (serving/scheduler.py)
-   │   sorts WAITING / PREFILL / DECODE queues
-   │   allocates paged KV blocks
-   │   emits SchedulerOutput with separate prefill & decode batches
-   ▼
-BatchBuilder.build()                      (serving/batch.py)
-   │   packs sequences into contiguous tensors
-   ▼
-ModelRunner.run_step()                    (serving/model_runner.py)
-   │   forward pass, calls same Sync* MoE blocks + native engine
-   ▼
-Sampler.sample()                          (serving/sampler.py)
-   │
-   ▼
-StreamManager → SSE response              (serving/stream.py)
-```
+
+Notes:
+- `Scheduler.schedule()` and `BatchBuilder.from_scheduler_output()` run before the speculative gate. `ContinuousBatchingEngine.step()` then checks `_can_delegate_speculative(batch)`; only eligible fresh singleton greedy prefill requests enter `_step_speculative()`, otherwise the normal `_execute_batch()` + sampler path runs.
+- `_step_speculative()` emits one `RequestOutput` per committed token, then calls `scheduler.update_after_step(..., committed_counts={...})`.
+- `Scheduler.update_after_step()` advances `SequenceData`, appends committed tokens through `PagedKVCache.append_tokens()`, and frees completed sequences with `PagedKVCache.free_sequence()`.
+- `serving/spec_state.py` and `serving/spec_verify.py` define low-level tested helper contracts. `SpecDecodeState.record_verify()` and `apply_verify_step()` model committed-count bookkeeping for the rollback tests; the live `ContinuousBatchingEngine` path uses `Scheduler.update_after_step(..., committed_counts=...)` together with `PagedKVCache` directly.
+- Streaming and cleanup are ordinary server behavior. `StreamManager.push_token()` emits SSE chunks, and `_completion_event_generator()` / `_chat_event_generator()` call `abort_request()` when the client disconnects.
 
 ### Shared Components
 
@@ -201,66 +207,35 @@ Both paths share:
 
 ## 4. Request Lifecycle (Continuous Batching)
 
-1. **Intake.** `api_server_v2` validates the request, tokenizes the prompt,
-   and calls `engine.add_request(...)`, which creates a `SequenceData`.
-2. **Scheduling.** On each async tick, `Scheduler.schedule()` decides which
-   sequences to prefill, which to decode, and which to preempt. It allocates
-   paged KV blocks through `PagedKVCache`.
-3. **Batching.** `BatchBuilder` assembles input tensors, attention metadata,
-   and expert routing metadata for the step.
-4. **Forward pass.** `ModelRunner` runs one prefill or decode step via the
-   HuggingFace model; `Sync*MoeBlock` layers call
-   `DistributedExpertExecutor.dispatch_local()` which hands work to the native
-   dispatcher. Experts are fetched on-demand with prefetch hints from
-   `ExpertPrefetcher` and the tracer.
-5. **Sampling.** `Sampler` applies temperature, top-p, top-k, and stop rules.
-6. **Streaming.** `StreamManager` pushes partial deltas to any open SSE
-   clients. The FastAPI response emits OpenAI-shaped chunks.
-7. **Termination.** When a sequence finishes, the scheduler releases its KV
-   blocks, the expert tracer records the activation pattern, and
-   `EvictionSync` notifies optional prompt-optimization layers.
+1. **Intake.** `api_server_v2` validates the request, tokenizes the prompt, and calls `engine.add_request(...)`, which creates a `SequenceData`.
+2. **Scheduling.** On each async tick, `Scheduler.schedule()` decides which sequences to prefill, which to decode, and which to preempt. It allocates paged KV blocks through `PagedKVCache`.
+3. **Batching.** `BatchBuilder.from_scheduler_output()` assembles packed input tensors, attention metadata, and expert routing metadata for the step.
+4. **Forward pass.** `ContinuousBatchingEngine.step()` builds the batch, checks `_can_delegate_speculative(batch)`, and either enters `_step_speculative()` or falls back to `_execute_batch()` + sampling. The normal path still reaches `DistributedExpertExecutor.dispatch_local()` through the model blocks, so the same expert dispatch and prefetch hooks stay in play.
+5. **Speculative delegation.** If the batch is a fresh singleton greedy prefill request, `_step_speculative()` delegates to `DFlashSpeculator.generate()` and then records committed counts through `Scheduler.update_after_step(..., committed_counts=...)`.
+6. **Rollback bookkeeping.** `SpecDecodeState` and `apply_verify_step()` are low-level tested helpers for committed-count and truncation math. The live serving engine uses `Scheduler.update_after_step(..., committed_counts=...)` with `PagedKVCache` directly; these helpers describe and verify the contract but are not the live integration point.
+7. **Streaming.** `StreamManager` pushes partial deltas to open SSE clients. The FastAPI response emits OpenAI-shaped chunks.
+8. **Termination.** When a sequence finishes or the client disconnects, the scheduler releases its KV blocks, `abort_request()` clears callbacks and request state, and the cancel path updates request stats.
 
-## 5. Public API Surface
+## 5. API Stability Boundaries
 
-The public API is intentionally small.
+`__all__` only describes import convenience. It does not turn an internal module into a stable contract. The table below is the compatibility boundary.
 
-From the top-level package:
-- `moe_infinity.MoE` — the HuggingFace-style wrapper class.
-- `moe_infinity.OffloadEngine` — lower-level engine (rarely needed directly).
-- `moe_infinity.__version__`.
+| Surface | Stability | Intended audience | Compatibility promise |
+|---|---|---|---|
+| `moe_infinity.MoE`, `moe_infinity.OffloadEngine`, `moe_infinity.__version__` | Documented package surface | Users | The top-level class and package names are documented surfaces; individual methods have the lifecycle stated in their own rows or guides. |
+| `MoE.generate()` | Deprecated, pending removal | Existing synchronous callers | Emits `DeprecationWarning`. It remains documented for transition and current validation only, with no compatibility promise beyond transition documentation. |
+| `MoE.serve()`, `moe_infinity.entrypoints.openai.api_server_v2`, `moe_infinity.entrypoints.openai.protocol`, and the documented routes in `docs/serving.md` | Documented server surface | Operators and integrators | Request/response shapes and route behavior follow the documented server contract. |
+| `moe_infinity.spec_decode.DFlashConfig`, `DFlashSpeculator`, `read_dflash_config`, `validate_pairing`, `glm_dflash_available`, `glm_dflash_drafter_for`, `validate_glm_pairing` | Experimental exported `spec_decode` surface | Power users and contributors | Exported for experimentation and integration work, but not a stable compatibility contract. Changes should still be reflected in docs/release notes. |
+| `moe_infinity.spec_decode.dflash.validate_drafter`, `validate_drafter_module`, `bind_shared_weights` | Internal DFlash helpers | Contributors working in `dflash.py` | Module-level implementation details; exported only from `dflash.py`, not from the package root. |
+| `moe_infinity.engine.*`, `moe_infinity.serving.*`, `moe_infinity.memory.*`, `moe_infinity.models.*`, `moe_infinity.kernel.*`, `moe_infinity.distributed.*`, `moe_infinity.runtime.*` | Internal | Contributors | No compatibility promise. Import paths, class names, and helper signatures may change. |
 
-From the OpenAI server:
-- `python -m moe_infinity.entrypoints.openai.api_server_v2 --help`
-- Inference endpoints: `/v1/completions`, `/v1/chat/completions`, `/v1/models`.
-- Operational endpoints: `/health`, `/metrics`, `/admin/stats`, `/v1/config`
-  (GET/POST), `/v1/reload`.
-- Optional ContextPilot admin endpoints: `/contextpilot/toggle`,
-  `/contextpilot/inject-fault`, `/contextpilot/status`.
+If a symbol is exported but not listed in the documented package surface row, treat it as convenience-only unless the docs explicitly elevate it. Internal helpers may change without notice; documented behavior is tracked through the docs and changelog/release notes.
 
-Everything under `engine/`, `serving/`, `runtime/`, `memory/`, `distributed/`,
-`kernel/`, and `models/` is **internal**. Import paths may change without
-notice. If you need something from these modules from outside the repo, open
-an issue first.
-
-## 6. Future Work
-
-- **Unify `engine/` and `serving/`.** Today the synchronous and async paths
-  are two independent schedulers with duplicate data structures (`Sequence`
-  vs `SequenceGroup`, `SchedulerOutput` vs `SchedulerOutput`, etc.). A future
-  refactor should make `MoE.generate()` a synchronous facade over the
-  continuous batching engine so there is only one scheduling code path.
-- **Expand `distributed/` tests.** The distributed module has smoke tests
-  only (see `tests/python/unit/test_distributed_smoke.py`). Deeper coverage
-  requires a multi-process CUDA harness.
-- **Multi-node distributed inference.** The current distributed module only
-  supports single-host multi-GPU via NCCL; cross-host RPC scaffolding exists
-  but is not production-tested.
-
-## 7. Where to Look When …
+## 6. Where to Look When …
 
 | Symptom | Start here |
 |---|---|
-| Adding a new MoE model | `models/` — add a `Sync<Model>MoeBlock` wrapper, register it in `runtime/model_offload.py`, add the model type to `common/constants.py` |
+| Adding a new MoE model | `models/` - add a `Sync<Model>MoeBlock` wrapper, register it in `runtime/model_offload.py`, add the model type to `common/constants.py` |
 | Changing how experts are fetched | `distributed/expert_executor.py` + `core/parallel/expert_dispatcher*` |
 | Changing cache eviction | `memory/offloading_policy.py` (LRU/ARC) + `memory/expert_priority_score.py` |
 | Changing request scheduling (async path) | `serving/scheduler.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to MoE-Infinity will be documented in this file.
+
+## [Unreleased]
+
+### Added
+
+- Documentation hub at `docs/README.md` for users, operators, contributors, and project-history readers.
+- DFlash documentation that distinguishes direct batch-1 greedy and sampled draft/verify from the greedy-gated `MoE.generate` and serving integrations, explains the current batch>1 greedy-only constraint, and limits continuous-batching and route-ahead claims to validated paths.
+
+### Changed
+
+- Qwen3.5-MoE keeps its text backbone resident and offloads routed experts only on the text-only path.
+- GLM-5.2-FP8 keeps routed FP8 experts in the host store while non-routed FP8 weights dequantize to BF16 on load.
+- Root README is now a concise discovery surface and points readers to the docs hub, model compatibility, DFlash, serving, troubleshooting, architecture, and changelog.
+- Release notes are split out of README and tracked here instead of being presented as shipped releases.
+
+### Deprecated
+
+- `MoE.generate()` emits `DeprecationWarning` in the current code and is scheduled for removal. It remains documented as the current in-process synchronous transition path; `MoE.serve()` is recommended for continuous-batching HTTP serving and is not a drop-in in-process return API. No removal version is announced.
+
+### Fixed
+
+- Serving-path DFlash now truncates KV cache to the committed prefix after each verify step, so emitted and cached tokens stay aligned.
+- GPT-OSS resident-load path now materializes MXFP4 blocks, scales, router, biases, and attention sinks instead of leaving placeholder tensors in place.
+- GLM FP8 store and reload parity now stays stable across fresh stores and reloads.
+
+### Known Limitations
+
+- Batch > 1 DFlash is greedy-only, requires a bare HuggingFace target, and sampled batch > 1 remains unsupported.
+- Multi-node distributed inference is still unsupported.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to MoE-Infinity
 
-Thank you for contributing to **MoE-Infinity** — a cost-effective MoE inference library for memory-constrained GPUs.
+Thank you for contributing to **MoE-Infinity**, a cost-effective MoE inference library for memory-constrained GPUs.
 
 We welcome contributions across Python, C++/CUDA extensions, tests, docs, and examples.
 
@@ -15,6 +15,7 @@ We welcome contributions across Python, C++/CUDA extensions, tests, docs, and ex
 - [Code Style, Linting, and Formatting](#code-style-linting-and-formatting)
 - [Running Tests](#running-tests)
 - [Pull Request Process (Fork-and-Pull)](#pull-request-process-fork-and-pull)
+  - [Documentation impact by change type](#documentation-impact-by-change-type)
 - [Commit Message Convention](#commit-message-convention)
 - [Contribution Tips for This Repo](#contribution-tips-for-this-repo)
 
@@ -108,7 +109,7 @@ Current lint/format stack includes:
 - `clang-format` (for C++/CUDA sources)
 - `codespell`
 
-The pinned tool versions in `.pre-commit-config.yaml` are the source of truth — CI runs the exact same versions. Always run formatting through `pre-commit` (which installs those pinned versions in isolated environments) rather than a system-wide `ruff`/`clang-format`, whose version may differ and produce mismatched formatting.
+The pinned tool versions in `.pre-commit-config.yaml` are the source of truth. CI runs the exact same versions, so always run formatting through `pre-commit` (which installs those pinned versions in isolated environments) rather than a system-wide `ruff` or `clang-format`, whose version may differ and produce mismatched formatting.
 
 Please run formatting/lint checks before opening a PR.
 
@@ -180,6 +181,21 @@ When applicable:
 - Bug fix PRs should include a regression test.
 - Feature PRs should include tests and an example or documentation update.
 - Performance PRs should include benchmark context (hardware, model, and before/after observations).
+
+### Documentation impact by change type
+
+A change can match more than one row. Satisfy every row that applies before opening the PR, and update the authoritative guide for each surface you changed. Update the [Documentation hub](./docs/README.md) only when adding, removing, or renaming a guide, or when changing documentation navigation.
+
+| Change type | Required docs | Concrete examples |
+| --- | --- | --- |
+| New user feature | [README](./README.md) discovery, the feature guide or API page, and [Changelog](./CHANGELOG.md) `Unreleased`. | Add a new section to `docs/serving.md`, link it from `README.md`, and add an `Unreleased` note. |
+| Model support | [Model compatibility matrix](./docs/model-compatibility.md), the model family guide, and [Changelog](./CHANGELOG.md) `Unreleased`. | Add the checkpoint row in `docs/model-compatibility.md`, then update `moe_infinity/models/deepseek_v4/README.md` or `docs/glm-5.2.md`. |
+| Config, CLI, or env | The config or env guide, [README](./README.md) discovery if the quick start changes, and [Changelog](./CHANGELOG.md) `Unreleased`. | Update `docs/configuration.md`, `docs/environment-variables.md`, and the matching README command. |
+| Architecture | [Architecture](./ARCHITECTURE.md) and [Changelog](./CHANGELOG.md) `Unreleased`. | Update the module map, request lifecycle, or public API boundary notes. |
+| Performance | [Benchmarking guide](./docs/benchmarking.md), the relevant reproduction or runbook page, and [Changelog](./CHANGELOG.md) `Unreleased`. | Add benchmark data with model, checkpoint, hardware, software, workload, baseline, and limitations. |
+| User-visible bug | The guide for the affected surface and [Changelog](./CHANGELOG.md) `Unreleased`. Add [README](./README.md) discovery when the fix changes the user entry point. | Update troubleshooting, serving, or model docs if the fix changes what users must do or expect. |
+
+If a change spans more than one row, satisfy every matching row. Do not rely on the README alone when a deeper guide exists.
 
 ## Commit Message Convention
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,18 @@ MoE-Infinity is a cost-effective, fast, and easy-to-use library for Mixture-of-E
 
 ## Overview
 
-MoE-Infinity runs large Mixture-of-Experts models on memory-constrained GPUs by **offloading expert weights to host memory (and SSD)** and fetching them just in time. An activation-aware cache keeps hot experts resident on the GPU, while activation tracing and prefetching hide most of the transfer cost. On top of the offloading runtime, MoE-Infinity ships a HuggingFace-compatible `MoE` class and an async, OpenAI-compatible serving engine with continuous batching, paged KV cache, and streaming.
+MoE-Infinity runs large Mixture-of-Experts models on memory-constrained GPUs by offloading expert weights to host memory and SSD, then fetching them when needed. An activation-aware cache keeps hot experts resident on the GPU, while tracing and prefetching hide transfer cost. On top of the offloading runtime, MoE-Infinity ships a HuggingFace-compatible `MoE` class and an OpenAI-compatible serving engine with continuous batching, paged KV cache, and streaming.
 
-This open-sourced version has been redesigned to be HuggingFace-friendly and differs from the version reported in the [paper](https://arxiv.org/abs/2401.14361), which prioritizes extreme performance. **Single-server multi-GPU inference is supported** — expert parameters are distributed round-robin across all visible GPUs, with per-GPU caching, peer-to-peer transfers, and dedicated I/O threads. Multi-node distributed inference (across separate machines) is not yet supported.
-
-## Features
-
-Key benefits include:
-
-- **Cost-effective.** Expert offloading to host memory/SSD lets memory-constrained GPUs serve MoE models that would otherwise not fit. DeepSeek-V4-Flash additionally offloads **FP4-quantized** experts for a large memory reduction.
-- **Fast.** Activation-aware expert caching, prefetching, and tracing minimize offloading overhead; fused CUDA kernels, CUDA graph capture, Marlin INT4 GEMM, and FP4/MXFP4 expert paths accelerate the hot path.
-- **HuggingFace-native.** Drop-in `MoE` class with the familiar `from_pretrained` / `generate` workflow, compatible with standard HuggingFace checkpoints.
-- **Production serving.** OpenAI-compatible HTTP server with continuous batching, paged KV cache, request scheduling with preemption, prefix caching, streaming (SSE), runtime hot reload, watchdog/health monitoring, and crash-recovery logging.
-- **Acceleration-aware.** Automatically integrates with [FlashAttention](https://github.com/Dao-AILab/flash-attention) and [FlashInfer](https://flashinfer.ai/) when installed, with graceful fallback to built-in kernels.
-- **Multi-GPU.** Single-server multi-GPU with round-robin expert distribution, per-GPU caching, and an in-memory N-way tensor-parallel shard loader.
+This open-sourced version is HuggingFace-friendly and differs from the version reported in the [paper](https://arxiv.org/abs/2401.14361), which prioritized extreme performance. Start at [docs/README.md](docs/README.md) for the longer guides. Single-server multi-GPU inference is supported, with expert parameters distributed round-robin across visible GPUs, per-GPU caching, topology-qualified peer access when available, explicit host-staging fallback otherwise, and dedicated I/O threads. Multi-node distributed inference, across separate machines, is not yet supported.
 
 ## Contents
+- [Documentation Hub](docs/README.md)
+- [Model Compatibility](docs/model-compatibility.md)
+- [DFlash](#dflash)
+- [Serving](docs/serving.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Architecture](./ARCHITECTURE.md)
+- [Changelog](./CHANGELOG.md)
 - [Key Features](#key-features)
 - [Supported Models](#supported-models)
 - [Installation](#installation)
@@ -30,51 +26,61 @@ Key benefits include:
     - [Enable FlashAttention (Optional)](#enable-flashattention-optional)
     - [Enable FlashInfer (Optional)](#enable-flashinfer-optional)
 - [Usage and Examples](#usage-and-examples)
-    - [Sample Code of Huggingface LLM Inference](#sample-code-of-huggingface-llm-inference)
     - [Running Inference](#running-inference)
     - [Benchmarking](#benchmarking)
     - [OpenAI-Compatible Server (Continuous Batching)](#openai-compatible-server-continuous-batching)
 - [ContextPilot Integration (Optional)](#contextpilot-integration-optional)
-- [Architecture](#architecture)
 - [Release Plan](#release-plan)
 - [Contributing and Security](#contributing-and-security)
 - [Citation](#citation)
 
 ## Key Features
 
-- **Expert offloading** with activation-aware caching, prefetching, and tracing for memory-constrained GPUs.
-- **FP4/MXFP4 expert quantization** with host offloading (DeepSeek-V4-Flash native FP4 path, plus Triton fallback).
-- **KV cache offloading** with paged attention for long-context serving.
-- **Continuous batching** serving engine with request scheduling, preemption, swapping, and prefix caching.
-- **Fused CUDA/Triton kernels** — fused QKV projection, fused Gate+Up+SiLU FFN, fused decode-phase paged attention, and Marlin INT4 (W4A16) GEMM.
-- **CUDA graph capture** for decode batches to cut per-step launch overhead.
-- **OpenAI-compatible API** with streaming chat/completions, runtime hot reload, and live config management.
-- **Serving stability** hardening with watchdogs, health monitoring, and crash-recovery (incremental result writer).
-- **Memory and prefetch coordination** to balance the GPU budget between experts and KV cache and improve throughput.
+- **Cost-effective.** Expert offloading to host memory and SSD lets memory-constrained GPUs serve MoE models that would otherwise not fit. DeepSeek-V4-Flash additionally offloads **FP4-quantized** experts.
+- **Fast.** Activation-aware expert caching, prefetching, tracing, fused CUDA kernels, CUDA graph capture, Marlin INT4 GEMM, and FP4/MXFP4 expert paths keep the hot path lean.
+- **HuggingFace-native.** The `MoE` class remains the current in-process synchronous API, but `MoE.generate()` emits `DeprecationWarning` and is scheduled for removal. Use `MoE.serve()` for continuous batching; it starts an async HTTP service and is not a drop-in in-process return API.
+- **Production serving.** OpenAI-compatible HTTP server with continuous batching, paged KV cache, request scheduling with preemption, streaming (SSE), runtime hot reload, watchdog/health monitoring, and crash-recovery logging. A prefix-cache flag and cache scaffolding exist, but the current OpenAI request path does not actively reuse cached prefixes; see [docs/serving.md](docs/serving.md#prefix-caching).
+- **Acceleration-aware.** Automatically integrates with [FlashAttention](https://github.com/Dao-AILab/flash-attention) and [FlashInfer](https://flashinfer.ai/) when installed, with graceful fallback to built-in kernels.
+- **DFlash.** The experimental direct speculator API supports batch-1 greedy and sampled draft/verify without a stable API promise; deprecated `MoE.generate()` and continuous serving delegate only greedy singleton requests. Batch>1 is currently greedy-only on the bare HuggingFace target path. Route-ahead is an executor-path capability, not evidence of a validated target/drafter pair; see the model-by-model status in [docs/dflash.md](docs/dflash.md#compatibility).
+- **Multi-GPU.** Single-server multi-GPU with round-robin expert distribution, per-GPU caching, and an in-memory N-way tensor-parallel shard loader; see [docs/multi-gpu.md](docs/multi-gpu.md) and [docs/troubleshooting.md](docs/troubleshooting.md).
 
 ## Supported Models
 
-MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/common/constants.py`](./moe_infinity/common/constants.py):
+MoE-Infinity supports HuggingFace MoE checkpoints registered in [`moe_infinity/common/constants.py`](./moe_infinity/common/constants.py). See [docs/model-compatibility.md](docs/model-compatibility.md) for the detailed compatibility matrix and model-specific notes.
 
 | Model | Example checkpoints |
 |---|---|
 | [DeepSeek-V2 / V3](https://huggingface.co/collections/deepseek-ai/deepseek-v2-669a1c8b8f2dbc203fbd7746) | `deepseek-ai/DeepSeek-V2-Lite-Chat`, `deepseek-ai/DeepSeek-V3` |
-| DeepSeek-V4-Flash (FP4 expert offloading) | requires a `transformers` build shipping `DeepseekV4ForCausalLM` |
+| DeepSeek-V4-Flash (FP4 expert offloading) | `deepseek-ai/DeepSeek-V4-Flash` |
 | [Mixtral](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1) | `mistralai/Mixtral-8x7B-Instruct-v0.1`, `Mixtral-8x22B` |
 | [Qwen3-MoE](https://huggingface.co/Qwen/Qwen3-30B-A3B) | `Qwen/Qwen3-30B-A3B` |
-| [Qwen3.5-MoE](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) | `Qwen/Qwen3.5-35B-A3B` (text-only; see note) |
-| [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2-FP8) | `zai-org/GLM-5.2-FP8` (requires `transformers` >= 5.12) |
+| [Qwen3.5-MoE](https://huggingface.co/Qwen/Qwen3.5-35B-A3B) | `Qwen/Qwen3.5-35B-A3B` |
+| [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2-FP8) | `zai-org/GLM-5.2-FP8` |
 | [GPT-OSS](https://huggingface.co/models?search=gpt-oss) | `openai/gpt-oss-*` |
 | [DBRX](https://huggingface.co/models?search=dbrx) | `databricks/dbrx-instruct` |
 | [Jamba](https://huggingface.co/models?search=jamba) | `ai21labs/Jamba-*` |
 | [OLMoE](https://huggingface.co/models?search=olmoe) | `allenai/OLMoE-*` |
 | [Meta NLLB-MoE](https://huggingface.co/facebook/nllb-moe-54b) | `facebook/nllb-moe-54b` |
 
-> DeepSeek-V4-Flash is only registered when your installed `transformers` provides `DeepseekV4ForCausalLM`; otherwise it is skipped automatically.
+> DeepSeek-V4-Flash is only registered when your installed `transformers` provides `DeepseekV4ForCausalLM`; otherwise it is skipped automatically. Path A uses the HF-native `MoE` wrapper, and Path B uses the official FP4 offload loader. See [docs/model-compatibility.md](docs/model-compatibility.md) and [moe_infinity/models/deepseek_v4/README.md](./moe_infinity/models/deepseek_v4/README.md).
 
-> Qwen3.5-MoE (`Qwen3_5MoeForConditionalGeneration`, requires `transformers` >= 5.12) is a vision-language checkpoint served **text-only**: its 256 routed experts are offloaded while the small text backbone — token embeddings, the hybrid linear (GatedDeltaNet) / full attention layers, shared expert, and `lm_head` — stays resident on GPU. The v5 packed expert tensors are expanded to per-expert on load. Vision and MTP weights are present but unused for text generation.
+> Qwen3.5-MoE (`Qwen3_5MoeForConditionalGeneration`, requires `transformers` >= 5.12) is a vision-language checkpoint served text-only. Its 256 routed experts are offloaded while the text backbone, token embeddings, hybrid linear and full attention layers, shared expert, and `lm_head` stay resident on GPU. The v5 packed expert tensors expand to per-expert on load. Vision and MTP weights are present but unused for text generation. See [docs/model-compatibility.md](docs/model-compatibility.md).
 
-> GLM-5.2 (`GlmMoeDsaForCausalLM`, `model_type="glm_moe_dsa"`) requires `transformers` >= 5.12 and is registered only when that class is importable (otherwise skipped automatically). Its 256 routed FP8 experts (block-scale e4m3, dequantized to BF16 on load) are offloaded; the 3 dense layers, shared expert, MLA attention, DSA indexer, and MTP layer stay resident. Sparse attention uses `attn_implementation="eager"`.
+Text-only Qwen3.5-MoE quick start:
+
+```python
+from moe_infinity import MoE
+
+model = MoE("Qwen/Qwen3.5-35B-A3B", {
+    "offload_path": "/ssd/moe-infinity/qwen3.5-35b-a3b",
+    "device_memory_ratio": 0.5,
+})
+```
+
+See the [model compatibility matrix](docs/model-compatibility.md) for the
+validated scope and current limitations.
+
+> GLM-5.2 (`GlmMoeDsaForCausalLM`, `model_type="glm_moe_dsa"`) requires `transformers` >= 5.12 and is registered only when that class is importable, otherwise it is skipped automatically. Its 256 routed FP8 experts are offloaded, while the 3 dense layers, shared expert, MLA attention, DSA indexer, and MTP layer stay resident. The routed experts stay FP8 in the host store, and non-routed FP8 weights are dequantized to BF16 on load. Sparse attention uses `attn_implementation="eager"`. See [docs/glm-5.2.md](docs/glm-5.2.md) and [docs/model-compatibility.md](docs/model-compatibility.md).
 
 ## Installation
 
@@ -97,7 +103,7 @@ conda activate moe-infinity
 
 ### Install from PyPI
 
-> **Note:** Official PyPI wheels are not published yet — the current `moe-infinity` entry on PyPI is a placeholder that does **not** contain the runtime (importing `MoE` from it will fail). Until the official release, please [install from source](#install-from-source).
+> **Note:** Official PyPI wheels are not published yet, the current `moe-infinity` entry on PyPI is a placeholder that does **not** contain the runtime. Importing `MoE` from it will fail. Until the official release, please [install from source](#install-from-source).
 
 ```bash
 # (available once official wheels are published) stable release
@@ -141,17 +147,17 @@ MOE_ENABLE_SM120=1 MOE_ENABLE_SM90=0 CUTLASS_DIR=~/cutlass pip install --no-buil
 
 ### Enable FlashAttention (Optional)
 
-FlashAttention is **not** installed by default. Install it (>=2.5.2) for faster inference:
+FlashAttention is **not** installed by default. Install it (>=2.5.2) if you want the FlashAttention path:
 ```bash
 FLASH_ATTENTION_FORCE_BUILD=TRUE pip install flash-attn
 # or, equivalently, via the optional extra:
 pip install -e '.[flash_attn]'
 ```
-Post-installation, MoE-Infinity will automatically integrate with FlashAttention to enhance performance.
+Post-installation, MoE-Infinity will automatically use FlashAttention when available.
 
 ### Enable FlashInfer (Optional)
 
-Install [FlashInfer](https://flashinfer.ai/) for optimized paged attention kernels during prefill and decode. FlashInfer provides significant speedups for paged KV cache attention compared to standard PyTorch SDPA.
+Install [FlashInfer](https://flashinfer.ai/) for optimized paged attention kernels during prefill and decode.
 
 ```bash
 # Install the FlashInfer Python package (JIT-compiles kernels to match your Torch/CUDA):
@@ -162,7 +168,7 @@ pip install -e '.[flashinfer]'
 
 Check the [FlashInfer installation guide](https://docs.flashinfer.ai/installation.html) for prebuilt-wheel options matching specific CUDA/PyTorch versions.
 
-Post-installation, MoE-Infinity will automatically detect and use FlashInfer for faster paged attention in both prefill and decode phases. When FlashInfer is not installed, MoE-Infinity gracefully falls back to its built-in attention kernels with no behavior change.
+Post-installation, MoE-Infinity will automatically detect and use FlashInfer when available. When FlashInfer is not installed, MoE-Infinity gracefully falls back to its built-in attention kernels with no behavior change.
 
 ## Usage and Examples
 
@@ -171,9 +177,16 @@ We provide a simple API for diverse setups, including single GPU and multiple GP
 ### Important Note
 
 - The `offload_path` must be unique for each MoE model. Reusing the same `offload_path` for different MoE models will result in unexpected behavior.
+- For multi-GPU ownership, visible-device ordering, and common failure modes, see [docs/multi-gpu.md](docs/multi-gpu.md) and [docs/troubleshooting.md](docs/troubleshooting.md).
 
 
 ### Sample Code of Huggingface LLM Inference
+
+> **Deprecation notice:** The examples below retain `MoE.generate()` because it
+> is the current in-process synchronous path and remains covered by repository
+> tests. It emits `DeprecationWarning` and is scheduled for removal. For
+> continuous batching, use `MoE.serve()` or the OpenAI-compatible server; that
+> HTTP serving path is not a drop-in replacement for an in-process tensor return.
 
 ```python
 import torch
@@ -202,6 +215,9 @@ output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
 print(output_text)
 ```
 
+For the source-derived config reference, see [docs/configuration.md](docs/configuration.md).
+Runtime and build env vars are listed in [docs/environment-variables.md](docs/environment-variables.md).
+
 ### Running Inference
 
 Run on a single GPU:
@@ -218,7 +234,7 @@ We provide ready-to-run examples under [`examples/`](./examples). The scripts do
 
 ```bash
 # Minimal single-prompt example (DeepSeek-V2-Lite-Chat)
-CUDA_VISIBLE_DEVICES=0 python examples/deepseek_v2_chat_example.py --offload_dir <your local path on SSD>
+CUDA_VISIBLE_DEVICES=0 python examples/readme_example.py --checkpoint deepseek-ai/DeepSeek-V2-Lite-Chat --offload_dir <your local path on SSD>
 
 # Streaming benchmark example over GSM8K (TTFT + decode timing)
 CUDA_VISIBLE_DEVICES=0 python examples/interface_example.py --model_name_or_path "deepseek-ai/DeepSeek-V2-Lite-Chat" --offload_dir <your local path on SSD>
@@ -228,28 +244,7 @@ CUDA_VISIBLE_DEVICES=0 python examples/interface_example.py --model_name_or_path
 
 ### DeepSeek-V4-Flash (FP4 Expert Offloading)
 
-DeepSeek-V4-Flash has two usage paths depending on your checkpoint.
-
-**Path A — HuggingFace-native `MoE` API.** If your installed `transformers` ships `DeepseekV4ForCausalLM`, V4-Flash works through the same drop-in `MoE` class as above:
-
-```python
-from moe_infinity import MoE
-
-model = MoE("deepseek-ai/DeepSeek-V4-Flash", {
-    "offload_path": "/ssd/moe-infinity/deepseek-v4-flash",
-    "device_memory_ratio": 0.75,
-})
-```
-
-**Path B — Official FP4 offload loader.** The native V4-Flash checkpoint (FP4 routed experts + FP8 shared/attention weights) cannot be loaded by HuggingFace; it is driven through the official `inference/model.py` and MoE-Infinity's `load_offloaded_v4_flash` adapter, which streams the ~132 GB of FP4 experts from pinned host RAM (resident GPU memory drops to ~5-6 GB/rank):
-
-```bash
-torchrun --nproc-per-node 4 examples/deepseek_v4_flash_example.py \
-    --ckpt-path <MP_SHARDED_CKPT> --config-path <MP_SHARDED_CKPT>/config.json \
-    --max-resident-experts 16
-```
-
-**Suggested hardware / environment (Path B):** **4x GPUs** (tensor-parallel mp4; mp1 exceeds the sparse-attention kernel's shared-memory limit), **>= ~140 GB pinned host RAM**, and the `v4flash` docker image (tilelang `fp4_gemm`; on Blackwell/SM120 the native `moe_infinity._v4_fp4` CUDA path is auto-selected and is 1.5–3.2x faster). The checkpoint must first be converted to the official mp-sharded format. See [`moe_infinity/models/deepseek_v4/README.md`](./moe_infinity/models/deepseek_v4/README.md) for checkpoint conversion, kernel selection, and validation details.
+DeepSeek-V4-Flash depends on the validated mp4/official-container setup, so this README does **not** present it as a self-contained canonical example. Use the detailed family guide for the required container, mounts, checkpoint prep, and the validated harness: [`moe_infinity/models/deepseek_v4/README.md`](./moe_infinity/models/deepseek_v4/README.md). The ContextPilot A/B benchmark entry point is [`benchmarks/contextpilot/v4flash_ab.py`](./benchmarks/contextpilot/v4flash_ab.py).
 
 ### GLM-5.2 (FP8 Expert Offloading)
 
@@ -264,7 +259,11 @@ model = MoE("zai-org/GLM-5.2-FP8", {
 })
 ```
 
-> **Memory note:** the FP8 block-scaled routed experts are kept FP8 in the host store (~753 GB) and dequantized on-device by the expert dispatcher, which requires the native `moe_infinity._v4_fp4` extension. Weights that run in PyTorch rather than the dispatcher — MLA attention, the DSA indexer, the dense-layer MLPs, and the shared expert — are dequantized to BF16 on load. Requires `transformers` >= 5.12.
+> **Memory note:** the FP8 block-scaled routed experts stay FP8 in the host store and are dequantized on-device by the expert dispatcher. Weights that run in PyTorch rather than the dispatcher, namely MLA attention, the DSA indexer, the dense-layer MLPs, and the shared expert, are dequantized to BF16 on load. Requires `transformers` >= 5.12.
+
+## DFlash
+
+See [docs/dflash.md](docs/dflash.md) for the batch-1 greedy/sampled flow, the current batch>1 greedy-only constraint, and the compatibility matrix that separates DFlash pairing validation from route-ahead executor wiring.
 
 ### Benchmarking
 
@@ -300,87 +299,27 @@ python benchmarks/serving/latency.py \
 
 ### OpenAI-Compatible Server (Continuous Batching)
 
-MoE-Infinity includes a continuous batching serving engine with an OpenAI-compatible API. The server supports concurrent requests, streaming, request scheduling with preemption, and paged KV cache management.
+MoE-Infinity includes a continuous batching OpenAI-compatible server.
 
-Start the server:
+> **Security:** The parser default is `--host 0.0.0.0`, and authentication is
+> disabled when neither `--api-key` nor `MOE_API_KEYS` is configured. On an
+> untrusted, shared, or cloud host, bind to `127.0.0.1` or configure an API key
+> before exposure. Completion routes and privileged `/admin/stats`, `/v1/config`,
+> and `/v1/reload` endpoints share this authentication posture.
+
 ```bash
-python -m moe_infinity.entrypoints.openai.api_server_v2 \
-    --model deepseek-ai/DeepSeek-V2-Lite-Chat \
-    --offload-dir ./offload_dir \
-    --device-memory-ratio 0.5 \
-    --kv-cache-ratio 0.15 \
-    --max-batch-size 8
+python -m moe_infinity.entrypoints.openai.api_server_v2 --host 127.0.0.1 --model deepseek-ai/DeepSeek-V2-Lite-Chat --offload-dir ./offload_dir
 ```
 
-| Flag | Default | Description |
-|---|---|---|
-| `--device-memory-ratio` | 0.75 | Fraction of GPU memory for expert caching. Lower this if you hit OOM (0.5 is a safe starting point for 24GB GPUs). |
-| `--kv-cache-ratio` | 0.25 | Fraction of remaining GPU memory for paged KV cache blocks. |
-| `--max-batch-size` | 32 | Maximum number of concurrent sequences in a batch. |
-| `--enable-prefix-caching` | off | Enable prefix caching for shared prompt prefixes. |
-
-You can also start the server programmatically from Python:
-```python
-from moe_infinity import MoE
-
-model = MoE("deepseek-ai/DeepSeek-V2-Lite-Chat", {
-    "offload_path": "./offload_dir/deepseek-v2-lite",
-    "device_memory_ratio": 0.5,
-})
-model.serve(host="0.0.0.0", port=8000, offload_dir="./offload_dir")
-```
-
-Query via `/v1/completions`:
 ```bash
-curl http://localhost:8000/v1/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "deepseek-ai/DeepSeek-V2-Lite-Chat",
-        "prompt": "Hello, my name is",
-        "max_tokens": 32
-    }'
+curl http://localhost:8000/v1/completions -H 'Content-Type: application/json' -d '{"model":"deepseek-ai/DeepSeek-V2-Lite-Chat","prompt":"Hello","max_tokens":32}'
 ```
 
-Query via `/v1/chat/completions` with streaming:
-```bash
-curl http://localhost:8000/v1/chat/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "deepseek-ai/DeepSeek-V2-Lite-Chat",
-        "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Tell me a joke"}
-        ],
-        "max_tokens": 128,
-        "stream": true
-    }'
-```
-
-Supported request fields: `model`, `prompt`/`messages`, `max_tokens`, `temperature`, `top_p`, `stop`, `stream`.
-
-The server returns `finish_reason: "stop"` when the model emits an EOS token or hits a stop sequence, and `finish_reason: "length"` when `max_tokens` is reached.
-
-The server also exposes operational endpoints:
-
-| Endpoint | Method | Purpose |
-|---|---|---|
-| `/v1/models` | GET | List the loaded model(s). |
-| `/health` | GET | Liveness/readiness state (`STARTING`, `HEALTHY`, `UNHEALTHY`). |
-| `/metrics` | GET | Prometheus-format serving metrics. |
-| `/admin/stats` | GET | Engine statistics (queue depth, batch sizes, cache hit rates). |
-| `/v1/config` | GET / POST | Inspect and update runtime configuration. |
-| `/v1/reload` | POST | Hot-reload server Python modules without restarting the process. |
-
-You can also use the `openai` Python package:
-```bash
-pip install openai
-python tests/python/integration/test_oai_completions.py
-python tests/python/integration/test_oai_chat_completions.py
-```
+For the full serving surface, auth, watchdogs, DFlash, and operational endpoints, see [docs/serving.md](docs/serving.md).
 
 ## ContextPilot Integration (Optional)
 
-ContextPilot is an optional overlap-aware prompt optimization layer for shared-prefix and multi-turn workloads. You can enable it inside the OpenAI-compatible server before tokenization, or extend it into KV allocation and scheduling for deeper reuse gains.
+ContextPilot is an optional overlap-aware prompt optimization layer for shared-prefix and multi-turn workloads. You can enable it inside the OpenAI-compatible server before tokenization, or extend it into KV allocation and scheduling for deeper reuse.
 
 Phase B quick start, in-process middleware:
 
@@ -391,45 +330,21 @@ python -m moe_infinity.entrypoints.openai.api_server_v2 \
     --enable-contextpilot
 ```
 
-Set `CONTEXTPILOT_ENABLED=0` to force-disable ContextPilot at runtime, even if the CLI flag is enabled.
-
-Measured baseline on single A5000 (24 GB) with DeepSeek-V2-Lite-Chat (expert offloading):
-
-| Workload | TTFT p50 | E2E p50 | Prefill tok/s |
-|---|---:|---:|---:|
-| Shared-prefix RAG | 3.70s | 5.29s | 25.4 |
-| Multi-turn conversation | 3.82s | 5.46s | 26.3 |
-| Batch with overlap | 2.21s | 2.69s | 35.5 |
-| No-overlap baseline | 3.40s | 4.86s | 4.2 |
-
-Projected Phase B/C improvements (based on [ContextPilot benchmarks on vLLM/SGLang](https://github.com/EfficientContext/ContextPilot)):
-
-| Phase | Integration mode | Expected TTFT reduction | Expected token savings |
-|---|---|---:|---:|
-| Phase B | In-process middleware | 15–25% | 20–30% |
-| Phase C | Deep scheduler integration | 20–30% | 25–35% |
-
-Actual improvements depend on context overlap ratio. Run `python benchmarks/contextpilot/compare_phases.py` for detailed dry-run projections, or run Phase B against a live server for real measurements.
-
-See [docs/contextpilot/README.md](docs/contextpilot/README.md) for setup details, CLI flags, environment variables, admin endpoints, and troubleshooting.
+Set `CONTEXTPILOT_ENABLED=0` to force-disable ContextPilot at runtime, even if the CLI flag is enabled. For setup details, CLI flags, environment variables, admin endpoints, and troubleshooting, see [docs/contextpilot/README.md](docs/contextpilot/README.md).
 
 ## Architecture
 
-For a contributor-oriented map of the codebase — the two execution paths (synchronous `engine/` vs async `serving/`), module layout, request lifecycle, and the public API surface — see **[ARCHITECTURE.md](./ARCHITECTURE.md)**.
+For a contributor-oriented map of the codebase, including the synchronous `engine/` path, async `serving/` path, module layout, request lifecycle, and public API surface, see **[ARCHITECTURE.md](./ARCHITECTURE.md)**.
 
 ## Release Plan
 
-Recent releases and near-term roadmap:
+See [CHANGELOG.md](./CHANGELOG.md) for release history and unreleased notes. The current roadmap is:
 
-* ✅ Expert offloading runtime with activation-aware caching, prefetching, and tracing.
-* ✅ FP4/MXFP4 expert quantization with host offloading (DeepSeek-V4-Flash native FP4 path).
-* ✅ Continuous batching server with paged KV cache, streaming, preemptive scheduling, and prefix caching.
-* ✅ Fused CUDA/Triton kernels (QKV, Gate+Up+SiLU FFN, decode attention), Marlin INT4 GEMM, and CUDA graph capture.
-* ✅ Serving stability: watchdog/health monitoring, runtime hot reload, live config, and crash-recovery (incremental writer).
-* 🚧 Improving vLLM runtime interoperability.
-* 🚧 Expert parallelism and multi-node distributed MoE inference.
-* 🚧 OpenAI-compatible Batch API (`/v1/batches`).
-* More (We welcome contributors to join us!).
+- Improving vLLM runtime interoperability.
+- Expert parallelism and multi-node distributed MoE inference.
+- OpenAI-compatible Batch API (`/v1/batches`).
+
+These are roadmap notes, not shipped releases.
 
 ## Contributing and Security
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,40 @@
 # Package Release Guide
 
-This document describes the process of releasing a new version of the MoE-Infinity package.
+This document covers the checks that happen before versioning or tagging a release. It does not add a mandatory automated CI gate.
+
+## Release readiness checklist
+
+Before bumping the version or creating a tag, complete these checks:
+
+1. Finalize `CHANGELOG.md`
+   - close the current `## [Unreleased]` section
+   - move shipped items into a dated release entry
+   - recreate a fresh `## [Unreleased]` section at the top
+   - make sure Added, Changed, Fixed, and Known Limitations reflect what is actually shipping
+2. Review model and capability coverage
+   - confirm the supported model list and model-specific notes still match reality
+   - check that any new capability or constraint is documented in the most relevant guide
+3. Verify install and quick starts
+   - rerun any install path you touched
+   - smoke test the README quick starts and examples that changed
+4. Check links and contradictions
+   - verify links across `README.md`, `docs/README.md`, `docs/model-compatibility.md`, `docs/benchmarking.md`, `ARCHITECTURE.md`, and `CHANGELOG.md`
+   - make sure the README, docs, and release notes do not conflict
+5. Record breaking changes and known limitations
+   - call out migrations, unsupported paths, and user-visible limits
+   - keep the summary in `CHANGELOG.md` and the matching guide
+6. Capture performance context when you mention performance
+   - model / checkpoint
+   - hardware
+   - software
+   - workload
+   - baseline
+   - limitations
+7. Confirm the actual release artifacts
+   - verify whether this release publishes a wheel, an sdist, or both
+   - build and inspect the exact artifacts before tagging so the uploaded files are the ones you intend to publish
+
+This checklist is manual. It does not introduce a required automated CI gate.
 
 ## Automated Release Process
 
@@ -11,14 +45,24 @@ Stable releases are automated through GitHub Actions workflows in `.github/workf
 - `.github/workflows/build-test.yml`: build validation for pull requests.
 
 ### Steps to Release a New Version
-To release a new version, such as version 1.0.0, please adhere to the following procedure:
+To release a new version, such as version 1.0.0, follow this order:
 
+0. Finalize release notes
+   - close the current `## [Unreleased]` section in `CHANGELOG.md`
+   - move shipped notes into the dated release entry
+   - recreate a fresh `## [Unreleased]` section at the top
 1. Update Version:
    - Update `moe_infinity/__init__.py` (`__version__ = "..."`) to the new stable version.
    - Ensure `setup.py` remains `version=os.getenv("MOEINF_VERSION", "...")` and update the default fallback version there to match the new stable version.
    - If needed, bump `NIGHTLY_BASE_VERSION` in `.github/workflows/publish-test.yml` to the next planned stable series so nightly dev builds sort correctly.
-2. Commit Changes: Commit these changes with an appropriate commit message that summarizes the update, such as "Update version for 1.0.0 release".
-3. Create and Push Tag: Tag the latest commit with the new version number and push the tag to the repository. Use the following commands to accomplish this:
+2. Review the release checklist above
+   - confirm model and capability coverage
+   - verify install and quick starts
+   - check links and contradictions
+   - record breaking changes, known limitations, and performance context
+   - confirm the release artifact choice, wheel, sdist, or both
+3. Commit Changes: Commit these changes with an appropriate commit message that summarizes the update, such as "Update version for 1.0.0 release".
+4. Create and Push Tag: Tag the latest commit with the new version number and push the tag to the repository. Use the following commands to accomplish this:
     ```bash
     git tag v1.0.0
     git push origin v1.0.0
@@ -51,6 +95,8 @@ For developers who prefer to manually build and publish their package to PyPI, t
     twine upload dist/*
     ```
     Ensure that you have the necessary credentials configured for `twine` to authenticate to PyPI.
+
+Before uploading, inspect the wheel and sdist contents and confirm they match the release tag and changelog entries.
 
 
 To build the package wheel for multiple Python versions, you should execute the build process individually for each version by specifying the corresponding Python interpreter.

--- a/benchmarks/expert_io_microbench/README.md
+++ b/benchmarks/expert_io_microbench/README.md
@@ -1,20 +1,33 @@
 # Expert I/O Microbench Integration Runner
 
-`run_all.py` executes expert I/O microbench scenarios and writes a unified JSON report.
+`run_all.py` is the main entry point. It runs the routing, transfer, compute, and bubble scenarios, then merges their JSON into one report. Use the per-scenario scripts when you want to inspect a single stage in isolation.
 
-## Docker Setup
+## Prerequisites
 
-### Shared Memory (Required for Large Models)
-By default Docker limits `/dev/shm` to 64MB, which causes `Bus error` with large models.
-Always run with sufficient shared memory:
+- CUDA GPU and a working PyTorch build.
+- `transformers`, `moe_infinity`, and a local HuggingFace cache for the model you benchmark.
+- `psutil` if you want CPU RSS in the memory-style outputs.
+- `nsys` for `compare_baseline.py`, `run_decision_profile.py`, and `nsys_parser.py`.
+- `nvidia-smi` for PCIe link width and generation sampling in the decision profile workflow.
+- Enough `/dev/shm` for `--host-only`, or Docker `--shm-size=32g`.
+
+## Quick start
+
+Build the benchmark image first, using the documented Docker instructions in [docs/benchmark_reproduction.md](../../docs/benchmark_reproduction.md#per-framework-setup):
+
+```bash
+docker build -t moe-infinity-bench -f docker/Dockerfile .
+```
 
 ```bash
 docker run --gpus all --shm-size=32g --ipc=host moe-infinity-bench \
-  python benchmarks/expert_io_microbench/run_all.py ...
+  python benchmarks/expert_io_microbench/run_all.py \
+  --model deepseek-ai/DeepSeek-V2-Lite-Chat \
+  --offload-dir /path/to/offload \
+  --output-json benchmarks/expert_io_microbench/results/all.json
 ```
 
-### Host-Only Mode (Isolate PCIe Overhead)
-Use `--host-only` to copy expert weights to tmpfs (RAM), eliminating disk I/O:
+Host-only mode copies the offload tree to tmpfs first and removes disk I/O from the run:
 
 ```bash
 python benchmarks/expert_io_microbench/run_all.py \
@@ -24,52 +37,54 @@ python benchmarks/expert_io_microbench/run_all.py \
   --output-json host_only_results.json
 ```
 
-This reveals the **lower bound bubble ratio** — how much stall remains even with perfect prefetching
-(all experts in CPU RAM). Compare against disk mode to quantify disk I/O contribution.
+## Supported commands
 
-## Scenarios
+| Command | Use when | Key outputs | Notes |
+| --- | --- | --- | --- |
+| `python benchmarks/expert_io_microbench/run_all.py --model ... --offload-dir ... [--scenario all\|routing\|transfer\|compute\|bubble] [--host-only] [--theoretical-pcie-gbps ...] [--output-json ...]` | You want the merged report for all scenarios or one scenario. | `status`, `mode`, `scenarios`, `bandwidth_analysis`, `executive_summary`, `runner_stdout`, `runner_stderr` | Keeps going if one scenario fails and records the error under that key. |
+| `python benchmarks/expert_io_microbench/bench_routing.py --model ... --offload-dir ... [--host-only] [--output-json ...]` | You want routing and cache lookup timing only. | `routing`, `cache_lookup`, `cache`, `io_profiler_events` | Sets `MOE_INFINITY_PROFILE_IO=1` and `MOE_INFINITY_PROFILE_IO_SAMPLE=1.0` internally. |
+| `python benchmarks/expert_io_microbench/bench_transfer.py --model ... --offload-dir ... [--host-only] [--output-json ...]` | You want disk to CPU and CPU to GPU timing only. | `disk_to_cpu`, `cpu_to_gpu`, `sync_overhead` | Also records the number of sync events per step. |
+| `python benchmarks/expert_io_microbench/bench_compute_evict.py --model ... --offload-dir ... [--device-memory-ratio ...] [--host-only] [--output-json ...]` | You want expert compute, eviction, and queue coordination timing. | `expert_compute`, `eviction`, `queue_coordination`, `observed_stages`, `non_empty_components` | Default `device_memory_ratio` is low on purpose to increase eviction pressure. |
+| `python benchmarks/expert_io_microbench/bench_bubble.py --model ... --offload-dir ... [--host-only] [--output-json ...]` | You want bubble accounting and step decomposition. | `overall_bubble_ratio`, `per_layer_bubble`, `step_decomposition_mean`, `step_decomposition_percentiles` | Uses IOProfiler data to estimate how much of each step is spent waiting. |
+| `python benchmarks/expert_io_microbench/compare_baseline.py --nsys-report ... --benchmark-json ... --output-json ...` | You want to compare a baseline `.nsys-rep` profile against a new benchmark JSON. | `new_instrumentation_overhead_pct`, `overhead_regression_pct`, `verdict`, `baseline_nvtx_ranges` | Requires `nsys` on PATH or through `NSYS_BIN`. |
+| `nsys profile -t cuda,nvtx --capture-range=cudaProfilerApi python benchmarks/expert_io_microbench/run_decision_profile.py --model ... --offload-dir ... --hardware-tag ... --mode disk\|host-only --output-json ...` | You want the nsys-go/no-go profile for the IBP feasibility plan. | `decode_step_times_ns`, `decode_step_total_ns`, `pcie_link_width_observed`, `pcie_link_gen_observed` | Must run inside the `nsys profile` wrapper so `cudaProfilerStart/Stop` brackets the measured decode steps. |
+| `python benchmarks/expert_io_microbench/nsys_parser.py <rep.nsys-rep> [--steps N] [--link-width W] [--link-gen G] [--real-total-ns N]` | You want the raw summary tuple from a captured `.nsys-rep`. | `T_step_ns`, `T_transfer_ns`, `Util_pcie`, `verdict` | Uses `nsys stats` and a fixed PCIe link model, or the observed link width and generation if you pass them. |
 
-- `routing` → `bench_routing.py`
-- `transfer` → `bench_transfer.py`
-- `compute` → `bench_compute_evict.py`
-- `bubble` → `bench_bubble.py`
+## Environment variables
 
-Use `--scenario all` (default) to run every scenario, or run one scenario at a time.
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `MOE_INFINITY_PROFILE_IO` | set to `1` by the scenario scripts | Enables IOProfiler capture in the microbench scripts. |
+| `MOE_INFINITY_PROFILE_IO_SAMPLE` | set to `1.0` by the scenario scripts | Forces full sampling so the stage timings are easier to compare. |
+| `NSYS_BIN` | unset | Optional absolute path to the `nsys` binary for `nsys_parser.py`. |
+| `CUDA_VISIBLE_DEVICES` | inherited | Standard CUDA device selection. |
 
-## CLI
+## Expected outputs
 
-```bash
-python benchmarks/expert_io_microbench/run_all.py \
-  --model <hf-model-or-local-path> \
-  --offload-dir <offload-dir> \
-  --device-memory-ratio 0.5 \
-  --warmup 10 \
-  --iters 100 \
-  --scenario all \
-  --output-json benchmarks/expert_io_microbench/results/all.json
-```
+- `run_all.py` writes one merged JSON object with `scenarios`, `bandwidth_analysis`, and `executive_summary`.
+- `bench_routing.py` and `bench_transfer.py` return stage timing summaries and a `status` of `PASS` or `BLOCKED`.
+- `bench_compute_evict.py` adds `observed_stages` and `non_empty_components` so you can see whether all expected stages were hit.
+- `bench_bubble.py` reports `overall_bubble_ratio`, per-layer bubble ratios, and step decomposition percentiles.
+- `compare_baseline.py` returns `verdict` together with the measured overhead regression percentage.
+- `run_decision_profile.py` records the raw decode step times and the sampled PCIe link geometry used for the verdict.
 
-Optional:
+## NVTX and profiler workflow
 
-- `--theoretical-pcie-gbps <float>`: provide theoretical PCIe throughput explicitly. If omitted, runner attempts to read it from CUDA device properties.
-- `--host-only`: copy offload dir to `/dev/shm` once in `run_all.py` and run all scenarios from tmpfs.
+1. Capture a profile with `run_decision_profile.py` inside `nsys profile -t cuda,nvtx --capture-range=cudaProfilerApi`.
+2. Use `compare_baseline.py` to compare the new benchmark JSON against the baseline `.nsys-rep`.
+3. Use `nsys_parser.py` when you want the raw transfer and compute breakdown without the comparison wrapper.
 
-## Output sections
+The decision-profile runner toggles `cudaProfilerStart` and `cudaProfilerStop` around the measured decode steps. Warmup runs happen before the profiler starts, so they are excluded from the timing window.
 
-Unified output JSON includes:
+## Throughput and latency interpretation
 
-- `scenarios`: raw per-scenario benchmark JSON (or `{ "error": ... }` on failure)
-- `bandwidth_analysis`:
-  - `theoretical_bandwidth_gbps`
-  - per-link `actual_bandwidth_gbps`
-  - per-link `utilization_pct`
-- `executive_summary`:
-  - top 3 bottlenecks ranked by `% of step time`
+- Routing, transfer, compute, and bubble are stage microbenchmarks. Treat them as profiler tools, not as end-to-end serving throughput.
+- `--host-only` copies the offload directory to tmpfs. That removes disk I/O and exposes the lower bound when the experts live in CPU RAM.
+- Compare disk mode against host-only mode to separate disk time from PCIe time.
+- `overall_bubble_ratio` is the share of step time spent waiting. Lower is better.
+- `sync_overhead.sync_pct_of_step` shows how much of each step disappears into synchronization.
+- `bandwidth_analysis.top_bottlenecks` from `run_all.py` ranks the worst components by share of step time.
 
-The runner always continues if one scenario fails and records the failure under that scenario key.
+## Historical results
 
-## Help
-
-```bash
-python benchmarks/expert_io_microbench/run_all.py --help
-```
+This README does not pin a canonical result set. Any JSON or markdown you archive from a past run is historical, so label it with the commit, model, hardware, and date if you share it elsewhere.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# Documentation Hub
+
+This hub is the main index for the longer guides, grouped by audience so readers can jump to the right details quickly. If you are choosing a model, start with the compatibility matrix, then open the family guide for any special cases. For runtime behavior, use DFlash for sync speculative decode, OpenAI serving for the async server and cancellation flow, and Architecture for the public vs internal boundary.
+The configuration and environment reference pages are sourced from the code, so the field names and defaults stay aligned with the implementation.
+
+## Users
+
+Users are people who want to pick a model, check the compatibility matrix, and plan memory before reading deeper runtime details.
+
+- [Model compatibility matrix](./model-compatibility.md)
+- [Configuration and memory planning](./configuration.md)
+- [DFlash speculative decode](./dflash.md)
+- [GLM-5.2 guide](glm-5.2.md)
+- [DeepSeek-V4-Flash guide](../moe_infinity/models/deepseek_v4/README.md)
+- [ContextPilot](./contextpilot/README.md)
+
+## Operators
+
+Operators are people who run the OpenAI server and need runtime controls for deployment and support.
+
+- [OpenAI serving](./serving.md)
+- [Environment variables](./environment-variables.md)
+- [Single-server multi-GPU](./multi-gpu.md)
+- [Troubleshooting](./troubleshooting.md)
+
+## Contributors
+
+Contributors are people who change code, docs, or packaging and need the technical references before sending a patch, especially the architecture map and API stability table.
+
+- [Architecture](../ARCHITECTURE.md)
+- [Benchmarking catalog and runbooks](./benchmarking.md)
+- [Benchmark reproduction](./benchmark_reproduction.md)
+- [Expert I/O microbench runbook](../benchmarks/expert_io_microbench/README.md)
+- [C++ interface](./cpp-interface-spec.md)
+- [Contributing](../CONTRIBUTING.md)
+
+## Project History
+
+Project History is for people who want the release record and the process for cutting new releases.
+
+- [Changelog](../CHANGELOG.md)
+- [Release process](../RELEASE.md)

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,67 +1,67 @@
 # Benchmarking MoE-Infinity
 
-This guide explains how to correctly measure throughput and latency when running MoE-Infinity, and how to make fair comparisons with other inference frameworks.
+This guide covers the benchmark entry points under `benchmarks/`, labels each one as a stable user workflow, contributor-only spike, helper or report tool, or excluded helper module, and keeps the TTFT vs decode guidance in one place.
 
-## Key Terminology
+If you want the cross-framework comparison table, start with [Benchmark reproduction](benchmark_reproduction.md). For the expert I/O profiler flow, see [benchmarks/expert_io_microbench/README.md](../benchmarks/expert_io_microbench/README.md). For ContextPilot and DeepSeek-V4-Flash background, see [ContextPilot](contextpilot/README.md) and [DeepSeek-V4-Flash](../moe_infinity/models/deepseek_v4/README.md).
+
+## Key terminology
 
 | Term | Definition |
-|------|-----------|
-| **TTFT** (Time To First Token) | Time from submitting a prompt until the first generated token is produced. This covers prompt encoding (prefill). |
-| **ITL** (Inter-Token Latency) | Average time between consecutive generated tokens during the decode phase. |
-| **Decode Throughput** | Tokens generated per second during the decode phase only (excludes prefill). |
-| **End-to-End Throughput** | Total tokens generated divided by total wall-clock time (includes prefill). |
-| **Prefill** | The initial phase where the model processes all input tokens to build the KV cache. This is compute-bound and typically much faster per-token than decode. |
-| **Decode** | The autoregressive phase where the model generates one token at a time. This is memory-bandwidth-bound in MoE offloading scenarios. |
+| --- | --- |
+| TTFT (Time To First Token) | Time from prompt submission until the first generated token appears. This includes prefill. |
+| ITL (Inter-Token Latency) | Average time between generated decode tokens. |
+| Decode throughput | Tokens per second during decode only. This excludes prefill. |
+| End-to-end throughput | Total generated tokens divided by total wall clock time. This includes prefill. |
+| Prefill | The initial phase where the model processes the prompt and builds KV cache state. |
+| Decode | The autoregressive phase where the model emits one token at a time. |
+| Peak memory | Maximum GPU memory observed during the run. |
 
-## Common Measurement Pitfalls
+## Measurement rules
 
-### Pitfall 1: Including Prefill Time in Decode Throughput
+- Keep the model checkpoint, quantization, residency, offload path, and `device_memory_ratio` fixed when you compare runs.
+- Keep the GPU, CPU, RAM, storage, and software stack fixed too, including CUDA, PyTorch, and Transformers versions.
+- Use the same prompt length, output length, batch size, and concurrency for both baselines.
+- Warm up once before you start timing.
+- Separate TTFT from decode throughput. If you mix them, your numbers stop being comparable.
+- Compare like with like: p50-to-p50 or average-to-average. Do not compare a percentile on one side with an average on the other.
+- Record the exact commit, command line, and output file path with every result.
+- For cross-framework comparisons, use the same metric on both sides. For example, compare MoE-Infinity decode throughput with llama.cpp `eval time`, not `prompt eval time`.
 
-The most common mistake is dividing total generated tokens by total wall-clock time (which includes prefill). This conflates two fundamentally different phases and produces misleadingly low throughput numbers.
+## Using the StopWatch utility
 
-```python
-# WRONG: This includes prefill time in the throughput calculation
-start_time = time.time()
-output_ids = model.generate(input_ids, max_new_tokens=256)
-elapsed = time.time() - start_time
-throughput = len(output_ids[0]) / elapsed  # Includes prefill -- NOT decode throughput
-```
+MoE-Infinity provides a `StopWatch` class in [`examples/interface_example.py`](../examples/interface_example.py) that separates prefill from decode timing through HuggingFace `TextStreamer`.
 
-### Pitfall 2: Not Warming Up the Expert Cache
-
-The first inference run loads experts from disk into CPU memory and then transfers them to GPU. Subsequent runs benefit from cached experts. Always run at least one warmup request before measuring.
-
-### Pitfall 3: Comparing Different Metrics Across Frameworks
-
-When comparing with llama.cpp, vLLM, or other frameworks, ensure you are comparing the same metric. For example, llama.cpp reports separate `prompt eval time` and `eval time` -- use `eval time` for decode throughput comparison.
-
-## Using the StopWatch Utility
-
-MoE-Infinity provides a `StopWatch` class in [`examples/interface_example.py`](../examples/interface_example.py) that correctly separates prefill from decode timing by hooking into HuggingFace's `TextStreamer` callback.
-
-### How StopWatch Works
+### How StopWatch works
 
 ```
 generate() called
   |
   v
-put() called (1st time) --> start_prefilling = now
+put() called (1st time) -> start_prefilling = now
   |
   v
-put() called (2nd time) --> prefilling_time = now - start_prefilling
-                            start_decoding = now
-                            clear expert cache counts
+put() called (2nd time) -> prefilling_time = now - start_prefilling
+                           start_decoding = now
+                           clear expert cache counts
   |
   v
-put() called (3rd+ time) --> decoding_iterations++
+put() called (3rd+ time) -> decoding_iterations++
   |
   v
-end() called --> decoding_time = now - start_decoding
+end() called -> decoding_time = now - start_decoding
 ```
 
-The key insight: the `TextStreamer.put()` callback is invoked once per generated token. The first call marks the beginning of prefill, the second marks the first decoded token (end of prefill / start of decode), and all subsequent calls are decode iterations.
+The first callback marks the start of prefill. The second callback marks the first decoded token, which is the end of prefill and the start of decode.
 
-### Standalone Measurement Example
+If you want p50-style reporting from StopWatch, run multiple trials and take the median TTFT / E2E / decode-throughput values across runs. A single StopWatch run is a per-run measurement, not a percentile.
+
+### Standalone measurement example
+
+This example measures the current in-process synchronous `MoE.generate()` path.
+That method emits `DeprecationWarning` and is scheduled for removal, so treat
+the result as path-specific transition data. `MoE.serve()` is the recommended
+continuous-batching HTTP path, not a drop-in replacement for this in-process
+streamer benchmark.
 
 ```python
 import time
@@ -135,13 +135,51 @@ print(f"Per-token latency (decode):  {streamer.decoding_time / streamer.decoding
 print(f"Decode throughput:           {streamer.decoding_iterations / streamer.decoding_time:.2f} tokens/s")
 ```
 
-## Benchmark Scripts
+## Benchmark catalog
 
-MoE-Infinity includes ready-to-use benchmark scripts in [`benchmarks/serving/`](../benchmarks/serving/).
+| Workflow | Entry points | Purpose | Prerequisites | Metrics / output | Guide / status |
+| --- | --- | --- | --- | --- | --- |
+| Serving benchmarks | `benchmarks/serving/baseline_performance.py`<br>`benchmarks/serving/throughput.py`<br>`benchmarks/serving/latency.py`<br>`benchmarks/serving/memory.py`<br>`benchmarks/serving/kv_offload_benchmark.py` | Single request TTFT, throughput sweeps, concurrency latency, memory, and KV offload checks. | CUDA GPU, `transformers`, `moe_infinity`, model checkpoint, offload dir. | `ttft_ms`, `per_token_latency_ms`, `total_time_s`, `peak_gpu_memory_mb`, throughput per batch size, TTFT and ITL percentiles, expert hit rate, KV utilization, swap count. | Stable user workflow. Command examples are below. |
+| DeepSeek-V4-Flash ContextPilot A/B | `benchmarks/contextpilot/v4flash_ab.py`<br>`benchmarks/contextpilot/v4flash_ab_report.py` | A/B compare ContextPilot on DeepSeek-V4-Flash and emit a markdown GO/NO-GO report. | 4 GPUs in mp4 setup, official DeepSeek-V4 checkpoint, `torchrun`, pinned host RAM, `v4flash` image. | `ttft_p50`, `e2e_p50`, prompt token savings, decode tok/s, GO/NO-GO report. | Stable user workflow. See the DeepSeek-V4 guide and the ContextPilot guide. |
+| Serving validation and FlashInfer checks | `benchmarks/serving/ab_kernel_bench.py`<br>`benchmarks/serving/validate_flashinfer.py`<br>`benchmarks/serving/validate_batched_dispatch.py` | FlashInfer vs naive SDPA, FlashInfer import and correctness checks, batched dispatch feasibility. | CUDA GPU, FlashInfer for `validate_flashinfer.py`, source tree for dispatch analysis. | Speedup, GO/NO-GO summary, correctness checks, static interface analysis. | Contributor-only, experimental. Use before changing serving kernels or dispatch wiring. |
+| ContextPilot phase benchmarks | `benchmarks/contextpilot/baseline.py`<br>`benchmarks/contextpilot/phase_a_benchmark.py`<br>`benchmarks/contextpilot/phase_b_benchmark.py`<br>`benchmarks/contextpilot/phase_c_benchmark.py`<br>`benchmarks/contextpilot/compare_phases.py`<br>`benchmarks/contextpilot/memory_profile.py`<br>`benchmarks/contextpilot/reorder_overhead.py`<br>`benchmarks/contextpilot/gen_longctx_workload.py` | Baseline generation, sidecar and middleware comparisons, scheduler phase comparisons, RSS profiling, reorder overhead, and workload generation. | Local or mocked ContextPilot, optional GPU or HTTP server for real phase runs, `psutil` for `memory_profile.py`. | TTFT p50/p90/p99, E2E p50/p90/p99, token savings, KV and expert hit rates, RSS over checkpoints, reorder p50/p90/p99, generated workload JSON. | Contributor-only, experimental. Use the ContextPilot integration guide. |
+| Expert I/O microbench | `benchmarks/expert_io_microbench/run_all.py`<br>`benchmarks/expert_io_microbench/bench_routing.py`<br>`benchmarks/expert_io_microbench/bench_transfer.py`<br>`benchmarks/expert_io_microbench/bench_compute_evict.py`<br>`benchmarks/expert_io_microbench/bench_bubble.py`<br>`benchmarks/expert_io_microbench/compare_baseline.py`<br>`benchmarks/expert_io_microbench/run_decision_profile.py`<br>`benchmarks/expert_io_microbench/nsys_parser.py` | Routing, transfer, compute, bubble, merged bandwidth analysis, NVTX baseline comparison, and nsys go or no-go profiling. | CUDA GPU, model cache for the scenario scripts, offload dir, `/dev/shm` for host-only mode, `nsys` for the comparison and decision tools. | Routing and cache lookup mean and percentiles, transfer timing and sync overhead, expert compute / eviction / queue coordination, bubble ratio, bandwidth utilization, overhead regression percent, transfer step times, verdict. | Contributor-only, experimental. Detailed runbook in `benchmarks/expert_io_microbench/README.md`. |
+| Cross-framework comparison suite | `benchmarks/comparison/run_all.sh`<br>`benchmarks/comparison/run_moe_infinity.py`<br>`benchmarks/comparison/run_vllm.py`<br>`benchmarks/comparison/run_llamacpp.py`<br>`benchmarks/comparison/aggregate_results.py` | Reproduce the single-GPU MoE-Infinity vs vLLM vs llama.cpp table. | Docker, GPU, offload dir, HuggingFace cache or access, benchmark images. | TTFT, per-token latency, peak GPU memory, per-model JSON, markdown, CSV, and JSON comparison tables. | Contributor-only, reproducibility workflow. See `docs/benchmark_reproduction.md`. |
+| Performance model and roofline | `benchmarks/performance_model/bench_glm.py`<br>`benchmarks/performance_model/report_glm.py` | Tiny GLM decode versus MTP validation and roofline report generation. | CUDA GPU, `MOE_GLM_TINY=1`, `matplotlib`, `numpy`, conference plot helper. | Decode tok/s, MTP tok/s, mean accept length, peak memory, arithmetic intensity, predicted bound, markdown report and plots. | Contributor-only, experimental. Helper modules are excluded below. |
+| Kernel microbenchmarks | `benchmarks/ab_fused_kernels.py`<br>`benchmarks/ab_kernels_micro.py`<br>`benchmarks/bench_p0_topk_softmax.py`<br>`benchmarks/mxfp4_benchmark.py` | Fused kernels on or off, kernel-only A/B, gating softmax microbench, and MXFP4 versus BF16 dequant. | CUDA GPU, optional `sglang-kernel`, optional FlashInfer, optional Triton or SM120 support depending on the script. | Median, p10, p90, p99 microseconds, speedups, correctness checks, TTFT, per-token latency, peak GPU memory, expert weight size. | Contributor-only, experimental. Do not treat these as production SLA numbers. |
+| Evaluation utility | `benchmarks/eval/perplexity.py` | Perplexity evaluation over Wikitext, C4, or PTB. | CUDA GPU, `datasets`, `transformers`, offload dir, local model cache. | Perplexity, NLL, sample count, elapsed seconds. | Contributor-only utility, useful for model checks, not serving validation. |
 
-### Baseline Performance (Single Request)
+## DFlash validation
 
-Measures single-request TTFT, per-token latency, and peak GPU memory across multiple prompt lengths.
+There is no standalone benchmark CLI under `benchmarks/` for DFlash. Use [`docs/dflash.md`](dflash.md) and the gated tests under `tests/python/dflash/` instead.
+
+Typical validation commands:
+
+```bash
+MOE_DFLASH_GPU=1 pytest -q tests/python/dflash/test_gpu_serving_dflash.py
+MOE_DFLASH_GPU=1 pytest -q tests/python/dflash/test_gpu_20b_dflash.py
+MOE_DFLASH_GPU=1 pytest -q tests/python/dflash/test_gpu_120b.py
+```
+
+## Excluded helpers and fixtures
+
+These files are support code, not standalone benchmark entry points.
+
+| Path group | Why excluded |
+| --- | --- |
+| `benchmarks/comparison/__init__.py`, `benchmarks/contextpilot/__init__.py`, `benchmarks/eval/__init__.py`, `benchmarks/expert_io_microbench/__init__.py`, `benchmarks/performance_model/__init__.py`, `benchmarks/serving/__init__.py` | Package markers only. |
+| `benchmarks/comparison/common.py` | Shared result dataclasses, model metadata, and loaders for the comparison suite. |
+| `benchmarks/contextpilot/benchmark_utils.py`, `benchmarks/contextpilot/dataset_utils.py`, `benchmarks/contextpilot/http_benchmark.py` | Shared ContextPilot helpers, workload builders, and HTTP utilities. |
+| `benchmarks/expert_io_microbench/harness.py`, `benchmarks/expert_io_microbench/stats.py` | Shared profiler and timing primitives for the expert I/O suite. |
+| `benchmarks/performance_model/model_config.py`, `benchmarks/performance_model/roofline.py`, `benchmarks/performance_model/types.py` | Pure model and roofline math, plus dataclasses. |
+
+## Serving benchmark commands
+
+These are the stable serving workflows referenced in the catalog above.
+
+### Baseline performance
+
+Measures single request TTFT, per-token latency, and peak GPU memory.
 
 ```bash
 python benchmarks/serving/baseline_performance.py \
@@ -151,14 +189,9 @@ python benchmarks/serving/baseline_performance.py \
     --output-json baseline_results.json
 ```
 
-**Output fields:**
-- `ttft_ms` -- Time to first token (milliseconds)
-- `per_token_latency_ms` -- Average per-token decode latency (milliseconds)
-- `peak_gpu_memory_mb` -- Peak GPU memory usage (MB)
+### Throughput sweep
 
-### Throughput Sweep
-
-Measures tokens/s across different batch sizes to find the throughput-optimal batch size.
+Measures decode throughput across batch sizes and can compare against the baseline JSON.
 
 ```bash
 python benchmarks/serving/throughput.py \
@@ -171,9 +204,9 @@ python benchmarks/serving/throughput.py \
     --output-json throughput_results.json
 ```
 
-### Latency Under Concurrency
+### Latency under concurrency
 
-Measures TTFT and ITL at p50/p90/p99 percentiles across different concurrency levels.
+Measures TTFT and ITL percentiles across concurrency levels.
 
 ```bash
 python benchmarks/serving/latency.py \
@@ -186,19 +219,28 @@ python benchmarks/serving/latency.py \
     --output-json latency_results.json
 ```
 
-**Output fields per concurrency level:**
-- `ttft_p50_ms`, `ttft_p90_ms`, `ttft_p99_ms` -- TTFT percentiles
-- `itl_p50_ms`, `itl_p90_ms`, `itl_p99_ms` -- Inter-token latency percentiles
-
-### Kernel Microbenchmark
-
-Compares gating kernel (top-k softmax) performance across implementations.
+### Memory and KV offload
 
 ```bash
-python benchmarks/bench_p0_topk_softmax.py --num-iters 200 --warmup 50
+python benchmarks/serving/memory.py \
+    --model deepseek-ai/DeepSeek-V2-Lite-Chat \
+    --offload-dir /path/to/offload/dir \
+    --batch-size 8 \
+    --prompt-length 128 \
+    --max-new-tokens 16 \
+    --output-json memory_results.json
+
+python benchmarks/serving/kv_offload_benchmark.py \
+    --model deepseek-ai/DeepSeek-V2-Lite-Chat \
+    --offload-dir /path/to/offload/dir \
+    --num-requests 8 \
+    --prompt-length 256 \
+    --max-new-tokens 32 \
+    --enable-kv-offload \
+    --output-json kv_offload_results.json
 ```
 
-## Comparing with Other Frameworks
+## Comparing with other frameworks
 
 ### llama.cpp
 
@@ -209,32 +251,53 @@ llama_perf_context_print: prompt eval time = 2251.78 ms /  39 tokens (57.74 ms p
 llama_perf_context_print:        eval time = 122985.89 ms / 491 runs  (250.48 ms per token, 3.99 tokens per second)
 ```
 
-- **`prompt eval time`** = Prefill. Compare with MoE-Infinity's TTFT.
-- **`eval time`** = Decode. Compare with MoE-Infinity's decode time.
-- **`eval` tokens per second** = Decode throughput. Compare with `decoding_iterations / decoding_time`.
+- `prompt eval time` is prefill. Compare it with MoE-Infinity TTFT.
+- `eval time` is decode. Compare it with MoE-Infinity decode time.
+- `eval` tokens per second is decode throughput. Compare it with `decoding_iterations / decoding_time`.
 
-### vLLM / SGLang
+### vLLM and SGLang
 
-These frameworks report TTFT and ITL directly in their benchmark outputs. Use p50 values for comparison with MoE-Infinity's `StopWatch` measurements (which report averages).
+These frameworks report TTFT and ITL directly in their benchmark outputs. Compare p50-to-p50 or average-to-average. For MoE-Infinity `StopWatch`, collect multiple trials and compare the median of those runs when you want p50-style reporting.
 
-### Fair Comparison Checklist
+### Fair comparison checklist
 
-- [ ] Same model weights (not quantized vs full-precision)
-- [ ] Same GPU and same `device_memory_ratio` / memory allocation
-- [ ] Same number of GPU layers offloaded (e.g., llama.cpp's `-ngl` flag)
-- [ ] Prefill excluded from decode throughput in both frameworks
-- [ ] At least one warmup run before measurement
-- [ ] Same `max_new_tokens` / generation length
-- [ ] Same sampling strategy (`do_sample=False` / greedy for deterministic comparison)
+- Same model weights, not quantized versus full precision.
+- Same GPU and same `device_memory_ratio` or memory allocation.
+- Same number of GPU layers offloaded, for example llama.cpp `-ngl`.
+- Prefill excluded from decode throughput in both frameworks.
+- At least one warmup run before measurement.
+- Same `max_new_tokens` or generation length.
+- Same sampling strategy, `do_sample=False` or greedy for deterministic comparison.
+- Same batch or concurrency setting and the same prompt length.
+- Same baseline file or comparison table revision when you cite the result.
 
 ## Tuning `device_memory_ratio`
 
-The `device_memory_ratio` parameter controls what fraction of GPU memory is allocated for expert caching. The remainder is used by PyTorch for activations, KV cache, and other tensors.
+`device_memory_ratio` controls what fraction of GPU memory is allocated for expert caching. The remainder is used by PyTorch for activations, KV cache, and other tensors.
 
 | Value | Effect |
-|-------|--------|
-| **Higher** (e.g., 0.85) | More experts cached on GPU = fewer cache misses = faster decode. Risk: OOM if model activations are large. |
-| **Lower** (e.g., 0.50) | Fewer experts cached = more cache misses = slower decode. Benefit: more headroom for large prompts / batches. |
-| **Default** (0.75) | Good starting point for most single-GPU setups. |
+| --- | --- |
+| Higher, for example 0.85 | More experts cached on GPU, fewer cache misses, faster decode. Risk, OOM if model activations are large. |
+| Lower, for example 0.50 | Fewer experts cached, more cache misses, slower decode. Benefit, more headroom for large prompts or batches. |
+| Default 0.75 | Good starting point for most single-GPU setups. |
 
-If you encounter CUDA OOM errors, lower this value. If decode throughput is poor, try raising it (assuming no OOM).
+If you encounter CUDA OOM errors, lower this value. If decode throughput is poor, try raising it, assuming no OOM.
+
+## Reproducibility template
+
+Fill this in for every benchmark run:
+
+| Field | Value |
+| --- | --- |
+| Commit | `git rev-parse HEAD` |
+| Benchmark workflow | `benchmarks/serving/throughput.py` |
+| Model / checkpoint | `deepseek-ai/DeepSeek-V2-Lite-Chat` |
+| GPUs, CPU, RAM, storage | `1 x A100 80GB, 32 CPU cores, 256 GB RAM, NVMe SSD` |
+| CUDA, PyTorch, Transformers | `CUDA 12.8, PyTorch 2.5.x, Transformers 5.x` |
+| Residency / offload / quantization | `device_memory_ratio=0.75, offload_dir=/ssd/offload, FP16` |
+| Batch / concurrency | `batch_size=8` or `concurrency=4` |
+| Prompt / output lengths | `prompt_length=128, max_new_tokens=16` |
+| Warmup / iterations | `warmup=1, iters=50` |
+| Baseline | `baseline_results.json` or `comparison_table.md` |
+| Metrics captured | `ttft_ms, itl_p50_ms, decode_toks_per_s, peak_gpu_memory_mb` |
+| Notes | `host-only, nsys, FlashInfer on, sampled off` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,95 @@
+# Configuration and memory planning
+
+This page is the source of truth for `ArcherConfig` in
+`moe_infinity.utils.config`.
+It documents the Python config layer only. The OpenAI server has a separate
+config layer with names like `offload_dir`, `device_memory_ratio`, and
+`kv_cache_ratio`, so do not copy those semantics onto
+`kv_cache_memory_ratio`.
+
+## Serving crosswalk
+
+| Python config | Current server name | Note |
+| --- | --- | --- |
+| `offload_path` | `--offload-dir` / `MoE.serve(offload_dir=...)` | The server builds `<offload_dir>/<model>` and uses that as the cache root. |
+| `device_memory_ratio` | `--device-memory-ratio` / `MoE.serve(device_memory_ratio=...)` | Same split, same broad meaning. |
+| `kv_cache_memory_ratio` | no direct CLI | Native-engine memory split only, the serving engine uses its own `kv_cache_ratio`. |
+| `use_native_engine` | none | Python-only switch between native engine and HuggingFace `generate()`. |
+| `enable_kv_cache_offload` | none | Native-engine scaffold only. |
+| `enable_attention_offload` | none | Currently a no-op in stock code. |
+
+## ArcherConfig fields
+
+### File and trace fields
+
+| Field | Type | Default | Valid values / range | Effect | Interactions / status |
+| --- | --- | --- | --- | --- | --- |
+| `offload_path` | `str` | `""` | filesystem path string, required in practice | Root of the offload store. The runtime creates the directory, writes `name_id_map.json` and `model_signature.json`, and reuses them on later loads. | Must be unique per model/config pair. A reused path with a different model or fingerprint raises on load. Stable. |
+| `trace_capacity` | `int` | `1000` | any integer accepted by the parser, it must be large enough to allocate the trace tensor | Sizes the expert trace collection. | Loaded traces must fit in this capacity. Stable. |
+| `trace_path` | `Optional[os.PathLike[str]]` | `None` | file path or `None`, directories are rejected | Intended to load a saved trace, but current production flow normalizes it to an absolute `str` and forwards that `str` into `ExpertTracer.load_trace()`, which only accepts `os.PathLike` or `np.ndarray`, so the load is currently ineffective. | Current behavior is a type mismatch in the call chain; no stability/support claim. |
+| `perfect_cache_file` | `str` | derived | `<offload_path>/perfect_cache` | Derived internal path for the cache file. | No current production consumer. Internal. |
+| `device_per_node` | `int` | derived | `torch.cuda.device_count()` | Records the visible device count at config init. | Internal metadata, not a control knob. Internal. |
+
+### Memory and execution fields
+
+| Field | Type | Default | Valid values / range | Effect | Interactions / status |
+| --- | --- | --- | --- | --- | --- |
+| `prefetch` | `bool` | `False` | `True` / `False` | No current production consumer. | Legacy or reserved knob. Reserved. |
+| `speculative_prefetch` | `bool` | `False` | `True` / `False` | Enables expert prefetch driven by router logits. | Used by `DistributedExpertExecutor` and `ExpertPrefetcher`. Experimental. |
+| `speculative_prefetch_overlap` | `bool` | `False` | `True` / `False` | Issues speculative prefetch before the dispatch barrier so PCIe copies can overlap compute. | Requires `speculative_prefetch=True`. Can increase cache pressure and trigger `All cached expert locked` warnings when `device_memory_ratio` is high. Experimental. |
+| `device_memory_ratio` | `float` | `0.9` | `[0.0, 1.0]` | Fraction of GPU memory reserved for expert cache and native-engine budgeting. | Pairs with `kv_cache_memory_ratio`. If the native zero-KV heuristic kicks in and the sum would exceed `1.0`, `device_memory_ratio` is reduced to fit. Stable. |
+| `num_threads` | `int` | `4` | any integer accepted by the parser, positive values make sense in practice | Number of expert compute threads per GPU. | Passed to the expert dispatcher. Stable. |
+| `host_memory_ratio` | `float` | `0.9` | any float accepted by the parser, no explicit validation | Reserved host-memory fraction. | No current production consumer. Reserved. |
+| `kv_cache_memory_ratio` | `float` | `0.0` | `[0.0, 1.0]` | Fraction of GPU memory reserved for KV cache blocks in the native path. | If `use_native_engine=True` and this is `0.0`, `__post_init__` auto-sets it to `0.15` and warns. If the final sum still exceeds `1.0`, validation raises. Stable. |
+| `use_native_engine` | `bool` | `True` | `True` / `False` | Chooses the native engine vs HuggingFace generation inside the deprecated synchronous `MoE.generate()` path. | `MoE.generate()` falls back to HF when this is false. The method emits `DeprecationWarning` and is scheduled for removal; `glm_moe_dsa` forces native off in `big_modeling`. |
+| `enable_attention_offload` | `bool` | `False` | `True` / `False` | Enables attention offload scaffolding. | Stock code does not yet branch on this flag. The actual backend object is created inside `big_modeling`. Experimental. |
+| `enable_kv_cache_offload` | `bool` | `False` | `True` / `False` | Enables KV cache offload scaffolding in the native engine. | Registers offload handlers when a native KV manager is present, but tensor wiring is still partial. Experimental. |
+| `attention_backend` | `str` | `"default"` | any string accepted by parsing, only `default` has a documented meaning today | Legacy reserved field for attention backend selection. | The stock runtime does not consume this string. The active backend object comes from `big_modeling`. Reserved. |
+
+## Memory ratio rules
+
+`__post_init__` does not enforce a hard invariant up front.
+It applies the following sequence:
+
+1. If `use_native_engine=True` and `kv_cache_memory_ratio == 0.0`, it sets `kv_cache_memory_ratio = 0.15` and warns.
+2. If that auto-fill makes `device_memory_ratio + kv_cache_memory_ratio > 1.0`, it shrinks `device_memory_ratio` to `1.0 - kv_cache_memory_ratio` and warns.
+3. If either ratio is outside `[0, 1]`, or the final sum is still above `1.0`, it raises `ValueError`.
+
+Normal `MoE` construction passes the already normalized `ArcherConfig` ratio into `MemoryCoordinator`; `MemoryCoordinator.from_config` keeps the same `0.15` fallback for direct callers that pass zero.
+
+For single-server multi-GPU ownership, visible-device ordering, and cache locality, see [Single-server multi-GPU](multi-gpu.md).
+
+## Offload store layout
+
+`offload_path` must be unique per model and config fingerprint.
+On first load the runtime writes:
+
+- `name_id_map.json`
+- `model_signature.json`
+
+On later loads it verifies both the model name and the config fingerprint.
+If either differs, it raises and tells you to use a different `offload_path` or delete the cache.
+
+If the failure looks like a serving or timeout issue instead, check [Troubleshooting](troubleshooting.md).
+
+## Native path notes
+
+- `use_native_engine=False` keeps the HuggingFace `generate()` path.
+- `enable_attention_offload` is still scaffolded.
+- `enable_kv_cache_offload` is only meaningful when the native engine is built.
+- `speculative_prefetch` drives the actual router-logit based expert prefetch.
+- `speculative_prefetch_overlap` moves that prefetch earlier, before the barrier.
+
+## Deprecated inputs
+
+`load_from_json()` still accepts `glm_fp8_in_store`, but it warns and drops the key.
+It is deprecated and ignored.
+
+Repo evidence:
+- `moe_infinity/utils/config.py`
+- `moe_infinity/runtime/model_offload.py`
+- `moe_infinity/entrypoints/big_modeling.py`
+- `moe_infinity/memory/memory_coordinator.py`
+- `moe_infinity/distributed/expert_executor.py`
+- `moe_infinity/memory/expert_prefetcher.py`
+- `moe_infinity/runtime/attention_backend.py`

--- a/docs/dflash.md
+++ b/docs/dflash.md
@@ -1,63 +1,256 @@
-# DFlash Speculative Decoding (gpt-oss-120b)
+# DFlash speculative decoding
 
-MoE-Infinity ships a **native** DFlash (block-diffusion) speculative-decoding
-path for gpt-oss. A greedy, batch-1 `MoE.generate(..., speculative_draft=...)`
-routes through the engine's `spec_strategy` seam and runs the native
-draft → verify → rollback loop in `moe_infinity/spec_decode/dflash.py`.
+MoE-Infinity ships a native DFlash draft, verify, rollback path for GPT-OSS and other supported MoE models. The deprecated synchronous wrapper `MoE.generate(..., speculative_draft=...)` remains the current in-process integration and emits `DeprecationWarning`; `MoE.serve(..., speculative_draft=...)` is the recommended continuous-batching HTTP path and is not a drop-in return API. Direct `DFlashSpeculator.generate(...)` is an experimental alternative for custom harnesses, with no stable API promise, and supports batch-1 greedy and sampled decoding. The `MoE` integrations are greedy-gated and delegate only singleton requests in the server. Batch > 1 DFlash stays on the bare HuggingFace target path.
 
-## Usage
+For server-side gating, sampled-request fallback, and exact troubleshooting language, see [Serving](serving.md), [Architecture](../ARCHITECTURE.md), and [Troubleshooting](troubleshooting.md).
+
+## Quick start
+
+This example requires a CUDA-capable source installation, access to both
+checkpoints, and enough GPU cache, host memory, and SSD capacity for GPT-OSS-120B.
+Checkpoint loading may download weights when they are not already cached. For a
+configurable runnable script using the same defaults, see
+[`examples/dflash_gpt_oss_example.py`](../examples/dflash_gpt_oss_example.py).
+The drafter loads with `trust_remote_code=True`, which executes code from the
+checkpoint repository. Use only a trusted drafter and pin the repository
+revision for reproducible or security-sensitive deployments.
 
 ```python
+from transformers import AutoTokenizer
+
 from moe_infinity import MoE
 from moe_infinity.spec_decode import DFlashSpeculator
 
-model = MoE("openai/gpt-oss-120b", {"offload_path": "/ssd/moe-infinity/gpt-oss-120b"})
-speculator = DFlashSpeculator(model, "z-lab/gpt-oss-120b-DFlash")  # trust_remote_code
+target = "openai/gpt-oss-120b"
+drafter = "z-lab/gpt-oss-120b-DFlash"
+prompt = "Question: What is the capital of France?\nAnswer:"
+
+tokenizer = AutoTokenizer.from_pretrained(target)
+input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+model = MoE(target, {
+    "offload_path": "/ssd/moe-infinity/gpt-oss-120b",
+    "device_memory_ratio": 0.75,
+})
+spec = DFlashSpeculator(model, drafter)
 
 output_ids = model.generate(
     input_ids,
     max_new_tokens=64,
-    do_sample=False,          # greedy → routes through the native DFlash strategy
-    speculative_draft=speculator,
+    do_sample=False,
+    speculative_draft=spec,
 )
 ```
 
-Omit `speculative_draft` (or pass a non-greedy sampling config / batch > 1) and
-`generate` uses the standard autoregressive path, **byte-identical** to before.
+If you want sampled batch-1 DFlash, call `spec.generate(...)` directly. The
+`MoE.generate` and serving integrations stay on the standard path for sampled
+requests today. The Qwen3.5-MoE wrapper is the explicit exception: sampled
+`MoE.generate(..., speculative_draft=...)` raises `ValueError` there, because
+that model path requires greedy speculative decode.
 
-## v1 scope
+## Capability matrix
 
-- **Greedy only** (`do_sample=False`); sampled speculative decoding is deferred.
-- **Resident by default.** Expert offload is a tunable knob (`device_memory_ratio`);
-  v1 does not couple expert prefetch to the speculative loop.
-- **Sync path only** — the async serving path is not spec-enabled.
-- **batch == 1.**
+| Capability | Status | Evidence or constraints |
+| --- | --- | --- |
+| Batch-1 direct `spec.generate`, greedy | Implemented, validated | `tests/python/dflash/test_native_step.py::test_native_multistep_greedy_matches_plain_greedy`, `tests/python/dflash/test_edge_cases.py` |
+| Batch-1 direct `spec.generate`, sampled | Implemented, validated on CPU tiny fixtures | `tests/python/dflash/test_sampled_spec.py::test_sampled_generate_is_seed_deterministic`; this path is direct, not through `MoE.generate` |
+| Batch > 1 direct `spec.generate`, greedy | Implemented, validated | `tests/python/dflash/test_batched_spec.py::test_batched_matches_looped_singles_token_identical` |
+| `MoE.generate(..., speculative_draft=...)`, greedy batch-1 | Implemented, validated | `tests/python/dflash/test_engine_wire.py`, `tests/python/dflash/test_spec_seam.py` |
+| `MoE.generate(..., speculative_draft=...)`, sampled batch-1 | Standard path for most models; Qwen3.5-MoE raises `ValueError` | The native speculator is greedy-gated in the engine, and the Qwen3.5 wrapper rejects sampled speculative decode on this path |
+| Continuous-batching serving | Implemented, validated on GPT-OSS-20B | `tests/python/dflash/test_gpu_serving_dflash.py`; only a fresh singleton greedy request can delegate |
+| Route-ahead expert prefetch | Implemented, scheduling-only, validated on synthetic offloaded shells | `tests/python/dflash/test_route_ahead_metrics.py`, `tests/python/dflash/test_route_ahead_wire.py`, `tests/python/dflash/test_qwen35_hybrid_rollback.py`; gpt-oss does not wire the executor |
 
-## How it works
+## Configuration
 
-Per step: prefill the target for an anchor; build a `block_size=10` block
-`[anchor, MASK×9]`; the non-causal drafter (reusing the target `embed_tokens` /
-`lm_head`, with a 5-layer target feature at layers `[1, 9, 17, 25, 33]` injected
-into every drafter layer) fills the 9 masks; the target verifies the whole block
-in **one full-logits forward**; the leading drafts the target's argmax agrees with
-are accepted, plus a bonus token (emitted but not cached); both KV caches roll
-back to the committed prefix.
+### Direct speculator API
 
-gpt-oss uses **sliding-window attention**, so the target rollback snapshots each
-sliding layer *before* the verify forward and rebuilds it from the committed
-prefix — a plain `DynamicCache.crop()` is invalid once the window is saturated
-(the layer has already evicted the tokens a partial accept must restore).
+- `DFlashSpeculator(moe, draft_model_path, device=None, dtype=torch.bfloat16)`
+  loads the drafter with `trust_remote_code=True` and defaults to bfloat16.
+- `DFlashSpeculator.from_models(moe, draft_model, config=None, device=None)`
+  skips checkpoint loading and reuses an already-built drafter module.
+- `DFlashSpeculator.generate(input_ids, max_new_tokens=256, temperature=0.0,
+  stop_token_ids=None, top_k=0, top_p=1.0, attention_mask=None)` is the public
+  experimental decode entry point; it has no stable API guarantee.
+- `DFlashSpeculator.enable_route_ahead_stats()` creates or resets a read-only
+  recorder. `route_ahead_stats` starts as `None`.
+- `read_dflash_config(draft_hf_config)` requires `block_size`, `mask_token_id`,
+  `target_layer_ids`, `hidden_size`, and `vocab_size`. `num_target_layers` is
+  optional and defaults to `-1`.
+- `validate_pairing(...)` checks `hidden_size`, `vocab_size`, `mask_token_id <
+  vocab_size`, `block_size >= 2`, and target layer range.
+- `validate_drafter(...)`, `validate_drafter_module(...)`, and
+  `bind_shared_weights(...)` are internal helpers inside `dflash.py`; they are
+  used by the implementation and tests, but they are not exported from
+  `moe_infinity.spec_decode.__init__`.
 
-## Testing
+### MoE and server knobs
 
-- **Autonomous (CPU, tiny model)** — no GPU / no checkpoints:
-  `pytest tests/python/dflash -q`. The losslessness gates are
-  `test_native_e2e.py` (native DFlash == plain greedy, token-identical) and
-  `test_spec_off_regression.py` (spec-off byte-identical to the pre-integration
-  baseline).
-- **GPU-gated (120B)**:
-  `MOE_DFLASH_GPU=1 pytest tests/python/dflash/test_gpu_120b.py -q`
-  with `openai/gpt-oss-120b` + `z-lab/gpt-oss-120b-DFlash` cached; resident, TP=2
-  on SM120. Reports token agreement-rate vs plain-decode self-consistency, the
-  acceptance-length histogram, and decode tok/s (DFlash vs no-spec). Skips
-  cleanly when the flag is unset or the checkpoints/GPU are unavailable.
+- `MoE.generate(..., speculative_draft=...)` attaches the speculator only for
+  the current call. Omit the kwarg, or pass `None` or `False`, to detach it.
+  For Qwen3.5-MoE, sampled requests on this path raise `ValueError` instead of
+  falling back silently.
+- Greedy DFlash delegation is gated by `temperature=0`, `top_k=0`, and
+  `top_p=1.0`; `do_sample=False` is the usual caller intent for that path, but
+  it is not a separate runtime gate.
+- `MoE.serve(..., speculative_draft=None)` defaults to `device_memory_ratio=
+  0.75`, `kv_cache_ratio=0.25`, `max_batch_size=32`, and
+  `enable_prefix_caching=False`.
+- `python -m moe_infinity.entrypoints.openai.api_server_v2 --speculative-draft
+  <drafter>` exposes the same path from the CLI. The parser default is off.
+
+If a sampled serving request falls back to the standard path, that is expected behavior, not a pairing failure; the pairing check is a separate validation step.
+
+## Draft, Verify, Commit, and Rollback
+
+1. **Draft**
+   - Build a block of the form `[anchor, MASK, MASK, ...]`.
+   - The target hidden states at the configured `target_layer_ids` are
+     concatenated into the drafter context feature.
+   - The drafter and target share the target `embed_tokens` and `lm_head`.
+
+2. **Verify**
+   - The target runs one full-logits forward over the whole block.
+   - Greedy mode uses the target argmax agreement rule.
+   - Sampled mode uses warped draft and target probabilities with lossless
+     rejection sampling.
+
+3. **Commit**
+   - The emitted step is `accepted drafts + bonus token`.
+   - The cached prefix is `anchor + accepted drafts`.
+   - The bonus token is emitted but not cached, because it becomes the next
+     anchor.
+
+4. **Rollback**
+    - Serving keeps `cached_len == prompt_len + emitted_len` after each committed
+      step. That is the state contract pinned by `SpecDecodeState`.
+    - `SpecDecodeState.record_verify(block_len, committed)` advances the cached
+      and emitted counts, and `apply_verify_step()` turns that into the
+      `truncate_target` passed to `PagedKVCache.truncate_tokens(seq_id, new_len)`.
+    - `PagedKVCache.truncate_tokens(seq_id, new_len)` frees tail blocks and
+      truncates swapped-out buffers.
+    - Sliding-window targets snapshot and replay the committed prefix when plain
+      `DynamicCache.crop()` is not enough.
+
+## Sampled decoding
+
+- Sampled DFlash is batch-1 only.
+- The direct path uses `warped_probs`, `acceptance_sampled`, and
+  `committed_tokens_sampled`.
+- Warp order matches the engine sampler, temperature first, then top-k, then
+  top-p, then softmax.
+- If you use `MoE.generate` or `MoE.serve`, sampled requests stay on the
+  standard path today, except that Qwen3.5-MoE intentionally rejects sampled
+  speculative decode with `ValueError` on the `MoE.generate` path.
+- Batch > 1 sampled DFlash is not supported.
+
+## Batched decoding
+
+- Batch > 1 direct DFlash is greedy only and requires a bare HuggingFace target.
+- Prompts must be left padded, or all the same length. `attention_mask` must be
+  0/1 valued and end with a real token.
+- `max_new_tokens` can be a single int or a per-sequence list.
+- The returned tensor is right padded, and `last_generated_lengths` stores the
+  true per-row new-token counts.
+- `MoE.generate(..., speculative_draft=...)` with batch > 1 raises
+  `NotImplementedError`.
+
+## Continuous-batching serving
+
+- `MoE.serve(..., speculative_draft=...)` and the OpenAI server CLI accept a
+  DFlash speculator.
+- The serving engine delegates only for a fresh singleton prefill request with
+  no prior output tokens that is greedy, stop-free, penalty-free, has
+  `top_k <= 0`, `top_p >= 1.0`, `repetition_penalty == 1.0`, `logprobs <= 0`,
+  and is within the per-step token cap.
+- A delegated serving step may emit several accepted tokens, and the engine
+  streams them one by one after recording committed counts.
+- The validated real-checkpoint serving harness is GPT-OSS-20B. GPT-OSS-120B
+  has no recorded real-checkpoint serving validation. Qwen3.5 serving wiring
+  has tiny-fixture coverage, but no real-checkpoint serving validation is
+  recorded.
+
+## Route-ahead expert prefetch
+
+Route-ahead is a scheduling-only add-on. It warms the exact routed expert union
+for the layer being dispatched, but it does not change routing or output
+tokens.
+
+- Activation happens only during a DFlash verify forward.
+- If route-ahead is active and a prefetcher exists, the executor pins the exact
+  routed union with `fetch_experts_lock_cache(...)` and enqueues the same set
+  with `speculative_prefetch(..., expert_ids=..., prefetch_layer_id=...)`.
+- If the context is inactive, there is no prefetcher, or the union is empty,
+  the executor falls back to the legacy pooled prefetch or a no-op.
+- The union is pinned one layer at a time because `ReplaceCacheCandidates` is
+  global and clears background queues.
+- Offloaded executor-backed models such as DeepSeek, Qwen, and Mixtral reach
+  this seam. GPT-OSS does not, because its expert path never wires an
+  `expert_executor`.
+
+Metric names:
+
+- `RouteAheadStepSummary(layers, predicted, actual, covered, kept, wasted)`
+- `RouteAheadStats.as_dict()` returns `steps`, `layers_observed`,
+  `predicted_experts`, `actual_experts`, `covered_experts`, `kept_experts`,
+  `wasted_experts`, `coverage`, and `waste_ratio`
+
+Coverage is `covered / actual` and defaults to `1.0` when `actual == 0`.
+Waste ratio is `wasted / predicted` and defaults to `0.0` when
+`predicted == 0`.
+
+## Observability
+
+- `route_ahead_stats` defaults to `None`. `enable_route_ahead_stats()` returns
+  the recorder and resets it on reuse.
+- `step_trace`, `last_target_cache`, `last_draft_cache`, and
+  `last_generated_lengths` are advanced internal diagnostics only; they have no
+  stability or compatibility guarantee.
+- `step_trace` records `prev_start`, `accept`, `start`, `emitted_len`,
+  `target_cache_len`, and `draft_cache_len`.
+- `last_target_cache` and `last_draft_cache` expose the final caches after a run.
+- `last_generated_lengths` is only set by the batched path.
+
+## Compatibility
+
+| Model | Target / drafter | Residency | Sync | Serving | Sampling | Route-ahead | Hardware / validation |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| GPT-OSS-20B | `openai/gpt-oss-20b` / `z-lab/gpt-oss-20b-DFlash` | Tunable via `offload_path` and `device_memory_ratio`; the GPU-gated harness uses a high resident setting | Greedy batch-1 validated | Continuous-batching greedy validated | Direct batch-1 sampled implemented, not yet validated on the real pair | Not wired: the GPT-OSS expert path does not attach an `expert_executor` | GPU-gated, no board asserted in repo tests |
+| GPT-OSS-120B | `openai/gpt-oss-120b` / `z-lab/gpt-oss-120b-DFlash` | Tunable via `offload_path` and `device_memory_ratio`; the GPU-gated harness uses a high resident setting | Greedy batch-1 validated | Implemented, not yet validated on a real serving harness | Direct batch-1 sampled implemented, not yet validated on the real pair | Not wired: the GPT-OSS expert path does not attach an `expert_executor` | GPU-gated, no board or TP count asserted in repo tests |
+| Qwen3.5-MoE | No published real-model drafter checkpoint is recorded in repo tests | Text backbone, shared expert, and `lm_head` stay resident, routed experts offload | Greedy batch-1 hybrid rollback validated on tiny CPU fixtures | Serving wiring has tiny-fixture coverage; no real-checkpoint serving validation is recorded | `MoE.generate` sampled DFlash is rejected, direct sampled speculator is not yet validated on a real checkpoint | Wired and exercised on synthetic/tiny CPU fixtures; not validated with a real target/drafter checkpoint | No real-model hardware validation recorded |
+
+Route-ahead is an execution-path capability of executor-backed offloaded models,
+not evidence that a validated DFlash target/drafter checkpoint pair exists.
+DeepSeek, Qwen, and Mixtral paths can reach the executor seam described above,
+but they are absent from this matrix unless the repo records a corresponding
+DFlash pairing and validation scope. No additional drafter pair is implied.
+
+The real-model harnesses skip cleanly unless `MOE_DFLASH_GPU=1` is set and the
+checkpoints are present in the HuggingFace cache.
+
+## Validation
+
+- CPU gate, no GPU or checkpoint download required:
+  `pytest -q tests/python/dflash -m "not gpu"`
+- GPT-OSS-20B GPU-gated validation:
+  `MOE_DFLASH_GPU=1 pytest -q tests/python/dflash/test_gpu_20b_dflash.py`
+- GPT-OSS-120B GPU-gated validation:
+  `MOE_DFLASH_GPU=1 pytest -q tests/python/dflash/test_gpu_120b.py`
+- GPT-OSS-20B serving versus sync validation:
+  `MOE_DFLASH_GPU=1 pytest -q tests/python/dflash/test_gpu_serving_dflash.py`
+
+## Known limitations and troubleshooting
+
+- Batch > 1 with `speculative_draft` through `MoE.generate` is not supported.
+- Batch > 1 sampled DFlash is not supported.
+- GPT-OSS route-ahead is not wired because the model path never attaches an
+  `expert_executor`.
+- Qwen3.5 greedy DFlash is supported through the hybrid cache replay path, but
+  sampled DFlash on a real Qwen3.5 checkpoint is not yet validated.
+- Missing checkpoints or `MOE_DFLASH_GPU` simply skip the GPU-gated harnesses.
+- `block_size`, `target_layer_ids`, hidden size, or vocab mismatches fail fast
+  during drafter validation.
+
+## Related files
+
+- `examples/dflash_gpt_oss_example.py`
+- `tests/python/dflash/`

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,87 @@
+# Environment variables
+
+This page lists the env keys read by production code and build files in this
+repo.
+It excludes test harness variables and other repo-local fixtures.
+
+Exact string comparisons matter. Several toggles only react to `"1"` or
+`"0"`.
+
+## Runtime and serving
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `MOE_API_KEYS` | unset | `moe_infinity/entrypoints/openai/api_server_v2.py` startup | Comma-separated bearer tokens for the OpenAI server. If non-empty, auth middleware enforces them. | CLI `--api-key` wins when present. Empty string means no auth. |
+| `CONTEXTPILOT_ENABLED` | `"1"` | `moe_infinity/entrypoints/openai/api_server_v2.py` startup and status | If `"0"`, force ContextPilot off. | `--enable-contextpilot` (or the corresponding programmatic enable) is still required; any nonzero value only removes the disable override and does not enable ContextPilot by itself. |
+
+## Acceleration fallbacks
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `MOE_DISABLE_FUSED_KERNELS` | `"0"` | `moe_infinity/kernel/__init__.py` import time | If `"1"`, QKV and FFN use eager/PyTorch fallback, while decode attention bypasses the fused decode wrapper and routes through `paged_attention_fwd`, which uses the CUDA paged-attention kernel when available and otherwise falls back to torch SDPA. | Read at import time, so set it before importing `moe_infinity.kernel`. |
+| `MOE_DISABLE_CUDA_GRAPHS` | unset, treated as off | `moe_infinity/serving/cuda_graph.py` init | If `"1"`, disable CUDA graph warmup, capture, and replay. | Read when `CudaGraphRunner` is constructed. |
+
+## Profiling and tracing
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `MOE_INFINITY_PROFILE_IO` | `"0"` in `IOProfiler`, truthy check in `ExpertTracer` | `moe_infinity/profiling/io_profiler.py`, `moe_infinity/memory/expert_tracer.py` | Enable I/O event capture, atexit flush, and trace recording. | The two consumers do not check it the same way. `IOProfiler` uses `== "1"`; `ExpertTracer` currently uses truthiness of the env string. |
+| `MOE_INFINITY_PROFILE_IO_OUT` | unset | `moe_infinity/profiling/io_profiler.py` | Append JSONL events to this path on flush. | No output if unset. |
+| `MOE_INFINITY_PROFILE_IO_SAMPLE` | `"1.0"` | `moe_infinity/profiling/io_profiler.py` | Sampling probability, clamped to `[0.0, 1.0]`. | `0` disables, `1` records all. |
+
+## Deterministic mode
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `MOE_DETERMINISTIC` | unset, treated as off | `moe_infinity/kernel/deterministic_matmul.py` import time | If `"1"`, turn on deterministic algorithms, set `CUBLAS_WORKSPACE_CONFIG=:16:8`, and set `NCCL_ALGO=Tree`. | The module snapshots and restores the previous values on disable. `CUBLAS_WORKSPACE_CONFIG` and `NCCL_ALGO` are standard CUDA/NCCL knobs, not MoE-Infinity env vars. |
+
+## Model-specific toggles
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `MOE_INFINITY_MXFP4_DEQUANT` | unset, treated as off | `moe_infinity/runtime/model_offload.py` checkpoint load path | If `"1"`, dequantize MXFP4 weights to BF16 while loading the offload cache. | Only matters for MXFP4 checkpoints. |
+| `MOE_DSV4_FORCE_NATIVE` | unset, auto | `moe_infinity/models/deepseek_v4/official_offload_adapter.py` | If `"0"`, force the non-native DeepSeek-V4 path. Otherwise auto-select native on Blackwell when the extension is available. | An explicit `use_native` argument still wins. |
+
+For `CUDA_VISIBLE_DEVICES` ordering, expert ownership, and one-host multi-GPU behavior, see [Single-server multi-GPU](multi-gpu.md).
+
+## Build and packaging
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `CUDA_HOME` | resolved by search, final fallback `/usr/local/cuda` | `setup.py` build | Locate the CUDA toolkit and feed it to the extension build. | The script also writes the resolved value back into `os.environ["CUDA_HOME"]` and `cpp_extension.CUDA_HOME`. |
+| `CUTLASS_DIR` | `~/cutlass` in `setup.py`, `$HOME/cutlass` in root `CMakeLists.txt` | `setup.py`, `CMakeLists.txt` | Locate CUTLASS headers. | Same env key, same purpose, two build systems. |
+| `NVTX_DISABLE` | `"0"` | `setup.py` build | If `"1"`, compile out NVTX instrumentation macros. | Build-time only. |
+| `MOE_ENABLE_SM90` | `"1"` | `setup.py` build | Include sm_90 kernels in the compiled extensions. | Build-time only. |
+| `MOE_ENABLE_SM120` | `"0"` | `setup.py` build | Include sm_120 kernels and the native FP4 extension arch flags. | Build-time only. |
+| `MOEINF_VERSION` | `"0.0.1"` | `setup.py` packaging | Set the package version string. | Packaging only. |
+
+## Standard third-party envs
+
+| Variable | Default | Where read | Effect | Notes |
+| --- | --- | --- | --- | --- |
+| `TRANSFORMERS_CACHE` | unset | `moe_infinity/entrypoints/big_modeling.py` checkpoint download | HuggingFace snapshot cache directory. | Standard HuggingFace env, not project-defined. |
+| `HOME` | shell home directory | `CMakeLists.txt` fallback | Used only to construct the default CUTLASS path when `CUTLASS_DIR` is unset in CMake. | Standard shell env, not project-defined. |
+
+## Test-only and harness variables
+
+These show up in repo tests and benchmarks, but they are not part of the
+production env surface documented above.
+
+- `MOE_GLM_TINY`, `MOE_GLM_SMOKE`, `MOE_GLM_MEDIUM`
+- `GPT_OSS_E2E`, `GPT_OSS_CHECKPOINT`, `GPT_OSS_DEVICE_MEMORY_RATIO`
+- `MOE_DFLASH_OFFLOAD` — DFlash GPU tests use it to override the offload root without editing the test; defaults to a model-specific cache path.
+- `DSV4_FLASH_CKPT`
+- `MOE_DFLASH_GPU`, `MOE_DFLASH_MEM_RATIO`
+- `WORLD_SIZE`, `RANK`, `LOCAL_RANK`
+
+Repo evidence:
+- `moe_infinity/kernel/__init__.py`
+- `moe_infinity/serving/cuda_graph.py`
+- `moe_infinity/profiling/io_profiler.py`
+- `moe_infinity/memory/expert_tracer.py`
+- `moe_infinity/kernel/deterministic_matmul.py`
+- `moe_infinity/runtime/model_offload.py`
+- `moe_infinity/models/deepseek_v4/official_offload_adapter.py`
+- `moe_infinity/entrypoints/openai/api_server_v2.py`
+- `setup.py`
+- `CMakeLists.txt`

--- a/docs/glm-5.2.md
+++ b/docs/glm-5.2.md
@@ -1,0 +1,93 @@
+# GLM-5.2 guide
+
+GLM-5.2 is the `glm_moe_dsa` route in MoE-Infinity. The registered class is
+`GlmMoeDsaForCausalLM`, and the checkpoint used in this repo is
+`zai-org/GLM-5.2-FP8`.
+
+## Maturity and compatibility
+
+- Transformers floor: `>= 5.12`
+- Registry status: conditional import, so the family is skipped when the class
+  is unavailable
+- Supported path: the HuggingFace-compatible `MoE` wrapper
+- Native serving engine: disabled for this family (`use_native_engine = False`)
+
+## Dependencies
+
+GLM-5.2 uses the shared MoE offload runtime plus the GLM-specific MTP and DSA
+helpers in `moe_infinity/spec_decode/`.
+
+The repo also exposes `glm_dflash_available()`, but it currently warns that no
+GLM drafter is registered, so route-ahead DFlash is not part of the supported
+path.
+
+## FP8 expert offloading
+
+The routed experts stay in the host store as FP8. On load, the router expands
+the packed expert tensors to per-expert state, then the dispatcher streams the
+needed experts to GPU.
+
+What stays resident on GPU:
+- 3 dense layers
+- shared expert
+- MLA attention
+- DSA indexer
+- MTP layer
+
+What is dequantized to BF16 on load:
+- non-routed FP8 weights that execute outside the expert dispatcher
+
+## Synchronous generation
+
+Synchronous generation goes through `MoE.generate`, which is deprecated,
+emits `DeprecationWarning`, and is scheduled for removal. It remains the current
+validated synchronous GLM path during the transition. The GLM family does not
+switch to a native engine, and the repo does not advertise a separate
+GLM-specific serving backend.
+
+For the current codebase, that means the validated path is the HF-style model
+wrapper plus the offload runtime, not a custom native executor.
+
+## Serving and speculative decoding
+
+Serving support exists through the normal MoE-Infinity server entrypoints, but
+GLM-specific speculative decoding is limited:
+
+- built-in MTP is present
+- no GLM drafter is registered for route-ahead prefetch
+- speculative draft/verify is not a validated GLM serving mode in this repo
+
+## Storage and memory requirements
+
+The guide assumes the FP8 routed experts are too large to keep fully resident,
+so host memory is required for the expert store.
+
+Memory layout summary:
+- host store: routed experts
+- GPU resident: dense blocks, shared expert, MLA attention, DSA indexer, MTP
+- execution precision: routed experts remain FP8 in storage, with BF16 compute
+  where needed outside the dispatcher
+
+## Validation
+
+Repo coverage includes:
+- `tests/python/unit/test_model_registry.py`
+- `tests/python/unit/test_glm_*`
+- `tests/python/integration/test_glm_smoke.py`
+- `tests/python/integration/test_glm_serving.py`
+- `tests/python/integration/test_glm_mtp.py`
+- `tests/python/integration/test_glm_fp8_store_parity.py`
+- `tests/python/integration/test_glm_fp8_reload_parity.py`
+
+The tiny harness validates the registration, routing, store parity, reload
+parity, and serving smoke path, but it does not claim full production topology
+coverage.
+
+## Known limitations
+
+- `use_native_engine = False` for GLM-5.2
+- no registered GLM drafter for route-ahead DFlash
+- no claim here for multi-node serving or untested topologies
+- speculative decoding is not treated as production-validated for this family
+
+See also: [Model compatibility matrix](model-compatibility.md).

--- a/docs/model-compatibility.md
+++ b/docs/model-compatibility.md
@@ -1,0 +1,42 @@
+# Model compatibility matrix
+
+This guide is the source of truth for the families registered in
+`moe_infinity/common/constants.py` and the runtime adapters wired in
+`moe_infinity/runtime/model_offload.py`.
+
+Legend:
+- `validated`, covered by a repo test on a real checkpoint or a close smoke harness
+- `implemented/experimental`, the code path exists, but the repo only has unit or fixture coverage
+- `not validated`, the repo has no harness for the claim
+- `unsupported`, no runtime path or a fail-fast guard blocks it
+
+Conditional registry keys, `deepseekv4`, `qwen3_5`, and `glmmoedsa`, only
+register when the matching Transformers class imports cleanly. The repo floor
+is `transformers>=5.3.0,<6`, but some families need newer builds.
+
+| Family / HF class | Example checkpoint | Minimum Transformers | Sync generation | Continuous serving | Expert offload / quantization | Speculative decoding | Validated topology | Limitations |
+|---|---|---|---|---|---|---|---|---|
+| DeepSeek-V2 (`DeepseekV2ForCausalLM`) | `deepseek-ai/DeepSeek-V2-Lite-Chat` | `>= 5.3.0` | validated | implemented/experimental | validated | not recorded | `1x GPU` | FlashAttention is excluded in the offload path, eager attention is used in the consistency harness |
+| DeepSeek-V3 (`DeepseekV3ForCausalLM`) | `deepseek-ai/DeepSeek-V3` | `>= 5.3.0` | implemented/experimental | implemented/experimental | implemented/experimental | not recorded | Not recorded | Only routing and paged-attention parity are covered in repo tests |
+| DeepSeek-V4 (`DeepseekV4ForCausalLM`) | `deepseek-ai/DeepSeek-V4-Flash` | Not recorded, guarded import | validated for the official offload path | not validated | validated | unsupported | `4x GPU mp4` | The official checkpoint must be mp-sharded; repo validation covers the mp4 path, while mp1 is not covered by repo tests |
+| Mixtral (`MixtralForCausalLM`) | `mistralai/Mixtral-8x7B-Instruct-v0.1` | `>= 5.3.0` | implemented/experimental | implemented/experimental | implemented/experimental | not recorded | Not recorded | No real-model harness is recorded in this repo |
+| Qwen3 (`Qwen3MoeForCausalLM`) | `Qwen/Qwen3-30B-A3B` | `>= 5.3.0` | validated | implemented/experimental | validated | not recorded | `1x GPU` | `Qwen3PagedAttention` exists, but the repo does not ship a real-model serving harness for it |
+| Qwen3.5 (`Qwen3_5MoeForConditionalGeneration`) | `Qwen/Qwen3.5-35B-A3B` | `>= 5.12` | validated on tiny fixtures through deprecated `MoE.generate()` | serving wiring covered by tiny fixtures; no real-checkpoint serving validation recorded | validated on tiny fixtures | validated on tiny fixtures | Tiny CPU fixtures only | Text-only path, vision and MTP weights stay unused, batch>1 speculative draft is blocked in deprecated `MoE.generate()` |
+| GLM-5.2 (`GlmMoeDsaForCausalLM`) | `zai-org/GLM-5.2-FP8` | `>= 5.12` | validated | validated on the tiny serving harness | validated | built-in MTP only | `1x GPU` | Native engine is forced off, no GLM DFlash drafter is registered, and non-zero temperature falls back to greedy in MTP |
+| GPT-OSS (`GptOssForCausalLM`) | `openai/gpt-oss-20b` | `>= 5.3.0` | validated for 20B | validated for 20B | validated | validated for greedy batch-1, sampled batch-1 implemented/experimental | GPU-gated | Route-ahead is not wired because the path never attaches an `expert_executor`; batch>1 `speculative_draft` is blocked |
+| DBRX (`DbrxForCausalLM`) | `databricks/dbrx-instruct` | `>= 5.3.0` | implemented/experimental | not validated | implemented/experimental | not recorded | Not recorded | Registry and adapter code exist, but there is no real-model harness in repo tests |
+| Jamba (`JambaForCausalLM`) | `ai21labs/Jamba-*` | `>= 5.3.0` | implemented/experimental | not validated | implemented/experimental | not recorded | Not recorded | Registry and adapter code exist, but there is no real-model harness in repo tests |
+| OLMoE (`OlmoeForCausalLM`) | `allenai/OLMoE-*` | `>= 5.3.0` | implemented/experimental | not validated | implemented/experimental | not recorded | Not recorded | Registry and adapter code exist, but there is no real-model harness in repo tests |
+| NLLB-MoE (`NllbMoeForConditionalGeneration`) | `facebook/nllb-moe-54b` | `>= 5.3.0` | implemented/experimental | not validated | implemented/experimental | not recorded | Not recorded | Encoder-decoder sparse parsing is covered, but there is no repo end-to-end harness |
+| OPT (`OPTForCausalLM`) | Not recorded | `>= 5.3.0` | unsupported | unsupported | unsupported | unsupported | Not recorded | Registry entry only, no adapter or test coverage beyond parser dispatch |
+
+Repo evidence:
+- `moe_infinity/common/constants.py` for the registry and conditional imports
+- `moe_infinity/runtime/model_offload.py` for the adapter wiring
+- `tests/test_gpt_oss_*`, `tests/python/v4/*`, `tests/python/integration/test_glm_*`,
+  `tests/python/unit/test_qwen3_5_moe.py`, `tests/python/unit/test_model_registry.py`,
+  `tests/python/unit/test_glm_*`, and `tests/python/integration/test_model_consistency.py`
+
+Use `Not recorded` when the repo has no direct evidence for a version,
+topology, or capability claim. Use `implemented/experimental` when the code path
+exists but only unit or fixture tests cover it.

--- a/docs/multi-gpu.md
+++ b/docs/multi-gpu.md
@@ -1,0 +1,106 @@
+# Single-server multi-GPU operation
+
+MoE-Infinity supports one Python process on one host with multiple visible CUDA devices.
+The generic expert-offload path assigns experts by visible GPU index and keeps a cache per GPU.
+It does not need `torchrun` for the standard `MoE` path.
+
+## Supported Topology
+
+- One server, one host, multiple visible GPUs.
+- One process for the generic `MoE` path.
+- Logical GPU numbering comes from `CUDA_VISIBLE_DEVICES`, so the first visible device becomes `cuda:0`.
+- The runtime assumes the visible set is fixed while the model is loaded.
+- Multi-node inference across separate machines is not supported here.
+
+### Exact commands
+
+Single visible GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=0 python script.py
+```
+
+Two visible GPUs:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 python script.py
+```
+
+Any visible order works, but it changes which physical GPU becomes logical `cuda:0` and therefore changes expert ownership.
+
+## Device Selection
+
+- `torch.cuda.device_count()` reports the visible GPUs.
+- `get_default_device()` returns `cuda:0` when CUDA is available.
+- `ArcherConfig.device_per_node` is set from `torch.cuda.device_count()`.
+- The expert dispatcher uses the visible device count, not PCIe slot order or UUIDs.
+- If you reorder `CUDA_VISIBLE_DEVICES`, you reorder logical ownership.
+
+## Expert Ownership and Caching
+
+- Expert placement is round robin by expert id, `gpu_id = expert_id % num_visible_gpus`.
+- `ExpertOffloadCoordinator` and the Python tests use the same rule.
+- `ExpertPrefetcher` warms the cache with `replace_cache_candidates(...)` and `enqueue_prefetch(...)`.
+- The C++ `ExpertDispatcher` keeps `cached_experts_`, `cache_sizes_`, and per-GPU fetch and exec queues.
+- `num_threads` is per GPU. `ExpertDispatcher` creates `num_threads` execution workers for each visible GPU, plus one fetch worker per GPU.
+- Eviction is per GPU and picks a cached expert that is idle and least used, so caching is local to the GPU that owns the expert.
+
+## Peer Transfers and Host Memory
+
+- The safe assumption is host staging.
+- `Node::SetDevice` stages data through pinned host memory when it loads from disk, then copies host to GPU with `cudaMemcpyHostToDevice`.
+- The KV offload path also uses CPU staging with `async_d2h` and `async_h2d`.
+- Do not assume universal GPU to GPU peer transfers. Whether a direct P2P path exists depends on the runtime, driver, and topology.
+- If peer access is absent or expensive, the runtime still works, but the transfer path will lean on host memory and the cache budget matters more.
+- For DeepSeek-V4-Flash, the official host store keeps routed experts in pinned host RAM and streams the needed experts into each rank's GPU cache.
+
+## Tensor Parallelism and Model-Specific Constraints
+
+- Expert distribution is not tensor parallelism.
+- The generic `MoE` path uses one process and round robin expert placement across visible GPUs.
+- Tensor-parallel loaders are model specific.
+- DeepSeek-V4-Flash uses the official `torchrun --nproc-per-node 4 ...` path, one shard per rank, with `model{rank}-mp{world_size}.safetensors`.
+- Its sparse-attention kernel is validated in repo with `--model-parallel 4`; mp1 is not covered by repo tests.
+- `patch_moe_with_offload(..., world_size > 1)` all-reduces the expert output across ranks in the official DeepSeek-V4 path.
+- Prefix-cache scaffolding is serving-side KV bookkeeping, but the current OpenAI request path has no active prefix-reuse integration. It does not change expert ownership or make multi-node inference supported; see [Serving](serving.md#prefix-caching).
+
+## Validation
+
+Generic single-process path:
+
+```bash
+pytest tests/python/unit/test_multi_gpu.py -q
+```
+
+Live multi-GPU smoke, one host:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 python tests/python/integration/test_multi_gpu_live.py
+```
+
+Single-process example with multiple visible GPUs:
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1 python examples/readme_example.py --checkpoint deepseek-ai/DeepSeek-V2-Lite-Chat --offload_dir /ssd/moe --max_new_tokens 64
+```
+
+Official DeepSeek-V4 tensor-parallel path:
+
+```bash
+torchrun --nproc-per-node 4 tests/python/v4/e2e_mp4_offload.py
+```
+
+## Unsupported Multi-Node
+
+- This guide covers one host only.
+- The public `MoE` path does not support running experts across separate machines.
+- If you need multi-node expert parallel, you need a separate distributed design.
+- The supported multi-GPU path is still single-server, even when multiple ranks are used for a model-specific loader.
+
+## Related guides
+
+- [Configuration](configuration.md)
+- [Serving](serving.md)
+- [Environment variables](environment-variables.md)
+- [Troubleshooting](troubleshooting.md)
+- [DeepSeek-V4-Flash](../moe_infinity/models/deepseek_v4/README.md)

--- a/docs/serving.md
+++ b/docs/serving.md
@@ -1,0 +1,224 @@
+# OpenAI-compatible serving guide
+
+Authoritative reference for the async OpenAI-compatible server.
+
+`MoE.generate()` remains the current in-process synchronous path, but it emits
+`DeprecationWarning` and is scheduled for removal. `MoE.serve()` is recommended
+for continuous batching; it starts an async HTTP service and is not a drop-in
+replacement for an in-process return value.
+
+## Quick Start
+
+> **Security:** The parser defaults to `--host 0.0.0.0`, and authentication is
+> disabled when neither `--api-key` nor `MOE_API_KEYS` is configured. On an
+> untrusted, shared, or cloud host, bind to `127.0.0.1` or configure an API key
+> before exposure. Completion routes and privileged `/admin/stats`, `/v1/config`,
+> and `/v1/reload` endpoints share this authentication posture.
+
+```bash
+python -m moe_infinity.entrypoints.openai.api_server_v2 \
+    --host 127.0.0.1 \
+    --model deepseek-ai/DeepSeek-V2-Lite-Chat \
+    --offload-dir ./offload_dir \
+    --device-memory-ratio 0.5 \
+    --kv-cache-ratio 0.25 \
+    --max-batch-size 8
+```
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"deepseek-ai/DeepSeek-V2-Lite-Chat","prompt":"Hello","max_tokens":32}'
+```
+
+For DFlash speculative decoding, use a validated pair such as `openai/gpt-oss-20b` with `z-lab/gpt-oss-20b-DFlash`, or leave `--speculative-draft` unset for non-DFlash targets.
+
+For one-host multi-GPU ownership and `CUDA_VISIBLE_DEVICES` ordering, see [Single-server multi-GPU](multi-gpu.md).
+
+## CLI Reference
+
+Stable options from `api_server_v2.py`:
+
+| Option | Default | Meaning |
+|---|---:|---|
+| `--host` | `0.0.0.0` | Bind address |
+| `--port` | `8000` | Listen port |
+| `--model` | required | Model checkpoint or local path |
+| `--offload-dir` | required | Expert offload directory |
+| `--speculative-draft` | none | DFlash drafter checkpoint |
+| `--device-memory-ratio` | `0.75` | GPU memory reserved for expert cache |
+| `--kv-cache-ratio` | `0.25` | Remaining memory reserved for KV cache |
+| `--max-batch-size` | `32` | Max concurrent sequences per batch |
+| `--api-key` | none | Comma-separated Bearer keys |
+| `--rate-limit` | `0` | Requests/minute/key; `0` disables |
+| `--max-waiting-requests` | `0` | Queue depth backpressure threshold; `0` disables |
+| `--max-n` | `16` | Cap for parallel sampling `n` / `best_of` |
+| `--enable-prefix-caching` | off | Enable prefix-cache bookkeeping flag |
+| `--startup-timeout` | none | Startup watchdog timeout, seconds |
+| `--decode-step-timeout` | none | Decode watchdog timeout, seconds |
+| `--enable-pyspy-dump` | off | Scaffolded flag; currently accepted and stored, but no py-spy dump is triggered |
+| `--enable-contextpilot` | off | Enable ContextPilot middleware |
+| `--contextpilot-debug` | off | Enable ContextPilot fault-injection/admin hooks |
+
+Internal / deprecated:
+
+- `MoE.generate(...)` emits `DeprecationWarning` and is scheduled for removal;
+  `MoE.serve(...)` is the continuous-batching HTTP transition path, not a
+  drop-in in-process call replacement.
+- `--max-waiting-requests` and `--max-n` feed internal module state used by middleware.
+
+## Python Startup
+
+```python
+from moe_infinity import MoE
+
+model = MoE("deepseek-ai/DeepSeek-V2-Lite-Chat", {
+    "offload_path": "./offload_dir/deepseek-v2-lite",
+    "device_memory_ratio": 0.5,
+})
+model.serve(host="127.0.0.1", port=8000, offload_dir="./offload_dir")
+```
+
+Binding the Python startup path to `0.0.0.0` has the same exposure and auth
+implications as the CLI. Configure `api_key` or `MOE_API_KEYS` before using a
+non-loopback bind on an untrusted network.
+
+`MoE.serve()` accepts the same serving knobs as the CLI for host, port, memory ratios, batch sizing, the prefix-cache feature flag, offload path, and DFlash drafter setup. The flag currently enables scaffolding only; it does not activate request-path reuse.
+
+## Request Fields and Streaming
+
+### `/v1/completions`
+
+Implemented request fields:
+
+- `model`, `prompt`
+- `max_tokens`, `temperature`, `top_p`
+- `n`, `best_of`
+- `stream`, `stop`, `logprobs`, `response_format`
+
+Accepted but currently no-op / unsupported:
+
+- `echo`, `suffix`, `user`
+
+Accepted but currently no-op:
+
+- `presence_penalty`, `frequency_penalty`, `logit_bias`
+
+### `/v1/chat/completions`
+
+Implemented request fields:
+
+- `model`, `messages`
+- `max_tokens`, `temperature`, `top_p`
+- `n`, `stream`, `stop`
+- `logprobs`, `top_logprobs`
+- `response_format`
+
+Accepted but currently no-op / unsupported:
+
+- `user`
+
+Accepted but currently no-op:
+
+- `presence_penalty`, `frequency_penalty`, `logit_bias`
+
+### Streaming
+
+- Streaming uses SSE.
+- The terminal event is `data: [DONE]`.
+- `finish_reason` is `stop` on EOS or stop-sequence termination, `length` on `max_tokens`, and `error` for JSON-object validation failures.
+- Parallel sampling is constrained to `n <= --max-n` and `best_of <= --max-n`.
+- Streaming with parallel sampling requires `n=1` and `best_of=1`.
+
+## Authentication and Rate Limiting
+
+- API key source: `--api-key` first, then `MOE_API_KEYS` if no CLI keys are provided.
+- Format: `Authorization: Bearer <key>`.
+- If no keys are configured, auth is disabled.
+- Exempt routes: `GET /health`, `GET /metrics`, `GET /v1/models`.
+- Protected routes: completions, chat completions, `/admin/stats`, `/v1/config`, `/v1/reload`.
+- `--rate-limit` is per-key requests/minute. `0` disables limiting.
+- Rate-limit failures return `429`.
+
+## Backpressure and Parallel Sampling
+
+- `--max-waiting-requests` applies queue backpressure on the scheduler.
+- When the queue reaches the threshold, the server returns `503` with a queue-full error.
+- `--max-n` caps `n` and `best_of`.
+- `n` must be positive; `best_of` must be positive and at least `n`.
+
+## Prefix Caching
+
+- `--enable-prefix-caching` toggles the feature flag.
+- The cache implementation is hash-based LRU with `block_size=16` and `max_entries=1000` by default.
+- Current serving code does not wire the cache into request execution, so there is no active reuse path yet.
+- Observability is internal (`hit_rate`, lookup/insert bookkeeping), not a public endpoint.
+
+The prefix-cache scaffold does not change expert ownership; the multi-GPU guide covers that layout separately.
+
+## DFlash Serving
+
+Use DFlash with a validated pair such as:
+
+```bash
+python -m moe_infinity.entrypoints.openai.api_server_v2 \
+    --model openai/gpt-oss-20b \
+    --offload-dir ./offload_dir \
+    --speculative-draft z-lab/gpt-oss-20b-DFlash
+```
+
+Startup validates the drafter/target pair: hidden size, vocab size, mask-token bounds, target layer IDs, and drafter `fc` shape.
+
+Delegation is server-wide and only applies when a request is:
+
+- a fresh singleton prefill request
+- greedy (`temperature=0`, no sampling)
+- `top_k <= 0`
+- `top_p >= 1.0`
+- `repetition_penalty == 1.0`
+- `logprobs <= 0`
+- no stop strings
+- within the current step token budget
+
+The exact gate is implemented in [`moe_infinity/serving/engine.py`](../moe_infinity/serving/engine.py) and also requires batch==1, no prior output tokens, and `max_tokens <= scheduler.max_tokens_per_step`.
+
+The delegated path runs the speculative loop and emits tokens normally through SSE.
+
+Route-ahead is internal to the DFlash verify path and is used only when speculative delegation is active.
+
+## Operational Endpoints
+
+| Endpoint | Method | Auth | Body | Response / scope | Production note |
+|---|---|---|---|---|---|
+| `/v1/models` | GET | exempt | none | loaded model list | safe for readiness checks |
+| `/health` | GET | exempt | none | `STARTING` / `HEALTHY` / `UNHEALTHY` | safe to expose |
+| `/metrics` | GET | exempt | none | Prometheus text metrics | safe to scrape internally |
+| `/admin/stats` | GET | protected | none | queue, batch, cache, engine stats | keep private |
+| `/v1/config` | GET | protected | none | current runtime config | admin-only |
+| `/v1/config` | POST | protected | JSON updates | only `max_batch_size` and `max_tokens_per_step` are mutable | admin-only |
+| `/v1/reload` | POST | protected | reload request | hot-reload Python modules | admin-only |
+
+The optional `/contextpilot/toggle`, `/contextpilot/inject-fault`, and
+`/contextpilot/status` routes are intentionally cataloged in
+[`docs/contextpilot/README.md`](contextpilot/README.md) rather than this core
+serving table. The fault-injection route is debug-only and requires
+`--contextpilot-debug`.
+
+## Watchdogs and Diagnostics
+
+- `--startup-timeout` is disabled by default.
+- When enabled, startup timeout causes a hard exit.
+- `--decode-step-timeout` is disabled by default.
+- When enabled, decode timeout marks the server unhealthy instead of exiting.
+- `--enable-pyspy-dump` is currently a scaffolded no-op flag: it is accepted and stored in watchdog config, but the watchdog flow does not trigger py-spy dumps yet.
+
+If you need timeout debugging, use the watchdog logs and the troubleshooting guide rather than expecting a py-spy dump.
+
+## Failure Modes
+
+- `401`: invalid or missing API key.
+- `429`: rate limit exceeded.
+- `503`: request queue full.
+- `400`: invalid `n` / `best_of` / other request validation.
+- `finish_reason="error"`: JSON-object validation failure.
+- Penalties and `logit_bias` are accepted by the request models but are not applied in sampling.

--- a/docs/superpowers/plans/2026-08-09-repository-documentation.md
+++ b/docs/superpowers/plans/2026-08-09-repository-documentation.md
@@ -1,0 +1,411 @@
+# Repository Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build and verify a layered, source-aligned documentation system for MoE-Infinity that serves users, operators, contributors, and maintainers without overstating support.
+
+**Architecture:** Keep `README.md` as the concise discovery and quick-start layer, route deeper reading through `docs/README.md`, and place detailed truth in focused guides. Use `ARCHITECTURE.md` for contributor flow and API boundaries, `CHANGELOG.md` for history, and contribution/release documents to enforce updates. Derive claims from source, tests, and recorded validation rather than registry presence or implementation seams alone.
+
+**Tech Stack:** Markdown, Python 3 AST and compilation checks, pytest, FastAPI route inspection, argparse inspection, Git read-only verification, repository-local shell commands.
+
+---
+
+## Execution Notes
+
+- This recovered plan describes the ten implemented task scopes.
+- Every command runs from the repository root unless a different directory is stated.
+- GPU, model-download, and destructive cache tests are excluded from the default verification path.
+- Commits are optional checkpoints. No commit, staging, push, or Git configuration change was performed during the execution that recovered this plan.
+
+## Exact File Map
+
+### Discovery and navigation
+
+- Modify `README.md` — overview, feature discovery, supported models, install, examples, serving and DFlash summaries, benchmark links.
+- Create `docs/README.md` — audience-oriented documentation hub.
+
+### Focused user and operator guides
+
+- Create `docs/model-compatibility.md` — registry-complete evidence matrix.
+- Create `docs/configuration.md` — active `ArcherConfig` fields and memory rules.
+- Create `docs/environment-variables.md` — runtime, serving, profiling, model, build, and packaging keys.
+- Modify `docs/dflash.md` — direct and integrated DFlash, rollback, sampling, route-ahead, compatibility, and validation.
+- Create `docs/serving.md` — CLI, request fields, auth, streaming, limits, endpoints, inactive prefix-cache scaffolding, DFlash, and watchdogs.
+- Create `docs/multi-gpu.md` — supported single-host topology and ownership.
+- Create `docs/troubleshooting.md` — symptom-first operational guidance.
+- Create `docs/glm-5.2.md` — GLM-specific FP8, serving, MTP, and validation scope.
+- Modify `moe_infinity/models/deepseek_v4/README.md` — DeepSeek-V4 official loader, FP4 offload, validation, and historical data caveats.
+
+### Contributor, benchmark, and process surfaces
+
+- Modify `ARCHITECTURE.md` — module map, two execution paths, lifecycle, and API boundaries.
+- Modify `docs/benchmarking.md` — terminology, catalog, exclusions, commands, fairness, and reproducibility.
+- Modify `benchmarks/expert_io_microbench/README.md` — executable profiler runbook.
+- Modify `examples/dflash_gpt_oss_example.py` — accurate documentation comments for the current DFlash path.
+- Create `CHANGELOG.md` — `Unreleased` additions, changes, fixes, and known limitations.
+- Modify `CONTRIBUTING.md` — documentation-impact matrix and test guidance.
+- Modify `.github/PULL_REQUEST_TEMPLATE.md` — documentation and evidence checklist.
+- Modify `RELEASE.md` — release documentation and artifact verification.
+
+### Recovered planning artifacts
+
+- Create `docs/superpowers/specs/2026-08-09-repository-documentation-design.md` — approved documentation design.
+- Create `docs/superpowers/plans/2026-08-09-repository-documentation.md` — this ten-task implementation plan.
+
+## Task 1: Inventory Source Truth and Documentation Gaps
+
+**Files:**
+- Inspect `README.md`.
+- Inspect `ARCHITECTURE.md`.
+- Inspect every Markdown file under `docs/`, `benchmarks/`, and `moe_infinity/models/`.
+- Inspect `moe_infinity/utils/config.py`, `moe_infinity/common/constants.py`, `moe_infinity/entrypoints/openai/api_server_v2.py`, `setup.py`, and benchmark entry points.
+
+- [x] Record the cumulative documentation surfaces and audience gaps.
+- [x] Extract active `ArcherConfig` fields and defaults from `moe_infinity/utils/config.py`.
+- [x] Extract production environment keys and build controls from Python, `setup.py`, and `CMakeLists.txt`.
+- [x] Extract API parser options and FastAPI route decorators.
+- [x] Extract model registry families, conditional imports, adapter paths, and tests.
+- [x] Classify files under `benchmarks/` as workflows, contributor tools, helpers, or generated results.
+- [x] Scan existing claims for stale DFlash, prefix-cache, multi-GPU, model-support, and performance wording.
+
+**Validation:**
+
+```bash
+python -m compileall -q examples benchmarks
+python -m moe_infinity.entrypoints.openai.api_server_v2 --help
+```
+
+Checklist:
+
+- [x] Every later guide has an identified source of truth.
+- [x] No capability level is inferred solely from registration.
+- [x] GPU and model-download evidence is separated from CPU fixture evidence.
+
+## Task 2: Establish the README and Documentation Hub Layers
+
+**Files:**
+- Modify `README.md`.
+- Create `docs/README.md`.
+
+- [x] Reduce the README to overview, discovery, prerequisites, minimal examples, and authoritative links.
+- [x] Add a supported-model discovery table without duplicating the detailed compatibility matrix.
+- [x] Add source-install and optional acceleration guidance.
+- [x] Add concise Qwen3.5 and GLM examples with model-specific caveats.
+- [x] State that prefix-cache scaffolding exists but the OpenAI request path has no active reuse integration.
+- [x] Organize the docs hub under Users, Operators, Contributors, and Project History.
+
+**Validation:**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+text = Path('README.md').read_text()
+assert 'docs/README.md' in text
+assert 'docs/model-compatibility.md' in text
+assert 'does not actively reuse cached prefixes' in text
+assert 'Qwen/Qwen3.5-35B-A3B' in text
+print('README discovery assertions passed')
+PY
+```
+
+Checklist:
+
+- [x] README summaries link to focused guides.
+- [x] The hub links every new authoritative guide.
+- [x] No inactive feature is advertised as active production behavior.
+
+## Task 3: Build the Model Compatibility and Family Guides
+
+**Files:**
+- Create `docs/model-compatibility.md`.
+- Create `docs/glm-5.2.md`.
+- Modify `moe_infinity/models/deepseek_v4/README.md`.
+- Modify model discovery and notes in `README.md`.
+
+- [x] Include every family from `MODEL_MAPPING_NAMES`, including conditional and registry-only entries.
+- [x] Separate sync generation, continuous serving, expert offload, speculative decoding, topology, and limitations.
+- [x] Mark tiny-fixture, real-checkpoint, and unrecorded validation distinctly.
+- [x] Document Qwen3.5 as text-only and state that no real-checkpoint serving validation is recorded.
+- [x] Document GLM FP8 residency, native-engine status, MTP scope, and missing GLM DFlash drafter.
+- [x] Preserve DeepSeek-V4 official-loader requirements and label incomplete-provenance measurements as historical.
+
+**Validation:**
+
+```bash
+pytest -q tests/python/unit/test_model_registry.py
+python - <<'PY'
+from pathlib import Path
+matrix = Path('docs/model-compatibility.md').read_text()
+for family in ('DeepSeek-V2', 'DeepSeek-V3', 'DeepSeek-V4', 'Mixtral', 'Qwen3', 'Qwen3.5', 'GLM-5.2', 'GPT-OSS', 'DBRX', 'Jamba', 'OLMoE', 'NLLB-MoE', 'OPT'):
+    assert family in matrix
+assert 'no real-checkpoint serving validation recorded' in matrix
+print('model matrix assertions passed')
+PY
+```
+
+Checklist:
+
+- [x] Conditional imports are named.
+- [x] Unsupported OPT status is explicit.
+- [x] Fixture coverage is not presented as production topology validation.
+
+## Task 4: Document Configuration and Environment Controls
+
+**Files:**
+- Create `docs/configuration.md`.
+- Create `docs/environment-variables.md`.
+- Link both from `README.md` and `docs/README.md`.
+
+- [x] Document all sixteen active `ArcherConfig` fields and exact defaults.
+- [x] Explain derived fields, memory-ratio normalization, and store fingerprint checks.
+- [x] Separate Python config names from serving config names.
+- [x] Document runtime, acceleration, profiling, deterministic, model-specific, build, packaging, and standard third-party environment keys.
+- [x] Exclude test-only variables from the production table while listing them separately.
+
+**Validation:**
+
+```bash
+pytest -q tests/python/unit/test_utils_config.py tests/python/unit/test_kv_config_wiring.py
+python - <<'PY'
+from dataclasses import fields
+from pathlib import Path
+from moe_infinity.utils.config import ArcherConfig
+doc = Path('docs/configuration.md').read_text()
+missing = [f.name for f in fields(ArcherConfig) if f.name not in doc]
+assert not missing, missing
+print('ArcherConfig coverage passed')
+PY
+```
+
+Checklist:
+
+- [x] Defaults match source.
+- [x] Reserved and scaffolded controls are identified.
+- [x] Build-time controls are not described as runtime toggles.
+
+## Task 5: Make DFlash Documentation Match Direct and Integrated Behavior
+
+**Files:**
+- Modify `docs/dflash.md`.
+- Modify DFlash discovery text in `README.md`.
+- Modify comments in `examples/dflash_gpt_oss_example.py`.
+
+- [x] Separate experimental direct `DFlashSpeculator.generate` behavior from deprecated `MoE.generate` and serving gates.
+- [x] Record batch-1 sampled direct support and greedy-gated integrations.
+- [x] Record batch-greater-than-one constraints and the bare HuggingFace target requirement.
+- [x] Explain draft, verify, commit, rollback, and cache truncation.
+- [x] Explain route-ahead as scheduling-only executor behavior.
+- [x] Add per-model route-ahead status: GPT-OSS not wired; Qwen3.5 synthetic/tiny coverage without real-checkpoint serving validation.
+- [x] State that executor wiring for DeepSeek, Qwen, and Mixtral does not imply a validated drafter pair.
+
+**Validation:**
+
+```bash
+pytest -q tests/python/dflash -m "not gpu"
+python - <<'PY'
+from pathlib import Path
+text = Path('docs/dflash.md').read_text()
+assert '| Route-ahead |' in text
+assert text.count('Not wired: the GPT-OSS expert path') == 2
+assert 'no real-checkpoint serving validation is recorded' in text
+assert 'No additional drafter pair is implied.' in text
+print('DFlash documentation assertions passed')
+PY
+```
+
+Checklist:
+
+- [x] No DeepSeek or Qwen drafter pair is invented.
+- [x] Sampling scope is explicit.
+- [x] Route-ahead metrics and fallback behavior are documented.
+
+## Task 6: Document Serving, Multi-GPU Operation, and Troubleshooting
+
+**Files:**
+- Create `docs/serving.md`.
+- Create `docs/multi-gpu.md`.
+- Create `docs/troubleshooting.md`.
+
+- [x] Document every API server CLI option and default.
+- [x] Document completions, chat, streaming, auth, rate limiting, backpressure, and operational endpoints.
+- [x] Explicitly route ContextPilot endpoints to `docs/contextpilot/README.md`.
+- [x] State that the prefix-cache flag and data structure are not wired into OpenAI request execution.
+- [x] Document DFlash serving delegation gates and watchdog behavior.
+- [x] Document single-host visible-device ordering, round-robin expert ownership, host staging, model-specific tensor parallelism, and unsupported multi-node operation.
+- [x] Add symptom-first troubleshooting entries linked to authoritative guides.
+
+**Validation:**
+
+```bash
+python -m moe_infinity.entrypoints.openai.api_server_v2 --help
+pytest -q tests/python/serving/test_api_routes.py tests/python/serving/test_cancellation.py tests/python/serving/test_hot_reload.py tests/python/serving/test_prefix_cache.py
+pytest -q tests/python/unit/test_watchdog_config.py tests/python/unit/test_startup_watchdog.py tests/python/unit/test_decode_watchdog.py
+pytest -q tests/python/unit/test_distributed_smoke.py tests/python/unit/test_multi_gpu.py
+```
+
+Checklist:
+
+- [x] Core and optional subsystem routes have explicit ownership.
+- [x] Prefix-cache wording is consistent across README, serving, multi-GPU, and troubleshooting.
+- [x] No multi-node support is implied.
+
+## Task 7: Rebuild the Contributor Architecture Map
+
+**Files:**
+- Modify `ARCHITECTURE.md`.
+
+- [x] Map Python packages and native extension source trees.
+- [x] Distinguish deprecated synchronous `MoE.generate` from async continuous serving.
+- [x] Diagram DFlash delegation, route-ahead, scheduling, sampling, streaming, and termination.
+- [x] Explain request lifecycle and committed-count bookkeeping.
+- [x] Define documented package/server surfaces versus internal modules.
+- [x] Add a symptom-to-module contributor lookup table.
+
+**Validation:**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+text = Path('ARCHITECTURE.md').read_text()
+assert text.count('```mermaid') == 2
+assert '## 5. API Stability Boundaries' in text
+assert 'Path A - Synchronous' in text
+assert 'Path B - Async continuous batching' in text
+print('architecture assertions passed')
+PY
+```
+
+Checklist:
+
+- [x] Mermaid fences are balanced.
+- [x] Live integration points are distinguished from contract helpers.
+- [x] Internal exports are not elevated into stable public APIs accidentally.
+
+## Task 8: Catalog Benchmarks and Reproduction Workflows
+
+**Files:**
+- Modify `docs/benchmarking.md`.
+- Modify `benchmarks/expert_io_microbench/README.md`.
+- Link existing `docs/benchmark_reproduction.md` and ContextPilot guides.
+
+- [x] Define TTFT, ITL, decode throughput, end-to-end throughput, prefill, decode, and peak memory.
+- [x] Catalog serving, ContextPilot, expert I/O, comparison, performance-model, kernel, and evaluation workflows.
+- [x] List helpers and package markers as excluded entry points.
+- [x] Add concrete serving commands and expert I/O profiler commands.
+- [x] Add fairness rules and reproducibility metadata.
+- [x] Label incomplete-provenance results as historical rather than canonical.
+
+**Validation:**
+
+```bash
+python -m compileall -q benchmarks
+bash -n benchmarks/comparison/run_all.sh
+for f in benchmarks/expert_io_microbench/run_all.py benchmarks/expert_io_microbench/bench_routing.py benchmarks/expert_io_microbench/bench_transfer.py benchmarks/expert_io_microbench/bench_compute_evict.py benchmarks/expert_io_microbench/bench_bubble.py benchmarks/expert_io_microbench/compare_baseline.py benchmarks/expert_io_microbench/run_decision_profile.py benchmarks/expert_io_microbench/nsys_parser.py; do python "$f" --help >/dev/null; done
+```
+
+Checklist:
+
+- [x] Every executable entry point is cataloged or intentionally classified.
+- [x] Prerequisites and output metrics are stated.
+- [x] DFlash tests are not mislabeled as a standalone benchmark CLI.
+
+## Task 9: Add History, Contribution, Release, and Review Enforcement
+
+**Files:**
+- Create `CHANGELOG.md`.
+- Modify `CONTRIBUTING.md`.
+- Modify `.github/PULL_REQUEST_TEMPLATE.md`.
+- Modify `RELEASE.md`.
+
+- [x] Create an `Unreleased` changelog with Added, Changed, Fixed, and Known Limitations.
+- [x] Map feature, model, config, architecture, performance, and bug changes to required docs.
+- [x] Require evidence fields for performance, support, and model behavior changes.
+- [x] Add release checks for links, contradictions, limitations, artifacts, and provenance.
+- [x] Keep checks truthful as manual process requirements unless CI actually enforces them.
+
+**Validation:**
+
+```bash
+python - <<'PY'
+from pathlib import Path
+assert '## [Unreleased]' in Path('CHANGELOG.md').read_text()
+assert 'Documentation impact by change type' in Path('CONTRIBUTING.md').read_text()
+assert '## Documentation impact' in Path('.github/PULL_REQUEST_TEMPLATE.md').read_text()
+assert '## Release readiness checklist' in Path('RELEASE.md').read_text()
+print('process documentation assertions passed')
+PY
+```
+
+Checklist:
+
+- [x] Changelog distinguishes history from roadmap.
+- [x] PR evidence asks for model, hardware, software, workload, baseline, result, and limitations.
+- [x] Release guidance verifies actual wheel or source artifacts before upload.
+
+## Task 10: Recover Artifacts and Perform Cumulative Verification
+
+**Files:**
+- Create `docs/superpowers/specs/2026-08-09-repository-documentation-design.md`.
+- Create `docs/superpowers/plans/2026-08-09-repository-documentation.md`.
+- Reconcile `docs/dflash.md` and `docs/model-compatibility.md`.
+- Review every changed documentation file in the exact worktree.
+
+- [x] Recover the approved design as an accurate maintainable record of the implemented architecture.
+- [x] Recover this ten-task plan with exact paths, commands, and checklists.
+- [x] Reconcile Qwen3.5 serving language: tiny-fixture coverage exists, but no real-checkpoint serving validation is recorded.
+- [x] Validate all repository-local Markdown links and practical anchors.
+- [x] Validate DFlash and model matrix structure.
+- [x] Parse the Qwen3.5 README example as Python syntax.
+- [x] Scan for unresolved drafting markers and contradictory prefix-cache or DFlash route-ahead claims.
+- [x] Run focused non-GPU assertions and classify environment-only failures.
+- [x] Run `git diff --check`, inspect cumulative status, and confirm no runtime implementation edits were introduced.
+- [x] Confirm the original checkout remains clean.
+
+**Validation:**
+
+```bash
+pytest -q tests/python/unit/test_examples_smoke.py
+pytest -q tests/python/dflash -m "not gpu"
+git diff --check
+git status --short
+```
+
+Artifact checks:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+paths = [
+    Path('docs/superpowers/specs/2026-08-09-repository-documentation-design.md'),
+    Path('docs/superpowers/plans/2026-08-09-repository-documentation.md'),
+]
+for path in paths:
+    text = path.read_text()
+    assert text.startswith('# ')
+    assert text.endswith('\n')
+    assert len(text.splitlines()) >= 100
+print({str(path): len(path.read_text().splitlines()) for path in paths})
+PY
+```
+
+Final checklist:
+
+- [x] Design covers layering, evidence, coverage, enforcement, verification, and risks.
+- [x] Plan contains the required agentic-worker header, goal, architecture, tech stack, exact file map, and ten tasks.
+- [x] Commands avoid GPU and checkpoint downloads by default.
+- [x] No commit or staging action is required or performed.
+- [x] Structural verification is not described as reader testing.
+
+## Completion Criteria
+
+The program is complete when:
+
+- all authoritative guides agree on model, DFlash, prefix-cache, serving, and topology limits;
+- source-derived fields, options, routes, model families, and benchmark entry points are covered;
+- all local Markdown links and practical anchors resolve;
+- fenced examples and documented safe commands pass syntax checks;
+- focused non-GPU tests pass or any pre-existing/environment fixture failure is reproduced and classified;
+- `git diff --check` succeeds;
+- the cumulative diff contains documentation, example comments, and model subdirectory README changes only;
+- the original checkout remains clean;
+- no commit, stage, push, or Git configuration change occurs unless separately requested.

--- a/docs/superpowers/specs/2026-08-09-repository-documentation-design.md
+++ b/docs/superpowers/specs/2026-08-09-repository-documentation-design.md
@@ -1,7 +1,7 @@
 # Repository Documentation Design
 
-**Date:** 2026-08-09  
-**Status:** Approved and implemented  
+**Date:** 2026-08-09
+**Status:** Approved and implemented
 **Scope:** Repository-wide documentation architecture, evidence standards, and maintenance controls
 
 ## 1. Purpose

--- a/docs/superpowers/specs/2026-08-09-repository-documentation-design.md
+++ b/docs/superpowers/specs/2026-08-09-repository-documentation-design.md
@@ -1,0 +1,237 @@
+# Repository Documentation Design
+
+**Date:** 2026-08-09  
+**Status:** Approved and implemented  
+**Scope:** Repository-wide documentation architecture, evidence standards, and maintenance controls
+
+## 1. Purpose
+
+MoE-Infinity needs documentation that helps four audiences without forcing each
+reader through implementation details:
+
+- users selecting a model and running the Python API;
+- operators deploying the OpenAI-compatible server;
+- contributors changing model, runtime, benchmark, or release behavior;
+- maintainers reviewing project history and release readiness.
+
+The design replaces a single overloaded README with a layered system. The root
+README remains the discovery and quick-start surface. A documentation hub routes
+readers to focused guides. Architecture and changelog files carry contributor
+and project-history concerns. Every capability claim is scoped to code and test
+evidence rather than inferred from a registry entry or an implementation seam.
+
+## 2. Design Principles
+
+### 2.1 Layer information by reader intent
+
+The documentation has four layers:
+
+1. **Discovery:** `README.md` identifies the project, lists major capabilities,
+   gives minimal installation and usage examples, and links authoritative guides.
+2. **Navigation:** `docs/README.md` groups focused guides by audience.
+3. **Authority:** focused pages document configuration, environment variables,
+   model compatibility, serving, DFlash, multi-GPU operation, benchmarking, and
+   troubleshooting.
+4. **Maintenance and history:** `ARCHITECTURE.md`, `CHANGELOG.md`,
+   `CONTRIBUTING.md`, `RELEASE.md`, and the PR template define boundaries,
+   history, and update expectations.
+
+The same detailed subject should not be independently specified in several
+places. Secondary pages summarize and link to the authoritative guide.
+
+### 2.2 Prefer scoped claims over blanket support language
+
+Registration, implementation, fixture coverage, real-checkpoint validation, and
+production support are separate states. Documentation must say which state is
+supported by evidence. Examples:
+
+- a model registry entry does not prove end-to-end generation or serving;
+- a tiny CPU fixture does not prove a real checkpoint or GPU topology;
+- an executor hook does not establish a validated DFlash target/drafter pair;
+- a feature flag and cache class do not establish an active request-path feature;
+- historical benchmark numbers are not current performance guarantees.
+
+### 2.3 Keep operational truth close to source
+
+Source-derived references use exact names and defaults from implementation:
+
+- `ArcherConfig` fields come from `moe_infinity/utils/config.py`;
+- runtime and build environment keys come from production readers and build files;
+- server options come from the `api_server_v2.py` argument parser;
+- HTTP endpoints come from FastAPI route decorators;
+- model families come from `moe_infinity/common/constants.py` and adapter wiring;
+- benchmark entry points come from executable files under `benchmarks/`.
+
+When code has scaffolding without a live integration, the guide names that limit.
+
+## 3. Information Architecture
+
+### 3.1 Root README
+
+`README.md` owns:
+
+- project overview and core value proposition;
+- concise feature discovery with limitations linked inline;
+- supported-model discovery table;
+- installation prerequisites and source build commands;
+- minimal Python examples, including model-specific examples that are safe to show;
+- links to configuration, serving, DFlash, benchmarking, architecture, and history.
+
+The README does not duplicate complete configuration tables, server route tables,
+benchmark catalogs, or model validation matrices.
+
+### 3.2 Documentation hub
+
+`docs/README.md` is the stable index. It groups links under Users, Operators,
+Contributors, and Project History. New focused guides must be linked from the hub
+and, when user-facing, discovered from the root README.
+
+### 3.3 Focused guides
+
+The authoritative focused guides are:
+
+| Guide | Responsibility |
+| --- | --- |
+| `docs/model-compatibility.md` | Registry families, maturity, checkpoint examples, versions, validation topology, and limitations. |
+| `docs/configuration.md` | `ArcherConfig` fields, defaults, memory-ratio rules, store layout, and deprecated inputs. |
+| `docs/environment-variables.md` | Production runtime, serving, acceleration, profiling, model, build, and packaging environment keys. |
+| `docs/dflash.md` | Direct and integrated DFlash behavior, sampling and batch constraints, serving delegation, rollback, route-ahead, and per-model evidence. |
+| `docs/serving.md` | CLI, Python startup, request fields, streaming, auth, backpressure, inactive prefix-cache scaffolding, DFlash gates, endpoints, and watchdogs. |
+| `docs/multi-gpu.md` | Single-host topology, device numbering, expert ownership, transfers, model-specific tensor parallelism, and unsupported multi-node scope. |
+| `docs/troubleshooting.md` | Symptom-first diagnosis tied to authoritative guides and focused tests. |
+| `docs/benchmarking.md` | Metrics, methodology, benchmark catalog, exclusions, commands, and reproducibility metadata. |
+| `docs/glm-5.2.md` | GLM-specific registration, FP8 residency, serving, speculative limitations, and validation. |
+| `moe_infinity/models/deepseek_v4/README.md` | DeepSeek-V4 official loader, checkpoint conversion, FP4 offload, validation, and historical measurements. |
+
+Existing ContextPilot, benchmark-reproduction, and C++ interface pages remain
+specialized references linked from the hub or benchmarking guide.
+
+### 3.4 Contributor architecture
+
+`ARCHITECTURE.md` maps modules, native extensions, synchronous and asynchronous
+execution paths, request lifecycle, DFlash integration, route-ahead behavior,
+and API stability boundaries. It distinguishes documented package/server surfaces
+from internal modules. Diagrams explain flow; prose records caveats that diagrams
+cannot express safely.
+
+### 3.5 Changelog and process documents
+
+`CHANGELOG.md` separates shipped history from the `Unreleased` section and records
+user-visible additions, changes, fixes, and known limitations. `RELEASE.md`
+requires changelog closure, artifact inspection, link checks, support review, and
+performance provenance. `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md`
+make documentation impact and evidence part of normal review.
+
+## 4. Evidence Policy
+
+### 4.1 Evidence levels
+
+Capability descriptions use the following ladder:
+
+1. **Registered:** a family or option is recognized by source code.
+2. **Implemented/experimental:** a path exists and has unit or synthetic coverage.
+3. **Validated on tiny fixtures:** behavior is exercised without a real checkpoint.
+4. **Validated on a real checkpoint:** a repository harness records that checkpoint.
+5. **Validated topology:** hardware or process layout is explicitly recorded.
+6. **Unsupported:** no runtime path exists or a fail-fast guard blocks the path.
+
+The strongest phrase used in a guide must not exceed the strongest repository
+evidence. Missing evidence is written as “not recorded” or “not validated,” not
+silently converted into support.
+
+### 4.2 Model and DFlash evidence
+
+The model matrix covers every registry family, including conditional families and
+registry-only unsupported entries. DFlash documentation separately records target
+and drafter pairings. Route-ahead is described as an executor-path capability;
+it does not create or imply a checkpoint pairing. GPT-OSS explicitly lacks the
+executor wiring. Qwen3.5 serving and route-ahead may cite tiny/synthetic fixtures,
+while stating that no real-checkpoint serving validation is recorded.
+
+### 4.3 Performance evidence
+
+Performance claims require model/checkpoint, hardware, software, workload,
+baseline, metric definition, and limitations. Measurements without complete
+provenance are labeled historical snapshots. TTFT, inter-token latency, decode
+throughput, and end-to-end throughput remain distinct.
+
+## 5. Coverage and Cross-Linking
+
+The documentation must cover these source surfaces:
+
+- all active `ArcherConfig` fields and defaults;
+- all project-owned production environment variables and build controls;
+- all server parser options and route decorators, with explicit exclusions for
+  optional subsystem routes documented elsewhere;
+- every registered model family and conditional-import caveat;
+- every executable benchmark entry point or an explicit helper/exclusion class;
+- all documented local scripts, tests, files, and anchors;
+- shipped limitations for batch size, sampling, serving, topology, and inactive
+  scaffolding.
+
+Cross-links follow authority:
+
+- README summaries link to focused guides;
+- troubleshooting entries link to the guide that owns the behavior;
+- model-specific pages link back to the compatibility matrix;
+- benchmarking pages link to reproduction or subsystem runbooks;
+- architecture links to serving and DFlash when user-facing contracts matter.
+
+## 6. Enforcement
+
+Documentation maintenance is enforced socially and mechanically:
+
+- `CONTRIBUTING.md` maps change types to required documents;
+- the PR template asks for README discovery, authoritative-guide updates,
+  compatibility/architecture/benchmark impact, changelog impact, and evidence;
+- `RELEASE.md` requires a final contradiction and link review;
+- focused tests verify parser, config, model registry, serving, watchdog,
+  distributed, and DFlash behavior;
+- lightweight scripts validate Markdown links, anchors, table shape, examples,
+  stale claims, and local paths.
+
+Commits are optional execution checkpoints, not a documentation requirement.
+No commits were created during the execution that recovered this artifact.
+
+## 7. Verification Strategy
+
+Verification is layered to avoid claiming more than the environment proves:
+
+1. Run local Markdown link and anchor checks across repository docs.
+2. Parse fenced Python examples with `ast.parse` and compile examples/benchmarks.
+3. Check Markdown table column counts for compatibility and catalog tables.
+4. Compare code-derived surfaces against their authoritative pages.
+5. Run safe `--help` commands for documented CLIs.
+6. Run `pytest -q tests/python/dflash -m "not gpu"` and focused non-GPU suites.
+7. Run `git diff --check`, inspect `git status --short`, scan for secrets, and
+   confirm documentation-only scope.
+8. Record unavailable Markdown LSP or hardware-dependent checks as limitations.
+
+GPU and model-download tests are never implied by a CPU-only run. Reader testing
+is a separate review activity and is not claimed by structural verification.
+
+## 8. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| README and focused guide drift | Keep detailed truth in one focused guide and link from summaries. |
+| Registry mistaken for support | Use the evidence ladder and explicit matrix limitations. |
+| Fixture coverage overstated | Name tiny/synthetic coverage and separately state real-checkpoint status. |
+| Scaffolding presented as active | Say whether request execution actually consumes the feature. |
+| Historical numbers read as guarantees | Require provenance or label the data historical. |
+| Local paths and anchors rot | Run repository-wide link, anchor, and path checks. |
+| Generated or environment failures obscure docs defects | Diagnose and classify fixture, dependency, GPU, and model-download failures. |
+| Process docs become ceremonial | Tie each checklist item to a specific authoritative file or validation command. |
+
+## 9. Maintenance Rules
+
+- Update the focused guide and changelog when user-visible behavior changes.
+- Update README discovery only when the entry point or major capability changes.
+- Update architecture when module ownership, execution flow, or API boundaries change.
+- Add model rows only with explicit evidence and limitations.
+- Add benchmark rows with prerequisites, outputs, status, and exclusions.
+- Preserve explicit inactive-feature wording until a live integration and tests exist.
+- Re-run structural and focused tests before release or major documentation review.
+
+This design records the implemented documentation architecture. It is intended to
+remain maintainable as source behavior changes, not to preserve historical wording.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,120 @@
+# Troubleshooting
+
+Use the entries below as symptom-first checks. Each one lists the likely cause, a quick confirmation step, and the exact fix.
+
+## GPU OOM or cache budget mismatch
+
+- **Symptom:** load or generate hits CUDA OOM, or the cache footprint is larger than expected.
+- **Likely cause:** `device_memory_ratio` and `kv_cache_memory_ratio` leave too little room, or the offload directory is being reused for a different model.
+- **How to confirm:** run `pytest tests/python/unit/test_utils_config.py -q` and print the loaded config, or inspect the live budget with `ArcherConfig.load_from_json({...})` and `MemoryCoordinator.from_config(...)`.
+- **Resolution:** lower `device_memory_ratio`, set `kv_cache_memory_ratio` explicitly, and use a unique `offload_path` per model. The current prefix-cache flag and scaffolding do not participate in OpenAI request execution or change the expert cache budget; see [Serving](serving.md#prefix-caching).
+- **Related guide:** [Configuration](configuration.md)
+
+## Reused offload path or fingerprint mismatch
+
+- **Symptom:** the loader raises `Model name mismatch`, `Model config mismatch`, or says the cache is legacy.
+- **Likely cause:** `offload_path` points at a cache created for a different model or config, so `model_signature.json` no longer matches.
+- **How to confirm:** open `offload_path/model_signature.json` and compare it with the current model name and config, or run `pytest tests/python/unit/test_model_signature.py -q`.
+- **Resolution:** prefer a new `offload_path` for the model. If you must delete the old cache, remove only the generated MoE-Infinity offload cache after confirming it contains no user data or checkpoint source, then reload the model.
+- **Related guide:** [Configuration](configuration.md)
+
+## Missing or incompatible extension or CUDA runtime
+
+- **Symptom:** import or load fails with `moe_infinity._store extension is required. Install with CUDA enabled.` or a similar missing-extension error.
+- **Likely cause:** the source install did not build the CUDA extensions, or Torch and the CUDA toolkit do not match.
+- **How to confirm:**
+
+  ```bash
+  python -c 'import importlib.util as u; print("moe_infinity._store: OK" if u.find_spec("moe_infinity._store") else "moe_infinity._store: missing")'
+  ```
+
+- **Resolution:** rebuild with the matching CUDA toolkit, reinstall with `pip install --no-build-isolation -e .`, and install the optional attention packages that you want to use.
+- **Related guide:** [Environment variables](environment-variables.md)
+
+## Unsupported SM120 or Blackwell build
+
+- **Symptom:** the native DeepSeek-V4 path does not load on Blackwell, or the build fails around the SM120 path.
+- **Likely cause:** `MOE_ENABLE_SM120` was not set during build, `CUTLASS_DIR` is missing, or the native path was intentionally disabled.
+- **How to confirm:**
+
+  ```bash
+  python - <<'PY'
+  import torch
+
+  try:
+      from moe_infinity.models.deepseek_v4.official_offload_adapter import (
+          native_fp4_available,
+      )
+  except Exception as e:
+      print(f'import_error={type(e).__name__}: {e}')
+  else:
+      print(f'native_fp4_available={native_fp4_available()}')
+
+  print(f'cuda_capability={torch.cuda.get_device_capability() if torch.cuda.is_available() else None}')
+  PY
+  ```
+
+- **Resolution:** rebuild with `MOE_ENABLE_SM120=1 CUTLASS_DIR=... pip install -e .` for the Blackwell path, or set `MOE_DSV4_FORCE_NATIVE=0` if you want the tilelang fallback.
+- **Related guide:** [DeepSeek-V4-Flash](../moe_infinity/models/deepseek_v4/README.md)
+
+## Attention backend fallback policy
+
+- **Symptom:** the model loads with eager/other attention even when FlashAttention is installed, or FlashInfer-specific paths are absent.
+- **Likely cause:** some model families intentionally choose eager; for example, the runtime forces `attn_implementation="eager"` for `glm_moe_dsa`, and otherwise selects eager whenever FlashAttention is unavailable. FlashInfer is a separate optional backend and may still be absent even if FlashAttention is present.
+- **How to confirm FlashInfer availability:**
+
+  ```bash
+  python -c 'from moe_infinity.runtime.flashinfer_utils import HAS_FLASHINFER; print(f"HAS_FLASHINFER={HAS_FLASHINFER}")'
+  ```
+
+- **How to confirm FlashAttention selection:** inspect the model-family branch in `moe_infinity/runtime/model_offload.py` or print the same condition the loader uses before model construction; the stock code switches to eager for `glm_moe_dsa` and otherwise uses FlashAttention only when the runtime reports it available.
+- **Resolution:** keep the fallback if correctness matters more than backend selection, or install the matching optional package and model-family path if you are validating that specific branch.
+- **Related guide:** [Serving](serving.md)
+
+## Startup or decode timeout
+
+- **Symptom:** `/health` returns 503 with `starting` or `unhealthy`, or the logs mention a startup or decode watchdog timeout.
+- **Likely cause:** model init exceeded `--startup-timeout`, or decode stalled longer than `--decode-step-timeout`.
+- **How to confirm:** `curl http://localhost:8000/health` and check for the exact reason, or run `pytest tests/python/unit/test_watchdog_integration.py -q` to see the same state transitions.
+- **Resolution:** raise or disable the timeout flags, then check model load, extension import, and GPU availability. The current watchdog path does not emit a py-spy dump, so use logs and timeout repros instead.
+- **Related guide:** [Serving](serving.md)
+
+## Auth rejects requests or the queue is full
+
+- **Symptom:** requests return 401, 429, or 503 with `queue_full`.
+- **Likely cause:** `MOE_API_KEYS` or `--api-key` does not match the Bearer token, the per-key rate limit is hit, or `_max_waiting_requests` is full.
+- **How to confirm:** send a request with and without the Bearer token, or run `pytest tests/python/serving/test_api_routes.py -q` and look for the same status codes.
+- **Resolution:** set the API key and rate limit flags consistently, lower request pressure, or raise `--max-waiting-requests` if the queue is too small.
+- **Related guide:** [Serving](serving.md)
+
+## DFlash target and drafter pairing fails
+
+- **Symptom:** the server says it cannot configure DFlash, or sampled requests take the standard decode path.
+- **Likely cause:** the drafter checkpoint is wrong, `trust_remote_code` is missing, or the target/drafter pair fails validation; sampled requests are also routed away by design in the serving path.
+- **How to confirm:** check that `MoE.serve(..., speculative_draft=...)` or `--speculative-draft` was passed, and compare the setup with `docs/dflash.md` and `tests/python/dflash/test_native_e2e.py`. If the request was sampled, compare it with the serving matrix in `docs/dflash.md`.
+- **Resolution:** use the matching target and drafter pair, keep greedy decode for serving, keep batch size at 1, and pass the drafter through the server hook. Deprecated `MoE.generate(..., speculative_draft=...)` remains the current in-process transition path. For sampled batch-1 DFlash, the experimental direct speculator path is available without a stable API promise.
+- **Related guide:** [DFlash](dflash.md)
+
+## Unsupported model or Transformers version
+
+- **Symptom:** model registration fails, or a checkpoint that works in one environment fails in another.
+- **Likely cause:** the checkpoint is not on the supported model list, or the installed `transformers` version is too old for that architecture.
+- **How to confirm:** check the supported model table in `README.md`, then print `transformers.__version__` and compare it with the model-specific notes.
+- **Resolution:** upgrade `transformers`, switch to the model-specific loader, or choose a checkpoint that is already listed as supported.
+- **Related guide:** [Top-level README](../README.md)
+
+## Multi-GPU ownership or P2P topology looks wrong
+
+- **Symptom:** one logical GPU stays idle, ownership looks shifted, or multi-GPU transfers are slower than expected.
+- **Likely cause:** `CUDA_VISIBLE_DEVICES` order does not match the intended ownership, or the topology does not give you a useful peer path.
+- **How to confirm:** run `nvidia-smi topo -m`, print `torch.cuda.device_count()` after setting `CUDA_VISIBLE_DEVICES`, and compare the memory deltas in `tests/python/integration/test_multi_gpu_live.py`.
+- **Resolution:** reorder `CUDA_VISIBLE_DEVICES` so the desired card is logical `cuda:0`, keep all devices on one host, and do not assume universal peer transfers.
+- **Related guide:** [Single-server multi-GPU](multi-gpu.md)
+
+## Related guides
+
+- [Configuration](configuration.md)
+- [Single-server multi-GPU](multi-gpu.md)
+- [Serving](serving.md)
+- [Environment variables](environment-variables.md)
+- [DFlash](dflash.md)

--- a/examples/dflash_gpt_oss_example.py
+++ b/examples/dflash_gpt_oss_example.py
@@ -1,29 +1,26 @@
-"""Native DFlash speculative decoding for gpt-oss-120b (v1: greedy, resident).
+"""Native DFlash speculative decoding for GPT-OSS, greedy batch-1 path.
 
-Drives the **native** DFlash draft->verify->rollback loop through the
-MoE-Infinity engine: a greedy, batch-1 ``model.generate(..., speculative_draft=...)``
-routes through ``GenerationEngine.spec_strategy`` (the native loop in
-``moe_infinity/spec_decode/dflash.py``). The drafter (``z-lab/gpt-oss-120b-DFlash``)
-loads via ``trust_remote_code=True`` and reuses the target's ``embed_tokens`` +
-``lm_head``. Omit ``speculative_draft`` (or use a non-greedy config / batch>1) and
-``generate`` uses the standard autoregressive path, byte-identical to before.
+This script keeps one end-to-end flow in view: a greedy,
+batch-1 ``model.generate(..., speculative_draft=...)`` call routes through the
+native DFlash draft, verify, rollback loop in
+``moe_infinity/spec_decode/dflash.py``. The drafter loads via
+``trust_remote_code=True`` and reuses the target's ``embed_tokens`` and
+``lm_head``. Omit ``speculative_draft`` or switch to a non-greedy config, and
+``generate`` stays on the standard autoregressive path.
 
-v1 scope (everything else is deferred):
-  * Greedy only (``do_sample=False``); sampled speculative decoding is deferred.
-  * Resident by default. Expert offload is a tunable knob (``device_memory_ratio``);
-    v1 does not couple expert prefetch to the speculative loop.
-  * Sync path only; the async serving path is not spec-enabled.
-  * batch == 1.
+``MoE.generate()`` is the current in-process synchronous path but emits
+``DeprecationWarning`` and is scheduled for removal. ``MoE.serve()`` is the
+recommended continuous-batching HTTP path, not a drop-in tensor-return API.
+Because ``trust_remote_code=True`` executes checkpoint repository code, use
+only a trusted and pinned drafter revision.
 
-Hardware: gpt-oss-120b is validated resident with TP=2 on Blackwell/SM120
-(RTX PRO 6000). Correctness is proven autonomously on a tiny CPU model
-(``tests/python/dflash/test_native_e2e.py``: native == plain greedy,
-token-identical); the 120B agreement-rate / acceptance-length / tok-s harness is
-GPU-gated (``tests/python/dflash/test_gpu_120b.py``, enabled via ``MOE_DFLASH_GPU=1``
-with the checkpoints cached). See ``docs/dflash.md``.
+The direct speculator API also supports batch-1 sampled decoding, and the
+batch>1, serving, and route-ahead variants are documented in
+``docs/dflash.md``.
 
-Run:
-    python examples/dflash_gpt_oss_example.py --offload_dir /ssd/moe-infinity/gpt-oss-120b
+Validation is covered by the CPU tiny losslessness gate
+(``tests/python/dflash/test_native_e2e.py``) plus the GPU-gated GPT-OSS-20B,
+GPT-OSS-120B, and serving harnesses under ``tests/python/dflash/``.
 """
 
 from __future__ import annotations
@@ -69,8 +66,8 @@ def main() -> None:
 
     input_ids = tokenizer(args.prompt, return_tensors="pt").input_ids
 
-    # Engine path: greedy batch-1 generate with a drafter routes through
-    # GenerationEngine.spec_strategy (the native DFlash loop).
+    # Engine path: greedy batch-1 generate with a drafter routes through the
+    # native DFlash loop.
     start = time.time()
     output_ids = model.generate(
         input_ids,

--- a/moe_infinity/models/deepseek_v4/README.md
+++ b/moe_infinity/models/deepseek_v4/README.md
@@ -1,5 +1,7 @@
 # DeepSeek-V4-Flash expert offloading for MoE-Infinity
 
+For the family matrix and cross-model notes, start at [docs/README.md](../../../docs/README.md) and [docs/model-compatibility.md](../../../docs/model-compatibility.md).
+
 Runs `deepseek-ai/DeepSeek-V4-Flash` with routed experts streamed from host
 memory, so the model fits where its ~132 GB of FP4 experts otherwise would not.
 
@@ -65,9 +67,8 @@ python convert.py --hf-ckpt-path <HF_CKPT> --save-path <OUT> \
   --n-experts 256 --model-parallel 4
 ```
 
-The official sparse-attention kernel is tuned for TP-sharded head counts; run
-with `--model-parallel 4` (16 heads/rank). mp1 (64 heads) exceeds the kernel's
-shared-memory limit on a single GPU.
+The validated mp4 e2e harness runs with `--model-parallel 4` (16 heads/rank);
+mp1 is not covered by repo tests for the sparse-attention path.
 
 ## Tests
 
@@ -103,9 +104,9 @@ model, store = load_offloaded_v4_flash(M, ckpt, cfg, dev, shard,
 #   MOE_DSV4_FORCE_NATIVE=0 (env) -> disable native auto-selection
 ```
 
-The native path is preferred because it is **1.5-3.2x faster than tilelang**
-and **2.3-3.6x faster than a fused Triton MXFP4 GEMM** (see benchmark below),
-while remaining bit-exact to the reference.
+Historical snapshot: the ratios below were captured in an internal run, but the
+commit, software stack, and capture date were not recorded in-repo, so treat
+them as illustrative rather than a current guarantee.
 
 It uses `moe_infinity._v4_fp4`:
 - `v4_fp4_dequant.cu` — FP4 E2M1 (packed uint8) + ue8m0 block-32 scale ->
@@ -131,10 +132,14 @@ The dequant + BF16 GEMM path avoids that bug, keeps host->GPU traffic quantized
 is the shipping native path. A fused FP4 MMA can replace it once the CUTLASS
 atom is fixed, behind the same `use_native` seam.
 
-## End-to-end validation & performance
+## End-to-end validation & historical snapshot
 
 Hardware: 4x RTX PRO 6000 Blackwell (SM120), mp4 tensor parallel, docker
 v4flash image. Prompt: "identity" (8-token prompt, 64 decode tokens).
+
+The throughput and memory numbers below are historical snapshot values only;
+they are not a current guarantee because the exact provenance was not recorded
+in-repo.
 
 ### Correctness
 - Native FP4 expert forward is **bit-exact** to the reference dequant path
@@ -181,9 +186,10 @@ error 0.0).
 | 64           |                     148 us |              210 us |             397 us |
 | 512 (prefill)|                     213 us |              323 us |             772 us |
 
-The native path (dequant once -> cuBLAS BF16 GEMM) is **1.5-3.2x faster than
-tilelang** (the `use_native=False` default) and **2.3-3.6x faster** than a fused
-Triton MXFP4 GEMM, because cuBLAS/cuBLASLt BF16 GEMM outperforms hand-written
-Triton GEMM and the dequant overhead is small. Recommendation: prefer
-`use_native=True`. (A fused FP4 MMA would beat dequant+GEMM on memory traffic,
-but the CUTLASS SM120 `mx_float4_t` atom is currently unusable, see above.)
+The native path (dequant once -> cuBLAS BF16 GEMM) was measured at **1.5-3.2x
+faster than the explicit tilelang comparison path (`use_native=False`)** and **2.3-3.6x faster**
+than a fused Triton MXFP4 GEMM in that snapshot, because cuBLAS/cuBLASLt BF16
+GEMM outperforms hand-written Triton GEMM and the dequant overhead is small.
+Recommendation in that snapshot: prefer `use_native=True`. (A fused FP4 MMA
+would beat dequant+GEMM on memory traffic, but the CUTLASS SM120 `mx_float4_t`
+atom is currently unusable, see above.)


### PR DESCRIPTION
## Summary
- establish a layered documentation hub, changelog, model compatibility matrix, and focused configuration, environment, serving, multi-GPU, troubleshooting, and benchmark guides
- update DFlash, Qwen3.5, GLM-5.2, DeepSeek-V4, and contributor architecture documentation to match current code and validation boundaries
- add documentation-impact checks to the PR template, contribution guide, and release process, with recovered design and implementation plan artifacts

## Documentation impact
- [x] README discovery and navigation updated
- [x] Authoritative feature, config, API, model, architecture, and benchmark guides updated
- [x] CHANGELOG `Unreleased` updated
- [ ] No documentation impact

## Validation
- `pytest -q tests/python/dflash -m "not gpu"` — 264 passed, 3 GPU-gated skipped
- focused config/model/serving/watchdog/distributed suite — 93 passed
- local Markdown links — 147 links, 37 anchors, 0 errors
- `python -m compileall -q examples benchmarks`
- `git diff --check origin/feat/dflash-tracks-abcd...HEAD`
- five-area final review: goal, QA, quality, security, and repository context all passed

## Notes
- This PR intentionally targets `feat/dflash-tracks-abcd`; the docs describe capabilities in that feature stack and should not land independently on `main`.
- Markdown LSP is unavailable in the current environment; structural link, anchor, path, and command checks were used instead.
- Two watchdog integration fixture failures reproduce unchanged on the base branch; no runtime or test code is modified here.