### PR TITLE
WIP: reconcile GLM-5.2 glm_moe_dsa (spec-decode + #130)

### DIFF
--- a/core/model/model_topology.cpp
+++ b/core/model/model_topology.cpp
@@ -625,13 +625,6 @@ void ArcherTopologyHandle::BuildTopologyFromSpecs(
 
   DLOG_INFO("Moving sparse parameters to CPU");
   if (!sparse_nodes.empty()) {
-    std::map<uint32_t, std::vector<size_t>> nodes_by_partition;
-    for (size_t i = 0; i < sparse_nodes.size(); i++) {
-      auto fid =
-          kTensorIndex->find(sparse_nodes[i]->tensor_ids[0])->second.file_id;
-      nodes_by_partition[fid].push_back(i);
-    }
-
     auto read_partition =
         [](const std::string& filename) -> std::pair<void*, int64_t> {
       struct stat st;
@@ -644,6 +637,7 @@ void ArcherTopologyHandle::BuildTopologyFromSpecs(
         free(buf);
         return {nullptr, 0};
       }
+      posix_fadvise(fd, 0, file_size, POSIX_FADV_SEQUENTIAL);
       int64_t total = 0;
       while (total < file_size) {
         auto n = ::read(fd, static_cast<char*>(buf) + total,
@@ -656,61 +650,65 @@ void ArcherTopologyHandle::BuildTopologyFromSpecs(
       return {buf, file_size};
     };
 
-    std::vector<uint32_t> partition_ids;
-    for (auto& [fid, _] : nodes_by_partition) partition_ids.push_back(fid);
-    std::sort(partition_ids.begin(), partition_ids.end());
+    // Fill every sparse (expert) tensor from a single sequential bulk read of
+    // its own partition file. Grouping placements by file_id and scattering via
+    // memcpy avoids per-tensor random ReadTensor reads, which collapse to
+    // effectively-infinite latency on a cold page cache when reloading a large
+    // offload store from disk.
+    struct TensorPlacement {
+      NodePtr node;
+      int64_t param_offset;
+      int64_t size;
+      int64_t file_offset;
+    };
+    std::map<uint32_t, std::vector<TensorPlacement>> tensors_by_file;
+    for (auto& node_ptr : sparse_nodes) {
+      node_ptr->default_device = torch::Device(torch::kCUDA, target_device_id);
+      target_device_id = (target_device_id + 1) % num_gpu;
 
-    for (size_t pi = 0; pi < partition_ids.size(); pi++) {
-      auto [buf, buf_size] = read_partition(
-          kArcherTensorHandle->GetIndexFileName(partition_ids[pi]));
+      node_ptr->host_memory_ptr = kHostMemoryPool->AllocateMemory(
+          node_ptr->id, node_ptr->byte_size, CPU_DEVICE);
+      assert(node_ptr->host_memory_ptr != nullptr);
+
+      int64_t param_offset = 0;
+      for (auto& tensor_id : node_ptr->tensor_ids) {
+        auto it = kTensorIndex->find(tensor_id);
+        auto& meta = it->second;
+        int64_t size_aligned =
+            (static_cast<int64_t>(meta.size) + kAioAlignment - 1) &
+            ~(kAioAlignment - 1);
+        tensors_by_file[meta.file_id].push_back(
+            {node_ptr, param_offset, static_cast<int64_t>(meta.size),
+             static_cast<int64_t>(meta.offset)});
+        param_offset += size_aligned;
+      }
+      node_ptr->device = CPU_DEVICE;
+    }
+
+    std::vector<uint32_t> file_ids;
+    for (auto& [fid, _] : tensors_by_file) file_ids.push_back(fid);
+    std::sort(file_ids.begin(), file_ids.end());
+
+    for (size_t fi = 0; fi < file_ids.size(); fi++) {
+      uint32_t fid = file_ids[fi];
+      auto [buf, buf_size] =
+          read_partition(kArcherTensorHandle->GetIndexFileName(fid));
       assert(buf != nullptr);
 
-      uint32_t current_fid = partition_ids[pi];
-      DLOG_INFO("Processing partition ", current_fid, " (",
-                buf_size / (1024 * 1024), " MB, ",
-                nodes_by_partition[current_fid].size(), " nodes)");
-
-      for (auto idx : nodes_by_partition[current_fid]) {
-        auto& node_ptr = sparse_nodes[idx];
-        node_ptr->default_device =
-            torch::Device(torch::kCUDA, target_device_id);
-        target_device_id = (target_device_id + 1) % num_gpu;
-
-        node_ptr->host_memory_ptr = kHostMemoryPool->AllocateMemory(
-            node_ptr->id, node_ptr->byte_size, CPU_DEVICE);
-        assert(node_ptr->host_memory_ptr != nullptr);
-
-        int64_t param_offset = 0;
-        bool need_fallback = false;
-        for (auto& tensor_id : node_ptr->tensor_ids) {
-          auto it = kTensorIndex->find(tensor_id);
-          auto& meta = it->second;
-          int64_t size_aligned =
-              (static_cast<int64_t>(meta.size) + kAioAlignment - 1) &
-              ~(kAioAlignment - 1);
-
-          if (meta.file_id == current_fid) {
-            memcpy(static_cast<char*>(node_ptr->host_memory_ptr) + param_offset,
-                   static_cast<char*>(buf) + meta.offset, meta.size);
-          } else {
-            kArcherTensorHandle->ReadTensor(
-                tensor_id,
-                static_cast<char*>(node_ptr->host_memory_ptr) + param_offset,
-                false);
-            need_fallback = true;
-          }
-          param_offset += size_aligned;
-        }
-        if (need_fallback) {
-          DLOG_WARN("Node ", node_ptr->id,
-                    " has cross-partition tensors, used ReadTensor fallback");
-        }
-
-        SetModuleMemoryFromDisk_Views(node_ptr->tensor_ids,
-                                      node_ptr->host_memory_ptr);
-        node_ptr->device = CPU_DEVICE;
+      auto& placements = tensors_by_file[fid];
+      DLOG_INFO("Processing partition ", fid, " (", buf_size / (1024 * 1024),
+                " MB, ", placements.size(), " tensors)");
+      for (auto& p : placements) {
+        memcpy(static_cast<char*>(p.node->host_memory_ptr) + p.param_offset,
+               static_cast<char*>(buf) + p.file_offset,
+               static_cast<size_t>(p.size));
       }
       free(buf);
+    }
+
+    for (auto& node_ptr : sparse_nodes) {
+      SetModuleMemoryFromDisk_Views(node_ptr->tensor_ids,
+                                    node_ptr->host_memory_ptr);
     }
   }
 

--- a/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
+++ b/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
@@ -222,3 +222,25 @@ both preserve the plan's *intent* and its no-duplicate guarantee (Task 5.3).
    (recommended; it builds); (b) fully vendor the NVTX3 header set (`nvToolsExt.h` + `nvtxDetail/` +
    `nvtxExtDetail/`) so the C++ wrapper is self-contained; or (c) add `<cuda>/include/nvtx3` to the
    include path — but then the system already ships `nvtx3.hpp` and vendoring is moot.
+
+---
+
+## Pre-existing issues surfaced during verification (NOT introduced here)
+
+- **`tests/python/unit/test_glm_routing.py::test_routing_parity` is a flaky pre-existing dev test.**
+  During a broad multi-file regression sweep it intermittently fails with all-`NaN` routing tensors.
+  Evidence it is not caused by this reconciliation:
+  - The test and its code-under-test (`moe_infinity/models/glm_moe_dsa.py`) are **byte-identical** to
+    `origin/dev` (this branch never touches them; confirmed by empty `git diff origin/dev --`).
+  - It **passes** in isolation (`5 passed`), in the dev-only 7-file batch (`28 passed`), and in the
+    plan's required Task 5.1 suite (`15 passed, 2 skipped` — stable across 3 runs).
+  - In one specific 8-file ordering it is **nondeterministic**: consecutive identical invocations gave
+    `1 failed` then `39 passed`. The test self-seeds (`torch.manual_seed(0)`), so the `NaN` originates
+    from a torch global mutated by another test at import/collection, i.e. a latent test-isolation
+    fragility in dev's suite.
+  - This branch's `test_glm_moe_dsa.py::test_glm_routing_parity_vs_hf` was made **hermetic** (skips via a
+    class-level `hasattr` check *before* constructing any model), so it contributes no RNG/side-effects;
+    the flake still appears intermittently, confirming the source is dev-side.
+  **Out of scope** to fix here (dev-owned test, unrelated to GLM salvage). Recommend the maintainer
+  harden `test_routing_parity` separately (e.g. guard against degenerate all-`-inf` groups / seed the
+  module init).

--- a/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
+++ b/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
@@ -166,13 +166,17 @@ The plan (dated 2026-08-14) assumed a `dev` snapshot that has since advanced to 
 (post-#150). Two plan steps were adjusted to avoid duplicating work `dev` already carries;
 both preserve the plan's *intent* and its no-duplicate guarantee (Task 5.3).
 
-1. **README GLM row/note — SKIPPED (already on `dev`).** Plan Task 4.2 Step 3 says to add a
-   GLM supported-models row after the `Meta NLLB-MoE` row plus an FP8-in-store note. But
-   `origin/dev:README.md` **already** contains a GLM-5.2 table row (line 58,
-   `| [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2-FP8) | zai-org/GLM-5.2-FP8 |`) and a
-   **more detailed** GLM-5.2 note (line 83, covering FP8-in-store, DSA indexer, MTP, eager
-   attention). Adding the plan's row/note would create duplicates and violate Task 5.3.
-   **Action:** leave `README.md` unmodified; the plan's documentation intent is already met.
+1. **Task 4.2 (README row/note + registry assertion) — SKIPPED (already on `dev`).** The plan
+   adds a GLM supported-models row + FP8-in-store note to `README.md` and a `glmmoedsa` branch
+   to `test_model_registry.py::test_all_models_registered`. Both are **already present** on
+   `origin/dev` @ `0e4904f`:
+   - `README.md` already has a GLM-5.2 table row (line 58), a **more detailed** note (line 83:
+     FP8-in-store, DSA indexer, MTP, eager attention), AND a full "### GLM-5.2 (FP8 Expert
+     Offloading)" usage section with code + memory note.
+   - `tests/python/unit/test_model_registry.py` lines 29-30 already contain
+     `if "glmmoedsa" in MODEL_MAPPING_NAMES: expected_models.add("glmmoedsa")`.
+   Adding either would duplicate and violate Task 5.3. **Action:** leave both unmodified; the
+   plan's doc + registry intent is already met (registry test: `4 passed`).
 
 2. **`test_glm_routing_parity_vs_hf` — GUARDED for the canonical block API.** Plan Verdict #7
    keeps `test_glm_moe_dsa.py` "verbatim"; Verdict #3 keeps `dev`'s canonical

--- a/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
+++ b/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
@@ -1,0 +1,190 @@
+# GLM-5.2 Reconciliation — Decision Log
+
+Auditable triage record for reconciling PR #130 (`origin/feat/glm-5.2-fp8-support`)
+against the spec-decode GLM stack already merged into `dev` (via PR #140,
+`origin/feat/dflash-spec-decode`).
+
+- **Reconciliation branch:** `reconcile/glm-5.2-fp8-onto-dev`
+- **Baseline:** `origin/dev` @ `0e4904f` (`fix(compat): handle DeepseekV2MoE→DeepseekV2Moe Transformers rename (#150)`) — contains the full spec-decode GLM + MTP + FP8 dequant-on-copy stack.
+- **#130 old merge-base:** `b33d5fa` (an older `dev`).
+- **Strategy:** canonicalize on `dev`'s GLM/FP8 stack; salvage only the genuinely-unique, non-conflicting deltas from #130.
+
+---
+
+## git cherry (commits unique to #130 = "+")
+
+`git cherry -v origin/feat/dflash-spec-decode origin/feat/glm-5.2-fp8-support`
+
+```
+- 1a8d4c76896d4850fd76f4c7723bca70f09a9cd0 build(deps): bump transformers to >=5.3.0,<6 (closes CVE-2026-1839)
++ 707cc06d1a90d82a32597dcf1cd2d04724cf2dc9 feat(fp8): add block-wise FP8 dequant utils and allow block-FP8 checkpoints
++ 038c1496dd32b66e8dbd8b5e4e973f8d387a5b9f feat(glm): register glm_moe_dsa architecture and expert parsing
++ 98a5a39ee95279eae6d9a728785e9b5833e9c9cc feat(glm): add SyncGlmMoeDsaMoEBlock offload wrapper
++ c8ae160c2e50f3e75ad3aa8440b068a3d9e1c43d feat(fp8): dequantize FP8 experts on-GPU after fetch in the native path
++ b5a015ac97c9571f1927429e93ffa8b8f982efb5 perf(offload): coalesce sequential partition reads when reloading the store
++ 187048c6008259327943a0b964bbfb3c104b3504 feat(glm): wire GLM offload loading with FP8-in-store experts
++ 9b49f43a9b64a5325b7680c02771b69b22a74dd8 test(glm): add GLM-5.2-FP8 unit tests and docs
++ 3dc4e72ea741d8ec20d1fd91a7578930fdaeb80b build(nvtx): auto-detect NVTX3 headers and libnvToolsExt for CUDA>=12.9
++ 3444ed9a1e1ced85750feabe2d761fad0f249c0c test(glm): add operator-gated MOE_GLM_SMOKE e2e regression test
+```
+
+(`1a8d4c7` transformers bump is NOT unique — spec-decode has it as `cb4c7e6`/`#111`.)
+
+## Files added ONLY by #130
+
+`git diff --diff-filter=A --name-only origin/feat/dflash-spec-decode..origin/feat/glm-5.2-fp8-support`
+
+```
+core/include/nvtx3/nvtx3.hpp
+tests/python/unit/test_glm_moe_dsa.py
+```
+
+## range-diff: old-base..#130  vs  old-base..spec-decode
+
+`git range-diff b33d5fa..origin/feat/glm-5.2-fp8-support b33d5fa..origin/feat/dflash-spec-decode`
+
+```
+ -:  ------- >  1:  9e42c9d Merge dev: fused MoE kernels, Qwen3 support, model improvements (#75)
+ -:  ------- >  2:  a55a2b4 fix(parallel): pass exec stream to CUTLASS fused MoE FFN to fix garbage output (#80)
+ -:  ------- >  3:  f178db3 Merge dev into main: resolve #95 (kNumDevices compile error) + 167 commits (#97)
+ -:  ------- >  4:  6285c09 Merge dev into main: ship DeepSeek-V4, IBP dispatcher, GPTQ/AWQ quant (#103, #98, #82) (#104)
+ 1:  1a8d4c7 !  5:  cb4c7e6 build(deps): bump transformers to >=5.3.0,<6 (closes CVE-2026-1839)
+ 2:  707cc06 <  -:  ------- feat(fp8): add block-wise FP8 dequant utils and allow block-FP8 checkpoints
+ 3:  038c149 <  -:  ------- feat(glm): register glm_moe_dsa architecture and expert parsing
+ 4:  98a5a39 <  -:  ------- feat(glm): add SyncGlmMoeDsaMoEBlock offload wrapper
+ 5:  c8ae160 <  -:  ------- feat(fp8): dequantize FP8 experts on-GPU after fetch in the native path
+ 6:  b5a015a <  -:  ------- perf(offload): coalesce sequential partition reads when reloading the store
+ 7:  187048c <  -:  ------- feat(glm): wire GLM offload loading with FP8-in-store experts
+ 8:  9b49f43 <  -:  ------- test(glm): add GLM-5.2-FP8 unit tests and docs
+ 9:  3dc4e72 <  -:  ------- build(nvtx): auto-detect NVTX3 headers and libnvToolsExt for CUDA>=12.9
+10:  3444ed9 <  -:  ------- test(glm): add operator-gated MOE_GLM_SMOKE e2e regression test
+ -:  ------- >  6:  d9569f3 chore(ci,docs): align Python floor to >=3.10 (drop 3.8/3.9 from publish matrices) (#117)
+ -:  ------- >  7:  1cc2d01 fix(install,server): repair source-install docs, deps, and /v1/config endpoint (#116)
+ -:  ------- >  8:  b265368 ci(publish): make release/nightly wheel builds compile the CUDA extensions (#118)
+ -:  ------- >  9:  20a9e98 Skip Claude review workflow on forked pull requests (#126)
+ -:  ------- > 10:  2fdb36c ci: relax exact setuptools pin in build-system requires (#121)
+ -:  ------- > 11:  4cdba02 feat(qwen3.5): Qwen3.5-35B-A3B MoE support (text-only, expert offload) (#128)
+ -:  ------- > 12:  ba56518 fix(aio,build): lost-wakeup deadlock + CUDA-13 NVTX (salvaged from #124) (#129)
+ -:  ------- > 13:  0010c9d feat(dflash): add DFlash speculative decoding module for GPT-OSS
+ -:  ------- > 14:  9b02fab docs(dflash): add runnable GPT-OSS speculative decoding example
+ -:  ------- > 15:  28993ae test(dflash): add greedy-agreement eval harness
+ -:  ------- > 16:  276fcf2 feat(glm): register glmmoedsa architecture (GlmMoeDsaForCausalLM, type=5, transformers>=5.12 guarded)
+ -:  ------- > 17:  d797138 refactor(fp8): relocate dequant_fp8_blockwise to utils/fp8.py (back-compat re-export preserved)
+ -:  ------- > 18:  e6a982d feat(glm): hf_config parse_moe_param/parse_expert_id GLM branch (MTP-78 skip guard)
+ -:  ------- > 19:  b02c3bd feat(glm): SyncGlmMoeDsaMoEBlock wrapper (HF-gate routing delegation)
+ -:  ------- > 20:  5fdaab7 feat(glm): FP8 block dequant-on-load for GLM experts (honors modules_to_not_convert)
+ -:  ------- > 21:  5ff3c27 feat(glm): DSA indexer classification + IndexShare ownership map
+ -:  ------- > 22:  5b2c2b6 feat(glm): wire GlmMoeDsa into offload engine (patch/unpatch, isinstance, first_k_dense, eager attn, MTP-safe)
+ -:  ------- > 23:  b91f1b1 docs(glm): add GLM-5.2 to supported models + FP8 offload usage
+ -:  ------- > 24:  c675f35 test(glm): verify MLA/DSA attention tensors stay resident (not misrouted as experts)
+ -:  ------- > 25:  7e319b9 test(glm): base contract chain + RAM/GPU-gated e2e smoke (skips until fp8-in-store)
+ -:  ------- > 26:  cc6ad2e test(glm): verify IndexShare needs no offload change (indexers only on 'full' layers)
+ -:  ------- > 27:  16ea9ca feat(glm): fp8-in-store Python layer (glm_fp8_in_store flag, scale sidecar, SetScales interface)
+ -:  ------- > 28:  034406b test(glm): budget-split coherence + gated 32k long-context prefill smoke
+ -:  ------- > 29:  eb03ba8 test(glm): consolidated DSA/IndexShare/MLA integration test (real-config consistency)
+ -:  ------- > 30:  9b39a10 feat(glm): DFlash adapter hook (availability + pairing validation, reuses dflash.py)
+ -:  ------- > 31:  3167500 feat(glm): native FP8 e4m3 block-scale dequant kernel + set_scales binding (bit-exact vs python; dispatcher H2D integration deferred)
+ -:  ------- > 32:  48d5385 fix(glm): model-load fixes exposed by real load (DeepseekV2Moe rename patch, GLM use_native_engine=False, e_score_correction_bias device guard)
+ -:  ------- > 33:  3db718a test(glm): tiny synthetic GLM reproducer (gated MOE_GLM_TINY) — reproduces native expert-dispatch SIGSEGV
+ -:  ------- > 34:  a4ddae4 fix(glm): register routed experts (add experts ModuleList + first_k_dense offset) — fixes native dispatch SIGSEGV; tiny GLM now generates end-to-end
+ -:  ------- > 35:  a80b3de feat(glm): MTP speculative decoding (built-in layer 78 drafter, lossless-by-construction; validated on tiny model)
+ -:  ------- > 36:  ffd93d9 feat(glm): MTP spec-decode instrumentation (accept-length tau, per-step stats, expert-fetch hook) — parity preserved
+ -:  ------- > 37:  116d253 test(glm): forked spec-decode test runner (MTP lossless + stats + DFlash adapter, process-isolated)
+ -:  ------- > 38:  adc4d7f feat(glm): validate GLM serving via OpenAI api_server_v2 (works as-is on non-paged HF path; +tokenizer save +gated test)
+ -:  ------- > 39:  951f3f2 test(glm): serving smoke covers completions + chat + streaming (one server, process-isolated)
+ -:  ------- > 40:  c16cb46 feat(glm): native fp8-in-store dequant-on-copy (SetScales + MoEMLP dequant, gated) — Option A==B parity on tiny FP8 GLM; completes T15/T16
+ -:  ------- > 41:  54a6b05 feat(perf-model): minimal roofline package + GLM-5.2 ModelParams/decode roofline (scaffold, cross-plan option b)
+ -:  ------- > 42:  cdc510d feat(perf-model): GLM benchmark harness (tiny-model decode + MTP on/off + predicted roofline -> CSV)
+ -:  ------- > 43:  a1ba227 feat(perf-model): GLM perf validation/summary + roofline & throughput plots (PDF+PNG) + markdown report
+ -:  ------- > 44:  d8e5924 chore(glm): finalize fp8-in-store always-on tail
+ -:  ------- > 45:  437f589 fix(offload): bind resident params to correct offload id (GLM q_a_layernorm mis-map)
+ -:  ------- > 46:  03b03b9 refine(offload): scope resident-weight tensor_ids sort to DENSE nodes only
+ -:  ------- > 47:  4b8b377 fix(offload): bind begin/end to stable tensor id (fixes intermittent resident-weight fetch mis-map)
+ -:  ------- > 48:  d80febc fix(glm): keep MTP-layer routed experts FP8 on fresh offload
+ -:  ------- > 49:  a0b0973 refactor(engine): extract _generate_standard + add spec_strategy seam (spec-off identical)
+ -:  ------- > 50:  48f68f2 feat(engine): rich on-device forward helper + 5-layer hidden-state capture for spec-decode
+ -:  ------- > 51:  b0e1ed2 feat(dflash): accept-rule + block-build pure fns with hand-checked unit tests
+ -:  ------- > 52:  1ecde09 feat(dflash): harden drafter loader (trust_remote_code + dim/vocab/mask asserts)
+ -:  ------- > 53:  7c96117 test(dflash): tiny synthetic gpt-oss target + drafter fixtures (CPU determinism)
+ -:  ------- > 54:  ccac7a1 feat(dflash): native draft->verify->rollback state machine (bonus emitted-not-cached)
+ -:  ------- > 55:  b1309d2 fix(dflash): tiny-target sliding_window 8->128 (>= block_size+1) for reconstructible sliding-window KV rollback
+ -:  ------- > 56:  f6d4d1b feat(dflash): edge cases (accept 0/9, EOS mid-block, max_new_tokens, batch==1 guard)
+ -:  ------- > 57:  0ea5015 feat(dflash): wire native speculator as GenerationEngine spec_strategy
+ -:  ------- > 58:  29c544f test(dflash): tiny-model E2E losslessness parity (native == plain greedy)
+ -:  ------- > 59:  9c176a5 test(engine): spec-off byte-identity regression + gpt-oss suite green
+ -:  ------- > 60:  7f62bda test(dflash): GPU-gated 120B validation harness (agreement-rate/accept-len/tok-s)
+ -:  ------- > 61:  d4a4c51 docs(dflash): native-path example + usage notes (trust_remote_code, TP=2 SM120)
+ -:  ------- > 62:  2d10994 fix(dflash): gather 5-layer feature + posterior to drafter device (multi-GPU TP>1)
+ -:  ------- > 63:  ccb7cac fix(gpt-oss): resident-load MXFP4 experts + sinks + router
+ -:  ------- > 64:  aad2cb6 feat(dflash): route-ahead prefetch, sampled/batched decoding, serving integration + drafter-driven contract (#139)
+```
+
+**Reading:** every #130 commit (left, `2:`–`10:`) has `< -------` (no direct spec-decode
+equivalent commit), but its *functionality* is superseded by spec-decode's granular GLM
+commits on the right (`16:`–`52:`). e.g. #130 `038c149` register ↔ `276fcf2`; #130
+`98a5a39` block ↔ `b02c3bd`; #130 `c8ae160` on-GPU dequant ↔ `c16cb46` dequant-on-copy
+(Option A==B parity); #130 `3444ed9` smoke ↔ `7e319b9`+`034406b`. Right-column `d9569f3`
+also shows spec-decode/`dev` deliberately aligned the Python floor to **>=3.10**, which is
+why #130's `setup.py` `python_requires>=3.8` downgrade must NOT be taken.
+
+---
+
+## Frozen per-commit verdicts
+
+| # | SHA | Verdict | Spec-decode equivalent on `dev` | Rationale (verified against `origin/dev`) |
+|---|-----|---------|-------------------------------|----------------------|
+| 1 | `707cc06` | **PARTIAL-KEEP** | `d797138` relocated `dequant_fp8_blockwise` only | `dev` `fp8.py` has ONLY `dequant_fp8_blockwise`. Salvage `dequant_fp8_state_dict` + `stack_expert_scales` (needed by the kept unit suite). Do NOT re-add `dequant_fp8_blockwise` (dev canonical). |
+| 2 | `038c149` | **DROP** | `276fcf2` + `e6a982d` | `dev` already registers `glmmoedsa` in `constants.py` (`MODEL_MAPPING_TYPES["glmmoedsa"]==5`, verified) and `hf_config.py` (two `elif "glmmoedsa" in arch`, verified). |
+| 3 | `98a5a39` | **DROP (conflicting-alt)** | `b02c3bd` (dev's `SyncGlmMoeDsaMoEBlock`) + `__init__.py` export | `dev` defines/exports `SyncGlmMoeDsaMoEBlock` (verified line 21 + `__init__` import/`__all__`). #130's block is a divergent alternative (108/89). Keep dev's DSA/MTP-integrated version. |
+| 4 | `c8ae160` | **DROP (conflicting-alt)** | `3167500` native kernel + `c16cb46` dequant-on-copy | spec-decode modified all four C++ files (`expert_dispatcher.cpp` +78, `expert_module.cpp` +32/-1, `expert_module.h` +5/-1, `py_archer_prefetch.cpp` +9/-8; verified). Canonical = dev's dequant-on-copy (`c16cb46` Option A==B parity). |
+| 5 | `b5a015a` | **KEEP (clean)** | none | `core/model/model_topology.cpp` diffstat `b33d5fa..spec-decode` is **empty** (verified). Self-contained partition-read coalescing perf fix. No conflict. |
+| 6 | `187048c` | **DROP (conflicting-alt)** | `5b2c2b6` wire GlmMoeDsa into offload | `dev` rewrote `model_offload.py`; #130's wiring targets its own dequant-after-fetch path; superseded. |
+| 7 | `9b49f43` | **KEEP (reconcile)** | different GLM tests in spec-decode | `tests/python/unit/test_glm_moe_dsa.py` is unique → keep. README GLM row/note + `test_model_registry.py` glmmoedsa assertion reconciled (see deviations). |
+| 8 | `3dc4e72` | **KEEP (reconcile)** | `ba56518` (CUDA-13 NVTX, different `setup.py` hunk) | `core/include/nvtx3/nvtx3.hpp` unique → keep. Reconcile only the NVTX auto-detect hunk onto dev's `setup.py`; do NOT take #130's fp4-kernel/CUDA-stub/`python_requires` regressions. |
+| 9 | `3444ed9` | **DROP (covered)** | `7e319b9` + `034406b` | `dev`'s `tests/python/integration/test_glm_smoke.py` already has `MOE_GLM_SMOKE`-gated `test_glm_generate_smoke` + `test_glm_long_context_prefill` (verified). |
+
+**Net wanted deltas that land:** `b5a015a` (perf); `nvtx3.hpp` + reconciled `setup.py`
+NVTX (`3dc4e72`); the two fp8 helpers (`707cc06` subset); `test_glm_moe_dsa.py` +
+`test_model_registry.py` glmmoedsa assertion (`9b49f43`).
+
+## Canonical FP8 dequant path
+
+**DECISION:** `dev`'s dequant-on-copy (spec-decode `3167500` native kernel + `c16cb46`
+SetScales/MoEMLP) is canonical. **DROPPED from #130:** `c8ae160` (on-GPU
+dequant-after-fetch), `98a5a39` (alt `SyncGlmMoeDsaMoEBlock`), `187048c` (alt offload
+wiring). Rationale: `c16cb46` validated Option A==B parity on tiny FP8 GLM; layering
+#130's alternative would duplicate and fork the FP8 path. None of the DROP-list files
+(`glm_moe_dsa.py`, `model_offload.py`, `constants.py`, `hf_config.py`, the C++
+`parallel/`+`py_archer_prefetch.cpp`, `test_glm_smoke.py`) are modified on this branch.
+
+---
+
+## Reconciliation deviations from the plan (dev evolved past plan assumptions)
+
+The plan (dated 2026-08-14) assumed a `dev` snapshot that has since advanced to `0e4904f`
+(post-#150). Two plan steps were adjusted to avoid duplicating work `dev` already carries;
+both preserve the plan's *intent* and its no-duplicate guarantee (Task 5.3).
+
+1. **README GLM row/note — SKIPPED (already on `dev`).** Plan Task 4.2 Step 3 says to add a
+   GLM supported-models row after the `Meta NLLB-MoE` row plus an FP8-in-store note. But
+   `origin/dev:README.md` **already** contains a GLM-5.2 table row (line 58,
+   `| [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2-FP8) | zai-org/GLM-5.2-FP8 |`) and a
+   **more detailed** GLM-5.2 note (line 83, covering FP8-in-store, DSA indexer, MTP, eager
+   attention). Adding the plan's row/note would create duplicates and violate Task 5.3.
+   **Action:** leave `README.md` unmodified; the plan's documentation intent is already met.
+
+2. **`test_glm_routing_parity_vs_hf` — GUARDED for the canonical block API.** Plan Verdict #7
+   keeps `test_glm_moe_dsa.py` "verbatim"; Verdict #3 keeps `dev`'s canonical
+   `SyncGlmMoeDsaMoEBlock`. These conflict for one test: `test_glm_routing_parity_vs_hf`
+   calls `sync.route_tokens_to_experts(router_logits)`, which is **#130's block API**. `dev`'s
+   canonical block instead delegates routing to HF (`_route` → `_hf_route_tokens =
+   getattr(GlmMoeDsaMoE, "route_tokens_to_experts", None)`) and exposes **no**
+   `route_tokens_to_experts` method (verified: `hasattr(...) == False`). Because this
+   environment ships `transformers.models.glm_moe_dsa`, the test would **run and
+   AttributeError** (not skip), contradicting the plan's own "0 failed" acceptance criterion
+   (Task 4.1 Step 3). **Action:** add a one-line capability guard — `pytest.skip(...)` when the
+   canonical block lacks `route_tokens_to_experts` — so the test still validates routing
+   parity on any block/env that exposes that API, and skips cleanly on `dev`'s
+   HF-delegating block. This is the only resolution consistent with both verdicts **and**
+   the plan's zero-failure criterion. Flagged for reviewer: the alternative is to port the
+   parity assertion to `dev`'s `_route` path instead of guarding.

--- a/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
+++ b/docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md
@@ -140,12 +140,13 @@ why #130's `setup.py` `python_requires>=3.8` downgrade must NOT be taken.
 | 5 | `b5a015a` | **KEEP (clean)** | none | `core/model/model_topology.cpp` diffstat `b33d5fa..spec-decode` is **empty** (verified). Self-contained partition-read coalescing perf fix. No conflict. |
 | 6 | `187048c` | **DROP (conflicting-alt)** | `5b2c2b6` wire GlmMoeDsa into offload | `dev` rewrote `model_offload.py`; #130's wiring targets its own dequant-after-fetch path; superseded. |
 | 7 | `9b49f43` | **KEEP (reconcile)** | different GLM tests in spec-decode | `tests/python/unit/test_glm_moe_dsa.py` is unique → keep. README GLM row/note + `test_model_registry.py` glmmoedsa assertion reconciled (see deviations). |
-| 8 | `3dc4e72` | **KEEP (reconcile)** | `ba56518` (CUDA-13 NVTX, different `setup.py` hunk) | `core/include/nvtx3/nvtx3.hpp` unique → keep. Reconcile only the NVTX auto-detect hunk onto dev's `setup.py`; do NOT take #130's fp4-kernel/CUDA-stub/`python_requires` regressions. |
+| 8 | `3dc4e72` | **DROP (superseded + build-breaking as shipped)** — see deviation #3 | `ba56518` (dev's header-only CUDA-13 NVTX fix) | Empirically the partial vendored header **breaks the C++ build** on this CUDA-13.1 host, and the setup.py hunk is superseded by `ba56518` + dev's already-present `core/include`. See deviation #3 for the compile-probe evidence. |
 | 9 | `3444ed9` | **DROP (covered)** | `7e319b9` + `034406b` | `dev`'s `tests/python/integration/test_glm_smoke.py` already has `MOE_GLM_SMOKE`-gated `test_glm_generate_smoke` + `test_glm_long_context_prefill` (verified). |
 
-**Net wanted deltas that land:** `b5a015a` (perf); `nvtx3.hpp` + reconciled `setup.py`
-NVTX (`3dc4e72`); the two fp8 helpers (`707cc06` subset); `test_glm_moe_dsa.py` +
-`test_model_registry.py` glmmoedsa assertion (`9b49f43`).
+**Net wanted deltas that actually land:** `b5a015a` (perf, Task 2.2); the two fp8 helpers
+(`707cc06` subset, Task 2.1); `test_glm_moe_dsa.py` (`9b49f43`, Task 4.1, with the routing-parity
+guard) + `test_model_registry.py` glmmoedsa assertion (Task 4.2). The NVTX salvage (`3dc4e72`)
+and the README doc row/note are NOT landed — both superseded by dev; see deviations #1 and #3.
 
 ## Canonical FP8 dequant path
 
@@ -188,3 +189,32 @@ both preserve the plan's *intent* and its no-duplicate guarantee (Task 5.3).
    HF-delegating block. This is the only resolution consistent with both verdicts **and**
    the plan's zero-failure criterion. Flagged for reviewer: the alternative is to port the
    parity assertion to `dev`'s `_route` path instead of guarding.
+
+3. **NVTX salvage (`3dc4e72`) — DROPPED with compile-probe evidence (build-breaking as shipped).**
+   Plan Verdict #8 keeps the vendored `core/include/nvtx3/nvtx3.hpp` and reconciles a `setup.py`
+   NVTX hunk. Two facts, verified against `origin/dev` @ `0e4904f`, make the salvage unsafe:
+   - **`core/include` is already index-1 in `setup.py`'s `COMMON_INCLUDE_PATHS`** (`get_path("core",
+     "include")`, before the conditional system-NVTX dir), and dev's `core/` C++ already
+     `#include <nvtx3/nvtx3.hpp>` (`expert_dispatcher.h`, `model_topology.h`,
+     `task_scheduler.cpp`, `archer_prio_aio_handle.cpp`). So dropping the vendored header in makes
+     it **shadow** the system header.
+   - #130 vendored **only** `nvtx3.hpp`, but that file does an unconditional `#include
+     "nvToolsExt.h"` (line 633). On this host, `nvToolsExt.h` exists **only** at
+     `/usr/local/cuda-13.1/include/nvtx3/nvToolsExt.h` (a sibling of the *system* header), never as a
+     bare header on the `-I` path. So the vendored (sibling-less) header cannot resolve it.
+
+   **Compile probe (g++ 13.3, CUDA 13.1), reproducible:**
+   ```
+   # P1  vendored wins (core/include first) + system cuda include  ->  FATAL
+   #     core/include/nvtx3/nvtx3.hpp:633: fatal error: nvToolsExt.h: No such file or directory
+   # P2  dev current (no vendored header), system nvtx3 only         ->  OK
+   # P3  vendored + -I<cuda>/include/nvtx3 (sibling resolvable)       ->  OK
+   ```
+   dev already builds NVTX correctly via system headers + the header-only link decision from
+   `ba56518` (dev does NOT link `libnvToolsExt`; comment at `setup.py` ~238). #130's setup.py hunk
+   additionally re-introduces a **conditional `-lnvToolsExt` link**, reversing `ba56518`, plus
+   fp4-kernel/CUDA-stub/`python_requires>=3.8` regressions if blind-applied. **Action:** land neither
+   the vendored header nor the setup.py hunk. **Flagged for reviewer** — options: (a) keep dev as-is
+   (recommended; it builds); (b) fully vendor the NVTX3 header set (`nvToolsExt.h` + `nvtxDetail/` +
+   `nvtxExtDetail/`) so the C++ wrapper is self-contained; or (c) add `<cuda>/include/nvtx3` to the
+   include path — but then the system already ships `nvtx3.hpp` and vendoring is moot.

--- a/moe_infinity/utils/fp8.py
+++ b/moe_infinity/utils/fp8.py
@@ -3,9 +3,17 @@
 
 from __future__ import annotations
 
+import re
+from typing import Callable, Dict, Optional
+
 import torch
 
 FP8_BLOCK = 128
+
+EXPERT_SCALE_KEY_RE = re.compile(
+    r"model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
+    r"(gate_proj|up_proj|down_proj)\.weight$"
+)
 
 
 def dequant_fp8_blockwise(
@@ -21,3 +29,57 @@ def dequant_fp8_blockwise(
         block_size, dim=1
     )[:n, :k]
     return (w * s_full).to(dtype)
+
+
+def dequant_fp8_state_dict(
+    state_dict: dict,
+    dtype: torch.dtype = torch.bfloat16,
+    block_size: int = FP8_BLOCK,
+    keep_fp8: Optional[Callable[[str], object]] = None,
+) -> Dict[str, torch.Tensor]:
+    kept_scales: Dict[str, torch.Tensor] = {}
+    for scale_key in [
+        k for k in list(state_dict) if k.endswith("weight_scale_inv")
+    ]:
+        weight_key = scale_key[: -len("_scale_inv")]
+        weight = state_dict.get(weight_key)
+        scale = state_dict.get(scale_key)
+        if weight is None or scale is None:
+            continue
+        if weight.numel() == 0 or scale.numel() == 0:
+            continue
+        if keep_fp8 is not None and keep_fp8(weight_key):
+            kept_scales[weight_key] = scale.to(torch.float32)
+            del state_dict[scale_key]
+            continue
+        state_dict[weight_key] = dequant_fp8_blockwise(
+            weight, scale, dtype, block_size
+        )
+        del state_dict[scale_key]
+    return kept_scales
+
+
+def stack_expert_scales(
+    flat_scales: Dict[str, torch.Tensor],
+) -> Dict[int, Dict[str, torch.Tensor]]:
+    per_layer: Dict[int, Dict[str, Dict[int, torch.Tensor]]] = {}
+    for key, scale in flat_scales.items():
+        match = EXPERT_SCALE_KEY_RE.match(key)
+        if not match:
+            continue
+        layer_id = int(match.group(1))
+        expert_id = int(match.group(2))
+        proj = match.group(3).split("_")[0]
+        per_layer.setdefault(layer_id, {}).setdefault(proj, {})[expert_id] = (
+            scale
+        )
+
+    stacked: Dict[int, Dict[str, torch.Tensor]] = {}
+    for layer_id, projs in per_layer.items():
+        stacked[layer_id] = {
+            proj: torch.stack(
+                [experts[i] for i in sorted(experts)]
+            ).contiguous()
+            for proj, experts in projs.items()
+        }
+    return stacked

--- a/tests/python/unit/test_glm_moe_dsa.py
+++ b/tests/python/unit/test_glm_moe_dsa.py
@@ -1,0 +1,227 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+# EfficientMoE Team
+
+import warnings
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+
+def _glm_config(num_hidden_layers=78, n_routed_experts=256):
+    return cast(
+        Any,
+        SimpleNamespace(
+            architectures=["GlmMoeDsaForCausalLM"],
+            model_type="glm_moe_dsa",
+            num_hidden_layers=num_hidden_layers,
+            n_routed_experts=n_routed_experts,
+            first_k_dense_replace=3,
+            n_shared_experts=1,
+            num_experts_per_tok=8,
+        ),
+    )
+
+
+def test_glm_registered_when_transformers_supports_it():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    pytest.importorskip("transformers.models.glm_moe_dsa")
+    from moe_infinity.common.constants import (
+        MODEL_MAPPING_NAMES,
+        MODEL_MAPPING_TYPES,
+        parse_expert_type,
+    )
+
+    assert "glmmoedsa" in MODEL_MAPPING_NAMES
+    assert MODEL_MAPPING_TYPES["glmmoedsa"] == 5
+    assert parse_expert_type(_glm_config()) == 5
+
+
+def test_glm_parse_moe_param():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from moe_infinity.utils.hf_config import parse_moe_param
+
+    assert parse_moe_param(_glm_config()) == (78, 256, 0)
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("model.layers.5.mlp.experts.42.gate_proj.weight", (5, 42)),
+        ("model.layers.77.mlp.experts.255.down_proj.weight", (77, 255)),
+        ("model.layers.3.mlp.shared_experts.up_proj.weight", (None, None)),
+        ("model.layers.10.mlp.gate.weight", (None, None)),
+        ("model.layers.78.mlp.experts.0.gate_proj.weight", (None, None)),
+        ("model.layers.5.self_attn.q_a_proj.weight", (None, None)),
+    ],
+)
+def test_glm_parse_expert_id(name, expected):
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    from moe_infinity.utils.hf_config import parse_expert_id
+
+    assert parse_expert_id(name, _glm_config()) == expected
+
+
+def test_glm_fp8_dequant_blockwise():
+    from moe_infinity.utils.fp8 import dequant_fp8_blockwise
+
+    torch.manual_seed(0)
+    weight = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    scale = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    scale_full = scale.repeat_interleave(128, 0).repeat_interleave(128, 1)[
+        :256, :384
+    ]
+    ref = (weight.to(torch.float32) * scale_full).to(torch.bfloat16)
+    out = dequant_fp8_blockwise(
+        weight, scale, dtype=torch.bfloat16, block_size=128
+    )
+    assert out.dtype == torch.bfloat16
+    assert torch.allclose(out.float(), ref.float(), rtol=1e-2, atol=1e-2)
+
+
+def test_glm_fp8_dequant_state_dict():
+    from moe_infinity.utils.fp8 import dequant_fp8_state_dict
+
+    weight = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    scale = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    state_dict = {
+        "m.gate_proj.weight": weight,
+        "m.gate_proj.weight_scale_inv": scale,
+        "m.norm.weight": torch.ones(8, dtype=torch.bfloat16),
+    }
+    dequant_fp8_state_dict(state_dict, dtype=torch.bfloat16, block_size=128)
+
+    assert "m.gate_proj.weight_scale_inv" not in state_dict
+    assert state_dict["m.gate_proj.weight"].dtype == torch.bfloat16
+    assert state_dict["m.norm.weight"].numel() == 8
+    assert not any("weight_scale_inv" in k for k in state_dict)
+
+
+def test_glm_fp8_selective_dequant_keeps_experts_fp8():
+    from moe_infinity.utils.fp8 import (
+        EXPERT_SCALE_KEY_RE,
+        dequant_fp8_state_dict,
+        stack_expert_scales,
+    )
+
+    expert_w = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    expert_s = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    dense_w = torch.randn(256, 384).to(torch.float8_e4m3fn)
+    dense_s = torch.rand(2, 3, dtype=torch.float32) + 0.5
+    state_dict = {
+        "model.layers.3.mlp.experts.7.gate_proj.weight": expert_w,
+        "model.layers.3.mlp.experts.7.gate_proj.weight_scale_inv": expert_s,
+        "model.layers.0.mlp.gate_proj.weight": dense_w,
+        "model.layers.0.mlp.gate_proj.weight_scale_inv": dense_s,
+    }
+    kept = dequant_fp8_state_dict(
+        state_dict,
+        dtype=torch.bfloat16,
+        block_size=128,
+        keep_fp8=EXPERT_SCALE_KEY_RE.match,
+    )
+
+    expert_key = "model.layers.3.mlp.experts.7.gate_proj.weight"
+    assert state_dict[expert_key].dtype == torch.float8_e4m3fn
+    assert expert_key in kept
+    assert torch.equal(kept[expert_key], expert_s)
+    assert "model.layers.0.mlp.gate_proj.weight_scale_inv" not in state_dict
+    assert state_dict["model.layers.0.mlp.gate_proj.weight"].dtype == (
+        torch.bfloat16
+    )
+    assert not any("weight_scale_inv" in k for k in state_dict)
+
+    stacked = stack_expert_scales(kept)
+    assert list(stacked.keys()) == [3]
+    assert stacked[3]["gate"].shape == (1, 2, 3)
+    assert torch.equal(stacked[3]["gate"][0], expert_s)
+
+
+def test_glm_cpp_dequant_matches_python():
+    _store = pytest.importorskip("moe_infinity._store")
+    if isinstance(_store, MagicMock):
+        pytest.skip(
+            "moe_infinity._store is stubbed by conftest; native "
+            "extension not built"
+        )
+    from moe_infinity.utils.fp8 import dequant_fp8_blockwise
+
+    torch.manual_seed(0)
+    shapes = [
+        ((256, 384), (2, 3)),
+        ((2048, 6144), (16, 48)),  # GLM-5.2 gate/up proj
+        ((6144, 2048), (48, 16)),  # GLM-5.2 down proj
+    ]
+    for w_shape, s_shape in shapes:
+        weight = torch.randn(*w_shape).to(torch.float8_e4m3fn)
+        scale = torch.rand(*s_shape, dtype=torch.float32) + 0.5
+        ref = dequant_fp8_blockwise(weight, scale, dtype=torch.bfloat16)
+        out = _store.dequant_fp8_blockwise(weight, scale)
+        assert out.dtype == torch.bfloat16
+        assert torch.equal(out, ref)
+        if torch.cuda.is_available():
+            out_gpu = _store.dequant_fp8_blockwise(weight.cuda(), scale.cuda())
+            assert out_gpu.dtype == torch.bfloat16
+            assert torch.equal(out_gpu.cpu(), ref)
+
+
+def test_glm_routing_parity_vs_hf():
+    pytest.importorskip("transformers.models.glm_moe_dsa")
+    from transformers.models.glm_moe_dsa.modeling_glm_moe_dsa import (
+        GlmMoeDsaMoE,
+    )
+
+    try:
+        from transformers import GlmMoeDsaConfig
+    except ImportError:
+        from transformers.models.glm_moe_dsa.configuration_glm_moe_dsa import (
+            GlmMoeDsaConfig,
+        )
+
+    from moe_infinity.models import SyncGlmMoeDsaMoEBlock
+
+    torch.manual_seed(0)
+    config = GlmMoeDsaConfig(
+        hidden_size=128,
+        moe_intermediate_size=64,
+        intermediate_size=256,
+        n_routed_experts=8,
+        num_local_experts=8,
+        num_experts_per_tok=4,
+        n_shared_experts=1,
+        n_group=1,
+        topk_group=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=2.5,
+        hidden_act="silu",
+        num_hidden_layers=4,
+    )
+    hf = GlmMoeDsaMoE(config).eval()
+    sync = SyncGlmMoeDsaMoEBlock(config).eval()
+    if not hasattr(sync, "route_tokens_to_experts"):
+        pytest.skip(
+            "canonical SyncGlmMoeDsaMoEBlock delegates routing to HF and has no "
+            "standalone route_tokens_to_experts; parity covered by "
+            "test_glm_routing.py::test_routing_parity"
+        )
+    sync.gate.load_state_dict(hf.gate.state_dict())
+    with torch.no_grad():
+        bias = torch.randn(config.n_routed_experts)
+        hf.gate.e_score_correction_bias.copy_(bias)
+        sync.gate.e_score_correction_bias.copy_(bias)
+
+    router_logits = torch.randn(32, config.n_routed_experts)
+    hf_idx, hf_w = hf.route_tokens_to_experts(router_logits)
+    our_idx, our_w = sync.route_tokens_to_experts(router_logits)
+
+    hf_sorted = torch.sort(hf_idx, dim=-1).values
+    our_sorted = torch.sort(our_idx, dim=-1).values
+    assert torch.equal(hf_sorted, our_sorted)
+
+    hf_ws = torch.gather(hf_w, 1, torch.argsort(hf_idx, dim=-1))
+    our_ws = torch.gather(our_w, 1, torch.argsort(our_idx, dim=-1))
+    assert torch.allclose(hf_ws, our_ws, rtol=1e-4, atol=1e-5)

--- a/tests/python/unit/test_glm_moe_dsa.py
+++ b/tests/python/unit/test_glm_moe_dsa.py
@@ -184,6 +184,13 @@ def test_glm_routing_parity_vs_hf():
 
     from moe_infinity.models import SyncGlmMoeDsaMoEBlock
 
+    if not hasattr(SyncGlmMoeDsaMoEBlock, "route_tokens_to_experts"):
+        pytest.skip(
+            "canonical SyncGlmMoeDsaMoEBlock delegates routing to HF and has no "
+            "standalone route_tokens_to_experts; parity covered by "
+            "test_glm_routing.py::test_routing_parity"
+        )
+
     torch.manual_seed(0)
     config = GlmMoeDsaConfig(
         hidden_size=128,
@@ -202,12 +209,6 @@ def test_glm_routing_parity_vs_hf():
     )
     hf = GlmMoeDsaMoE(config).eval()
     sync = SyncGlmMoeDsaMoEBlock(config).eval()
-    if not hasattr(sync, "route_tokens_to_experts"):
-        pytest.skip(
-            "canonical SyncGlmMoeDsaMoEBlock delegates routing to HF and has no "
-            "standalone route_tokens_to_experts; parity covered by "
-            "test_glm_routing.py::test_routing_parity"
-        )
     sync.gate.load_state_dict(hf.gate.state_dict())
     with torch.no_grad():
         bias = torch.randn(config.n_routed_experts)


### PR DESCRIPTION
> **DRAFT — do not merge.** Base: `dev`. This PR reconciles the two divergent `glm_moe_dsa`
> implementations (spec-decode's, already on `dev` via #140; and PR #130's) into one canonical
> stack by salvaging only #130's genuinely-unique, non-conflicting deltas onto `dev`.

## Strategy

`dev` @ `0e4904f` (post-#140/#150) is the **canonical baseline**: it already registers `glm_moe_dsa`
(type 5), ships its own DSA/MTP-integrated `SyncGlmMoeDsaMoEBlock`, the native FP8 e4m3 block-scale
**dequant-on-copy** path, DSA indexer/IndexShare, and MTP spec-decode. PR #130 branched from an older
`dev` (`b33d5fa`) and re-implemented an overlapping-but-divergent GLM/FP8 stack. Per the written
reconciliation plan, we **canonicalize on `dev`** and salvage only #130's unique wanted deltas —
dropping everything spec-decode already provides.

Full auditable triage (git cherry, range-diff, per-commit verdicts, and every deviation with evidence)
is in **`docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md`** (in this PR).

## What landed (net wanted deltas) — 4 files

| File | Source | What |
|---|---|---|
| `moe_infinity/utils/fp8.py` | #130 `707cc06` (subset) | Append `dequant_fp8_state_dict` + `stack_expert_scales` (+`re`/`typing`/`EXPERT_SCALE_KEY_RE`). Byte-identical to #130's tested helpers; dev's `dequant_fp8_blockwise` untouched. |
| `core/model/model_topology.cpp` | #130 `b5a015a` | Coalesce sparse-expert partition reads into one sequential bulk read per file (`struct TensorPlacement` + `posix_fadvise(SEQUENTIAL)`); fixes multi-day cold-cache store reloads. clang-format clean. |
| `tests/python/unit/test_glm_moe_dsa.py` | #130 `9b49f43` | Reconciled unit suite — the **only** coverage for the two new fp8 helpers. Two guards adapt it to dev (below). |
| `docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md` | new | Evidence + verdicts + deviations. |

## Per-commit verdicts (9 unique #130 commits)

`git cherry -v origin/feat/dflash-spec-decode origin/feat/glm-5.2-fp8-support` → 9 `+` commits:

| SHA | Verdict | Why |
|---|---|---|
| `707cc06` fp8 utils | **PARTIAL-KEEP** | Keep only `dequant_fp8_state_dict` + `stack_expert_scales`; dev owns `dequant_fp8_blockwise` (`d797138`). |
| `038c149` register | **DROP** | dev already registers `glmmoedsa` (`constants.py`, `hf_config.py`). |
| `98a5a39` block | **DROP (alt)** | dev owns `SyncGlmMoeDsaMoEBlock` (`b02c3bd`); #130's is a divergent alternative. |
| `c8ae160` on-GPU dequant | **DROP (alt)** | Canonical = dev's dequant-on-copy (`3167500`+`c16cb46`, Option A==B parity). |
| `b5a015a` partition-read perf | **KEEP** | `model_topology.cpp` untouched by spec-decode; self-contained. |
| `187048c` offload wiring | **DROP (alt)** | Superseded by dev's `5b2c2b6`. |
| `9b49f43` tests+docs | **KEEP (reconcile)** | Unit suite is unique; README row/note + registry assertion already on dev. |
| `3dc4e72` NVTX | **DROP (build-breaking as shipped)** | See deviation 3 — vendored header breaks the build; superseded by `ba56518`. |
| `3444ed9` smoke e2e | **DROP (covered)** | dev's `test_glm_smoke.py` already has the `MOE_GLM_SMOKE` gate. |

## Divergence summary (spec-decode/dev vs #130)

- **Block API:** dev's `SyncGlmMoeDsaMoEBlock` delegates routing to HF (`_route` → `_hf_route_tokens`)
  and integrates DSA/MTP; #130's inlines `route_tokens_to_experts` + nvtx annotations and assumes an
  always-present executor. **Kept dev's.**
- **FP8 path:** dev keeps routed experts FP8 in-store and dequantizes **on-copy** in the native
  dispatcher (`c16cb46`); #130 dequantizes **on-GPU after fetch** in a competing C++ path (touches the
  same `expert_dispatcher/expert_module/py_archer_prefetch`). **Kept dev's; #130's C++ dropped.**
- **DSA attention:** dev ships a dedicated `glm_dsa.py` + DSA indexer/IndexShare; #130 has none.

## Deviations from the plan (dev evolved past plan assumptions — all evidence-backed)

1. **Task 4.2 (README row/note + registry assertion) — SKIPPED, already on `dev`.** README already has
   a GLM-5.2 table row + a more detailed note + a full usage section; `test_model_registry.py` lines
   29-30 already assert `glmmoedsa`. Re-adding would duplicate (violates the no-dup rule). `README.md`
   and `test_model_registry.py` left untouched.
2. **`test_glm_routing_parity_vs_hf` — GUARDED.** It calls `sync.route_tokens_to_experts(...)` (#130's
   block API); dev's canonical block has no such method (`hasattr == False`) and this env ships
   `transformers.glm_moe_dsa`, so verbatim would **AttributeError**. Added a hermetic class-level
   `hasattr` guard that skips cleanly (parity is already covered by
   `test_glm_routing.py::test_routing_parity`, which uses `block._route`).
3. **NVTX salvage (`3dc4e72`) — DROPPED with compile-probe evidence.** The partially-vendored
   `nvtx3.hpp` (only `nvtx3.hpp`, not its `#include "nvToolsExt.h"` sibling) **shadows** the working
   system header (dev already puts `core/include` first on the include path) and **fails to compile**
   on this CUDA-13.1 host: `P1 (vendored wins) → fatal error: nvToolsExt.h: No such file or directory`;
   `P2 (dev current) → OK`. dev already solves CUDA≥12.9 NVTX header-only via `ba56518` (does not link
   `libnvToolsExt`); #130's setup.py hunk would reverse that and re-add fp4-kernel/CUDA-stub/
   `python_requires>=3.8` regressions if blind-applied. Landed neither file. Reviewer options in the
   decision log.

## Verification

- **Unit suite (required):** `test_glm_moe_dsa.py` + `test_model_registry.py` → **15 passed, 2 skipped,
  0 failed** (stable ×3). Skips: `_store` conftest-stubbed (cpp parity) and the routing-parity guard.
- **fp8 helpers:** import GREEN; `dequant_fp8_blockwise` defined exactly once; ruff check+format clean.
- **model_topology.cpp:** clean `git apply --3way` (no conflict markers); clang-format 0 violations;
  a faithful port of the already-compiled `b5a015a`. `-fsyntax-only` reached the file's own body with
  no syntax errors (only a pre-existing env `torch/extension.h` resolution issue). Full CUDA
  `pip install -e .` build **deferred to CI** (plan-sanctioned; `_store` is not built in this env).
- **LSP diagnostics:** clean on `fp8.py` and `test_glm_moe_dsa.py` (no errors/warnings). `clangd` not
  installed here → C++ relied on clang-format + clean apply.
- **No-duplicate checks:** one `SyncGlmMoeDsaMoEBlock`, one `glm_moe_dsa` module, one each of
  `dequant_fp8_blockwise`/`dequant_fp8_state_dict`/`stack_expert_scales`; all DROP-list files
  (`glm_moe_dsa.py`, `model_offload.py`, `constants.py`, `hf_config.py`, C++ `parallel/`+
  `py_archer_prefetch.cpp`, `test_glm_smoke.py`, `setup.py`, `README.md`, `test_model_registry.py`)
  **unmodified** vs `origin/dev`.

## Known pre-existing issue (not introduced here)

`tests/python/unit/test_glm_routing.py::test_routing_parity` (dev-owned, byte-identical to `origin/dev`)
is a **flaky** test: it passes in isolation / the dev-only batch / the required suite, but under one
multi-file ordering it nondeterministically produces all-`NaN` routing (`1 failed` then `39 passed` on
identical re-runs). Our guard is hermetic (skips before constructing any model), so this branch
contributes no RNG/side-effects — the flake is dev-side. Out of scope to fix here; recommend hardening
that test separately.

## `git diff --stat origin/dev...HEAD`

```
 core/model/model_topology.cpp                                        | 112 +++++-----
 docs/superpowers/plans/2026-08-14-glm-5.2-reconciliation.decision-log.md | 246 +++++++++++
 moe_infinity/utils/fp8.py                                            |  62 ++++
 tests/python/unit/test_glm_moe_dsa.py                                | 228 +++++++++
 4 files changed, 591 insertions(+), 57 deletions(-)
```
