### PR TITLE
test(integration): per-model examples + GPU real-checkpoint smoke tests

### DIFF
--- a/examples/dbrx_example.py
+++ b/examples/dbrx_example.py
@@ -1,0 +1,55 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="DBRX inference example")
+parser.add_argument(
+    "--checkpoint",
+    default="databricks/dbrx-instruct",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(
+    args.checkpoint, trust_remote_code=True
+)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+prompt = tokenizer.apply_chat_template(
+    [{"role": "user", "content": "What is 2+3? Answer briefly."}],
+    tokenize=False,
+    add_generation_prompt=True,
+)
+input_ids = tokenizer.encode(prompt, return_tensors="pt").to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/deepseek_v2_chat_example.py
+++ b/examples/deepseek_v2_chat_example.py
@@ -1,0 +1,56 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="DeepSeek-V2 chat example")
+parser.add_argument(
+    "--checkpoint",
+    default="deepseek-ai/DeepSeek-V2-Lite-Chat",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(
+    args.checkpoint, trust_remote_code=True
+)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+prompt = tokenizer.apply_chat_template(
+    [{"role": "user", "content": "What is 2+3? Answer briefly."}],
+    tokenize=False,
+    add_generation_prompt=True,
+)
+input_ids = tokenizer.encode(prompt, return_tensors="pt").to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/glm_example.py
+++ b/examples/glm_example.py
@@ -1,0 +1,52 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="GLM-5.2 inference example")
+parser.add_argument(
+    "--checkpoint",
+    default="zai-org/GLM-5.2-FP8",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(
+    args.checkpoint, trust_remote_code=True
+)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.5,
+}
+model = MoE(args.checkpoint, config)
+
+input_ids = tokenizer(
+    "The capital of France is", return_tensors="pt"
+).input_ids.to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/jamba_example.py
+++ b/examples/jamba_example.py
@@ -1,0 +1,52 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="Jamba inference example")
+parser.add_argument(
+    "--checkpoint",
+    default="ai21labs/Jamba-v0.1",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(
+    args.checkpoint, trust_remote_code=True
+)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+input_ids = tokenizer(
+    "The capital of France is", return_tensors="pt"
+).input_ids.to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/mixtral_example.py
+++ b/examples/mixtral_example.py
@@ -1,0 +1,54 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="Mixtral inference example")
+parser.add_argument(
+    "--checkpoint",
+    default="mistralai/Mixtral-8x7B-Instruct-v0.1",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+prompt = tokenizer.apply_chat_template(
+    [{"role": "user", "content": "What is 2+3? Answer briefly."}],
+    tokenize=False,
+    add_generation_prompt=True,
+)
+input_ids = tokenizer.encode(prompt, return_tensors="pt").to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/nllb_example.py
+++ b/examples/nllb_example.py
@@ -1,0 +1,52 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="NLLB-MoE translation example")
+parser.add_argument(
+    "--checkpoint",
+    default="facebook/nllb-moe-54b",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.checkpoint, src_lang="eng_Latn")
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+input_ids = tokenizer("Hello, how are you?", return_tensors="pt").input_ids.to(
+    "cuda:0"
+)
+forced_bos_token_id = tokenizer.convert_tokens_to_ids("fra_Latn")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        forced_bos_token_id=forced_bos_token_id,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/olmoe_example.py
+++ b/examples/olmoe_example.py
@@ -1,0 +1,51 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="OLMoE inference example")
+parser.add_argument(
+    "--checkpoint",
+    default="allenai/OLMoE-1B-7B-0924-Instruct",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+input_ids = tokenizer(
+    "The capital of France is", return_tensors="pt"
+).input_ids.to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/qwen3_5_example.py
+++ b/examples/qwen3_5_example.py
@@ -1,0 +1,55 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(
+    description="Qwen3.5-MoE text-only inference example"
+)
+parser.add_argument(
+    "--checkpoint",
+    default="Qwen/Qwen3.5-35B-A3B",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(
+    args.checkpoint, trust_remote_code=True
+)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+input_ids = tokenizer(
+    "The capital of France is", return_tensors="pt"
+).input_ids.to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/examples/qwen3_example.py
+++ b/examples/qwen3_example.py
@@ -1,0 +1,54 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import torch
+from transformers import AutoTokenizer
+
+from moe_infinity import MoE
+
+parser = argparse.ArgumentParser(description="Qwen3-MoE inference example")
+parser.add_argument(
+    "--checkpoint",
+    default="Qwen/Qwen3-30B-A3B",
+    help="HuggingFace model checkpoint",
+)
+parser.add_argument(
+    "--offload_dir",
+    default=os.path.join(os.path.expanduser("~"), "moe-infinity"),
+    help="Directory for offloading expert weights",
+)
+parser.add_argument(
+    "--max_new_tokens",
+    type=int,
+    default=64,
+    help="Maximum tokens to generate",
+)
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+config = {
+    "offload_path": args.offload_dir,
+    "device_memory_ratio": 0.75,
+}
+model = MoE(args.checkpoint, config)
+
+prompt = tokenizer.apply_chat_template(
+    [{"role": "user", "content": "What is 2+3? Answer briefly."}],
+    tokenize=False,
+    add_generation_prompt=True,
+)
+input_ids = tokenizer.encode(prompt, return_tensors="pt").to("cuda:0")
+
+with torch.no_grad():
+    output_ids = model.generate(
+        input_ids,
+        max_new_tokens=args.max_new_tokens,
+        do_sample=False,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+output_text = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+print(output_text)

--- a/tests/python/integration/test_model_smoke.py
+++ b/tests/python/integration/test_model_smoke.py
@@ -1,0 +1,93 @@
+import os
+
+import pytest
+
+pytestmark = pytest.mark.gpu
+
+MODELS = [
+    (
+        "deepseek_v2",
+        "deepseek-ai/DeepSeek-V2-Lite-Chat",
+        "MOE_DEEPSEEK_V2_SMOKE",
+        {"trust_remote_code": True, "device_memory_ratio": 0.75},
+    ),
+    (
+        "mixtral",
+        "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        "MOE_MIXTRAL_SMOKE",
+        {"trust_remote_code": False, "device_memory_ratio": 0.75},
+    ),
+    (
+        "qwen3",
+        "Qwen/Qwen3-30B-A3B",
+        "MOE_QWEN3_SMOKE",
+        {"trust_remote_code": False, "device_memory_ratio": 0.75},
+    ),
+    (
+        "qwen3_5",
+        "Qwen/Qwen3.5-35B-A3B",
+        "MOE_QWEN3_5_SMOKE",
+        {"trust_remote_code": True, "device_memory_ratio": 0.75},
+    ),
+    (
+        "gpt_oss",
+        "openai/gpt-oss-20b",
+        "MOE_GPT_OSS_SMOKE",
+        {"trust_remote_code": False, "device_memory_ratio": 0.75},
+    ),
+    (
+        "dbrx",
+        "databricks/dbrx-instruct",
+        "MOE_DBRX_SMOKE",
+        {"trust_remote_code": True, "device_memory_ratio": 0.75},
+    ),
+    (
+        "jamba",
+        "ai21labs/Jamba-v0.1",
+        "MOE_JAMBA_SMOKE",
+        {"trust_remote_code": True, "device_memory_ratio": 0.75},
+    ),
+    (
+        "olmoe",
+        "allenai/OLMoE-1B-7B-0924-Instruct",
+        "MOE_OLMOE_SMOKE",
+        {"trust_remote_code": False, "device_memory_ratio": 0.75},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("model_id", "checkpoint", "env_var", "options"),
+    MODELS,
+    ids=[model[0] for model in MODELS],
+)
+def test_generate_smoke(model_id, checkpoint, env_var, options, tmp_path):
+    if os.environ.get(env_var) != "1":
+        pytest.skip(
+            f"Set {env_var}=1 to run the heavy {model_id} end-to-end smoke."
+        )
+
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+
+    model = MoE(
+        checkpoint,
+        {
+            "offload_path": str(tmp_path / model_id),
+            "device_memory_ratio": options["device_memory_ratio"],
+        },
+    )
+    tok = AutoTokenizer.from_pretrained(
+        checkpoint, trust_remote_code=options["trust_remote_code"]
+    )
+    ids = tok("The capital of France is", return_tensors="pt").input_ids.cuda()
+    out = model.generate(ids, max_new_tokens=16)
+    text = tok.decode(out[0], skip_special_tokens=True)
+    assert out.shape[1] >= ids.shape[1] + 1
+    assert len(text) > 0

--- a/tests/python/integration/test_nllb_smoke.py
+++ b/tests/python/integration/test_nllb_smoke.py
@@ -1,0 +1,36 @@
+import os
+
+import pytest
+
+pytestmark = pytest.mark.gpu
+
+
+@pytest.mark.skipif(
+    os.environ.get("MOE_NLLB_SMOKE") != "1",
+    reason="Set MOE_NLLB_SMOKE=1 to run the heavy NLLB-MoE end-to-end smoke.",
+)
+def test_nllb_translation_smoke(tmp_path):
+    import torch
+
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+
+    from transformers import AutoTokenizer
+
+    from moe_infinity import MoE
+
+    checkpoint = "facebook/nllb-moe-54b"
+    model = MoE(
+        checkpoint,
+        {"offload_path": str(tmp_path / "nllb"), "device_memory_ratio": 0.75},
+    )
+    tok = AutoTokenizer.from_pretrained(checkpoint, src_lang="eng_Latn")
+    ids = tok("Hello, how are you?", return_tensors="pt").input_ids.cuda()
+    out = model.generate(
+        ids,
+        max_new_tokens=16,
+        forced_bos_token_id=tok.convert_tokens_to_ids("fra_Latn"),
+    )
+    text = tok.decode(out[0], skip_special_tokens=True)
+    assert out.shape[1] >= ids.shape[1] + 1
+    assert len(text) > 0


### PR DESCRIPTION
## What

Adds per-model **runnable examples** and **real-checkpoint GPU smoke regression tests** for the supported models, so the offload + `generate()` path has coverage per model before `dev` is promoted to `main`.

## Examples (`examples/`)
`deepseek_v2_chat_example.py` (also fixes a dangling README reference), `mixtral_example.py`, `qwen3_example.py`, `qwen3_5_example.py`, `glm_example.py`, `dbrx_example.py`, `jamba_example.py`, `olmoe_example.py`, `nllb_example.py`.

Each follows the `examples/readme_example.py` template (`MoE(ckpt, {offload_path, device_memory_ratio})` → tokenizer → `generate`), with per-model quirks: GLM-5.2 uses `device_memory_ratio=0.5`; NLLB uses the encoder-decoder translation path (`src_lang`, `forced_bos_token_id`); `trust_remote_code` set per model. GPT-OSS already has `dflash_gpt_oss_example.py`.

## Regression tests (`tests/python/integration/`)
- `test_model_smoke.py` — parametrized over the 8 decoder MoEs (deepseek_v2, mixtral, qwen3, qwen3.5, gpt_oss, dbrx, jamba, olmoe): load real checkpoint → `generate(max_new_tokens=16)` → assert output grew + non-empty decode.
- `test_nllb_smoke.py` — dedicated NLLB-MoE translation smoke.
- GLM-5.2 already has `test_glm_smoke.py`.

**Gating (won't touch CI):** every test is `@pytest.mark.gpu` **and** guarded by its own `MOE_<MODEL>_SMOKE=1` env var **and** a `torch.cuda.is_available()` skip. Heavy imports (`torch`/`transformers`/`moe_infinity`) are inside the tests. CI runs `-m "not gpu"` and doesn't collect `tests/python/integration`, so these skip cleanly and never block CI. Run locally with e.g. `MOE_MIXTRAL_SMOKE=1 pytest tests/python/integration/test_model_smoke.py -k mixtral`.

## Verification
- `py_compile` all 11 files: pass
- `ruff check`: All checks passed
- `pytest --collect-only`: 9 tests collect, skip cleanly with no GPU/env
- Scope limited to `examples/` + `tests/python/integration/`
