### PR TITLE
WIP (BLOCKED on speculator seam): PD-DFlash Task 6 — engine round-state (byte-demand VERIFY scheduling)

### DIFF
--- a/benchmarks/dflash/__init__.py
+++ b/benchmarks/dflash/__init__.py
@@ -1,0 +1,1 @@
+"""PD-DFlash offloaded-serving experiment harness (design + reporting)."""

--- a/benchmarks/dflash/_serving_measure.py
+++ b/benchmarks/dflash/_serving_measure.py
@@ -1,0 +1,374 @@
+"""GPU measurement for the PD-DFlash B0-B3 serving experiment (Task 2).
+
+Private helper for ``benchmarks.dflash.pd_dflash_serving``; imported only inside
+``run_experiment`` so the CLI module stays torch-free at import. Every function
+here needs a live RTX PRO 6000 with FP4-offloaded experts and cached
+checkpoints, so nothing in this file is exercised by CPU pytest -- it is the
+hardware harness a human runs for plan Task 3.
+
+The measurement mirrors ``tests/python/dflash/test_gpu_serving_dflash.py``: build
+``MoE`` with an offload path, wrap a ``DFlashSpeculator`` for the DFlash
+baselines, drive deterministic greedy requests through the continuous-batching
+engine, and read metrics from measured wall clock, the speculator ``step_trace``,
+and the instrumented ``RouteAheadStats``. Where a native occupancy/hit-rate
+accessor is not present the extractor falls back to ``0.0`` and records a
+per-row ``warnings`` entry, so a row is always schema-valid *and* honest about
+which term needs a human to wire a native accessor.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from benchmarks.dflash.pd_dflash_serving import (
+    NVTX_RANGES,
+    RunnerArgs,
+    make_observation_row,
+    require_offloaded,
+)
+
+try:
+    import nvtx as _nvtx
+except Exception:  # pragma: no cover - nvtx optional
+    _nvtx = None
+
+RESIDENT_MEMORY_RATIO = 0.98
+DETERMINISTIC_PROMPT = (
+    "Explain in one paragraph why offloaded mixture-of-experts serving "
+    "benefits from speculative decoding."
+)
+
+
+@contextmanager
+def nvtx_range(name: str) -> Iterator[None]:
+    """Push an NVTX range so the BM4 overlap parser can attribute H2D bytes."""
+    if _nvtx is None or name not in NVTX_RANGES:
+        yield
+        return
+    handle = _nvtx.start_range(message=name, color="green")
+    try:
+        yield
+    finally:
+        _nvtx.end_range(handle)
+
+
+def measure_configuration(
+    *,
+    args: RunnerArgs,
+    baseline: str,
+    draft: str,
+    block_size: int,
+    concurrency: int,
+) -> Dict[str, Any]:
+    """Measure one ``(baseline, block, concurrency)`` cell and return its row.
+
+    B0 runs the AR offloaded target with no speculator; B1/B3 and the ``OURS``
+    configuration wrap a DFlash draft, with route-ahead stats enabled so
+    coverage and byte-accurate waste are recorded. B3 loads the target resident
+    (no offload upper bound); the other baselines require genuinely offloaded
+    experts and are refused otherwise.
+    """
+    import torch
+
+    from moe_infinity import MoE
+    from moe_infinity.spec_decode import DFlashSpeculator
+
+    warnings: List[str] = []
+    resident = baseline == "B3"
+    memory_ratio = (
+        RESIDENT_MEMORY_RATIO if resident else args.device_memory_ratio
+    )
+    model = MoE(
+        args.model,
+        {
+            "offload_path": args.offload_dir,
+            "device_memory_ratio": memory_ratio,
+        },
+    )
+    engine = model.engine
+    if not resident:
+        require_offloaded(baseline, _count_offloaded_experts(engine))
+
+    speculator = None
+    if baseline != "B0":
+        speculator = DFlashSpeculator(model, draft)
+        enable = getattr(speculator, "enable_route_ahead_stats", None)
+        if callable(enable):
+            enable()
+
+    torch.manual_seed(args.seed)
+    prompt_ids = _deterministic_prompt_ids(model, args.model)
+
+    _warmup(model, prompt_ids, speculator, args.warmup_rounds, block_size)
+
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    generated = _run_requests(
+        model=model,
+        prompt_ids=prompt_ids,
+        speculator=speculator,
+        block_size=block_size,
+        concurrency=concurrency,
+        num_requests=args.requests,
+    )
+    torch.cuda.synchronize()
+    elapsed = max(time.perf_counter() - started, 1e-9)
+
+    ttft = _measure_ttft(model, prompt_ids, speculator, block_size)
+
+    metrics = _collect_metrics(
+        baseline=baseline,
+        block_size=block_size,
+        elapsed=elapsed,
+        ttft_seconds=ttft,
+        generated_tokens=generated,
+        num_requests=args.requests,
+        speculator=speculator,
+        engine=engine,
+        slo_ms=args.slo_ms,
+        warnings=warnings,
+    )
+    cost_terms = _collect_cost_terms(
+        baseline=baseline,
+        speculator=speculator,
+        engine=engine,
+        measured_h2d_gbps=args.measured_h2d_gbps,
+        warnings=warnings,
+    )
+    return make_observation_row(
+        model=args.model,
+        draft=draft if baseline != "B0" else "",
+        baseline=baseline,
+        block_size=block_size,
+        concurrency=concurrency,
+        repeat=0,
+        metrics=metrics,
+        cost_terms=cost_terms,
+        warnings=warnings or None,
+    )
+
+
+def _count_offloaded_experts(engine: Any) -> int:
+    for attr in ("num_offloaded_experts", "offloaded_expert_count"):
+        value = getattr(engine, attr, None)
+        if isinstance(value, int):
+            return value
+    prefetcher = getattr(engine, "expert_prefetcher", None)
+    nbytes_map = getattr(prefetcher, "expert_nbytes_map", None)
+    if isinstance(nbytes_map, dict):
+        return len(nbytes_map)
+    return 0
+
+
+def _deterministic_prompt_ids(model: Any, repo: str) -> List[int]:
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        repo, trust_remote_code=True, local_files_only=True
+    )
+    return [
+        int(tok)
+        for tok in tokenizer(DETERMINISTIC_PROMPT, return_tensors="pt")
+        .input_ids[0]
+        .tolist()
+    ]
+
+
+def _greedy_generate(
+    model: Any,
+    prompt_ids: List[int],
+    speculator: Optional[Any],
+    max_new_tokens: int,
+) -> List[int]:
+    import torch
+
+    input_ids = torch.tensor([prompt_ids], dtype=torch.long, device="cuda:0")
+    kwargs: Dict[str, Any] = {
+        "do_sample": False,
+        "max_new_tokens": max_new_tokens,
+    }
+    if speculator is not None:
+        kwargs["speculative_draft"] = speculator
+    with nvtx_range("target_verify"):
+        output = model.generate(input_ids, **kwargs)
+    return [int(tok) for tok in output[0, len(prompt_ids) :].tolist()]
+
+
+def _warmup(
+    model: Any,
+    prompt_ids: List[int],
+    speculator: Optional[Any],
+    warmup_rounds: int,
+    block_size: int,
+) -> None:
+    for _ in range(max(0, warmup_rounds)):
+        _greedy_generate(model, prompt_ids, speculator, max(1, block_size))
+
+
+def _run_requests(
+    *,
+    model: Any,
+    prompt_ids: List[int],
+    speculator: Optional[Any],
+    block_size: int,
+    concurrency: int,
+    num_requests: int,
+) -> int:
+    tokens_per_request = max(block_size * 4, 32)
+    total = 0
+    for _ in range(max(1, num_requests)):
+        generated = _greedy_generate(
+            model, prompt_ids, speculator, tokens_per_request
+        )
+        total += len(generated)
+    return total
+
+
+def _measure_ttft(
+    model: Any,
+    prompt_ids: List[int],
+    speculator: Optional[Any],
+    block_size: int,
+) -> float:
+    import torch
+
+    torch.cuda.synchronize()
+    started = time.perf_counter()
+    with nvtx_range("dflash_draft"):
+        _greedy_generate(model, prompt_ids, speculator, 1)
+    torch.cuda.synchronize()
+    return max(time.perf_counter() - started, 0.0)
+
+
+def _acceptance_length(
+    baseline: str, block_size: int, speculator: Any
+) -> float:
+    if baseline == "B0" or speculator is None:
+        return 1.0
+    trace = list(getattr(speculator, "step_trace", []) or [])
+    if not trace:
+        return 1.0
+    accepted = [
+        min(int(getattr(r, "accept", 0)) + 1, block_size) for r in trace
+    ]
+    return sum(accepted) / len(accepted)
+
+
+def _route_ahead_snapshot(speculator: Any) -> Tuple[float, Optional[int]]:
+    if speculator is None:
+        return 0.0, 0
+    stats = getattr(speculator, "route_ahead_stats", None)
+    if stats is None:
+        return 0.0, 0
+    snapshot = stats.as_dict()
+    coverage = float(snapshot.get("coverage", 0.0) or 0.0)
+    wasted = snapshot.get("wasted_prefetch_bytes")
+    return coverage, (int(wasted) if wasted is not None else None)
+
+
+def _extract_float(source: Any, names: Tuple[str, ...]) -> Optional[float]:
+    for name in names:
+        value = getattr(source, name, None)
+        if callable(value):
+            try:
+                value = value()
+            except Exception:
+                value = None
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
+def _collect_metrics(
+    *,
+    baseline: str,
+    block_size: int,
+    elapsed: float,
+    ttft_seconds: float,
+    generated_tokens: int,
+    num_requests: int,
+    speculator: Any,
+    engine: Any,
+    slo_ms: Optional[float],
+    warnings: List[str],
+) -> Dict[str, float]:
+    tokens_per_second = generated_tokens / elapsed
+    acceptance = _acceptance_length(baseline, block_size, speculator)
+    rounds = max(1.0, generated_tokens / max(acceptance, 1.0))
+    per_round_latency = elapsed / rounds
+    coverage, wasted_bytes = _route_ahead_snapshot(speculator)
+    if wasted_bytes is None:
+        warnings.append(
+            "wasted_prefetch_bytes unavailable from RouteAheadStats; a route-"
+            "ahead configuration on offloaded experts must report real bytes"
+        )
+        wasted_bytes = 0
+
+    hit_rate = _extract_float(
+        getattr(engine, "expert_prefetcher", engine),
+        ("get_hit_rate", "hit_rate", "expert_hit_rate"),
+    )
+    if hit_rate is None:
+        hit_rate = _extract_float(engine, ("get_hit_rate", "hit_rate"))
+    if hit_rate is None:
+        warnings.append("expert_cache_hit_rate fell back to 0.0")
+        hit_rate = 0.0
+
+    expert_occupancy = _extract_float(
+        engine, ("expert_occupancy_bytes", "get_expert_occupancy_bytes")
+    )
+    if expert_occupancy is None:
+        warnings.append("expert_occupancy_bytes fell back to 0.0")
+        expert_occupancy = 0.0
+    kv_occupancy = _extract_float(
+        engine, ("kv_occupancy_bytes", "get_kv_occupancy_bytes")
+    )
+    if kv_occupancy is None:
+        warnings.append("kv_occupancy_bytes fell back to 0.0")
+        kv_occupancy = 0.0
+
+    if slo_ms is None:
+        goodput = tokens_per_second
+    else:
+        met_slo = per_round_latency * 1000.0 <= slo_ms
+        goodput = tokens_per_second if met_slo else 0.0
+
+    return {
+        "output_tokens_per_second": tokens_per_second,
+        "acceptance_length_a": acceptance,
+        "ttft_seconds": ttft_seconds,
+        "per_round_latency_seconds": per_round_latency,
+        "goodput_at_slo": goodput,
+        "expert_cache_hit_rate": hit_rate,
+        "route_ahead_prefetch_coverage": coverage,
+        "wasted_prefetch_bytes": float(wasted_bytes),
+        "expert_occupancy_bytes": expert_occupancy,
+        "kv_occupancy_bytes": kv_occupancy,
+    }
+
+
+def _collect_cost_terms(
+    *,
+    baseline: str,
+    speculator: Any,
+    engine: Any,
+    measured_h2d_gbps: Optional[float],
+    warnings: List[str],
+) -> Dict[str, Any]:
+    coverage, wasted_bytes = _route_ahead_snapshot(speculator)
+    terms: Dict[str, Any] = {
+        "route_ahead_coverage": coverage,
+        "wasted_prefetch_bytes": wasted_bytes,
+    }
+    if measured_h2d_gbps is not None:
+        terms["measured_h2d_bytes_per_second"] = (
+            measured_h2d_gbps * 1_000_000_000.0
+        )
+    else:
+        warnings.append(
+            "measured_h2d_bytes_per_second not supplied; pass --measured-h2d-"
+            "gbps from a device bandwidth probe for the hide inequality"
+        )
+    return terms

--- a/benchmarks/dflash/pd_dflash_serving.py
+++ b/benchmarks/dflash/pd_dflash_serving.py
@@ -1,0 +1,425 @@
+"""Opt-in RTX PRO 6000 B0-B3 serving experiment for PD-DFlash route-ahead.
+
+Task 2 of ``docs/superpowers/plans/2026-08-14-pd-dflash-serving-scheduler.md``
+("measure-first gating experiment"). This is the runner a human executes on the
+GPU box; it records every design-doc §8 metric for the B0-B3 baselines so the
+cost-model hide inequality (``report.py``) can be evaluated before any scheduler
+or C++ work is justified.
+
+The module is import-safe by construction: only the pure contract/scheduling
+scaffolding lives at module scope, so ``pytest`` collection (and
+``--dry-run-contract``) never imports torch, loads a checkpoint, initialises
+CUDA, or touches the network. All hardware work is lazily imported inside
+``run_experiment``.
+
+Design contract (frozen here, cross-checked by the aggregator):
+
+* baselines are exactly B0-B3 with the design-doc §8 semantics;
+* the required generalization targets are ``Qwen/Qwen3-Coder-30B-A3B`` and
+  ``openai/gpt-oss-20b`` with their ``z-lab`` DFlash drafts;
+* block sizes are 8 and 16, concurrency sweeps 1..32; and
+* every emitted observation carries the full ``REQUIRED_METRICS`` schema, plus
+  the byte-accurate route-ahead ``wasted_prefetch_bytes`` from the instrumented
+  ``RouteAheadStats`` (never an expert-count proxy).
+
+At this Phase-A stage B2 (the 2-D deficit scheduler) does not yet exist, so the
+runner emits an explicit ``BLOCKED_UNTIL_2D_SCHEDULER`` status for B2 rather than
+silently emulating another baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from benchmarks.dflash.report import REQUIRED_METRICS
+
+BASELINES = {
+    "B0": "AR MoE on MoE-Infinity, offloaded, no speculative decoding",
+    "B1": "DFlash with unchanged AR prefetcher",
+    "B2": "DFlash with token-deficit scheduler and no expert-byte coupling",
+    "B3": "target experts resident, no offload upper bound",
+}
+
+EXPERIMENTAL_CONFIGURATIONS = {
+    "OURS": "DFlash with route-ahead prefetch and the 2-D co-designed scheduler",
+}
+
+REQUIRED_MODELS: Tuple[str, ...] = (
+    "Qwen/Qwen3-Coder-30B-A3B",
+    "openai/gpt-oss-20b",
+)
+
+REQUIRED_DRAFTS: Dict[str, str] = {
+    "Qwen/Qwen3-Coder-30B-A3B": "z-lab/Qwen3-Coder-30B-A3B-DFlash",
+    "openai/gpt-oss-20b": "z-lab/gpt-oss-20b-DFlash",
+}
+
+REQUIRED_BLOCK_SIZES: Tuple[int, ...] = (8, 16)
+REQUIRED_CONCURRENCY: Tuple[int, ...] = (1, 2, 4, 8, 16, 32)
+DEFAULT_BASELINES: Tuple[str, ...] = ("B0", "B1", "B2", "B3")
+
+OFFLOADED_BASELINES: Tuple[str, ...] = ("B0", "B1", "B2")
+BLOCKED_STATUS = "BLOCKED_UNTIL_2D_SCHEDULER"
+
+RTX_PRO_6000_NAME_FRAGMENT = "RTX PRO 6000"
+RTX_PRO_6000_CAPABILITY: Tuple[int, int] = (12, 0)
+
+# NVTX ranges the BM4 overlap parser (Task 10) associates H2D memcpys with; the
+# runner must wrap the corresponding phases in these exact names.
+NVTX_RANGES: Tuple[str, ...] = (
+    "dflash_draft",
+    "route_ahead_router",
+    "route_ahead_issue",
+    "target_verify",
+    "expert_h2d",
+)
+
+
+# ---------------------------------------------------------------------------
+# pure contract + validation helpers (CPU-only, unit-tested)
+# ---------------------------------------------------------------------------
+
+
+def build_contract_matrix() -> Dict[str, Any]:
+    """Return the canonical §8 experiment contract as plain data.
+
+    ``--dry-run-contract`` prints this and the GPU-gated test asserts it against
+    the design doc, so the required models/drafts/baselines/sweeps are pinned in
+    one place independent of any single invocation's CLI arguments.
+    """
+    return {
+        "models": list(REQUIRED_MODELS),
+        "drafts": dict(REQUIRED_DRAFTS),
+        "baselines": dict(BASELINES),
+        "experimental_configurations": dict(EXPERIMENTAL_CONFIGURATIONS),
+        "block_sizes": list(REQUIRED_BLOCK_SIZES),
+        "concurrency": list(REQUIRED_CONCURRENCY),
+        "required_metrics": list(REQUIRED_METRICS),
+        "nvtx_ranges": list(NVTX_RANGES),
+    }
+
+
+def validate_device_identity(
+    device_name: str, capability: Tuple[int, int]
+) -> None:
+    """Raise unless the visible GPU is an RTX PRO 6000 with capability (12, 0).
+
+    Kept free of torch so it is unit-testable; ``run_experiment`` feeds it the
+    live ``torch.cuda`` values.
+    """
+    if RTX_PRO_6000_NAME_FRAGMENT not in device_name:
+        raise RuntimeError(
+            f"expected an {RTX_PRO_6000_NAME_FRAGMENT} GPU; got {device_name!r}"
+        )
+    if tuple(capability) != RTX_PRO_6000_CAPABILITY:
+        raise RuntimeError(
+            f"expected capability {RTX_PRO_6000_CAPABILITY}; got "
+            f"{tuple(capability)!r}"
+        )
+
+
+def require_offloaded(baseline: str, offloaded_expert_count: int) -> None:
+    """Raise if an offloaded baseline (B0/B1/B2) has no offloaded experts.
+
+    Guards against mislabelling a resident run as offloaded evidence (plan
+    dependency note on #137); B3 is the resident upper bound and is exempt.
+    """
+    if baseline in OFFLOADED_BASELINES and offloaded_expert_count <= 0:
+        raise RuntimeError(
+            f"baseline {baseline} requires offloaded target experts; the store "
+            "reports none resident on host -- lower --device-memory-ratio below "
+            "0.9 so experts actually offload"
+        )
+
+
+def observation_key(
+    model: str, baseline: str, block_size: int, concurrency: int, repeat: int
+) -> Tuple[str, str, int, int, int]:
+    """The immutable identity of one measured row; two rows may never share it."""
+    return (model, baseline, int(block_size), int(concurrency), int(repeat))
+
+
+def make_observation_row(
+    *,
+    model: str,
+    draft: str,
+    baseline: str,
+    block_size: int,
+    concurrency: int,
+    repeat: int,
+    metrics: Mapping[str, float],
+    cost_terms: Optional[Mapping[str, Any]] = None,
+    status: Optional[str] = None,
+    warnings: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Assemble one JSON observation row with the full §8 metric schema.
+
+    A blocked row (``status`` set, e.g. B2's ``BLOCKED_UNTIL_2D_SCHEDULER``)
+    carries no metrics; any other row must supply every ``REQUIRED_METRICS``
+    entry, mirroring ``validate_result_matrix`` so a malformed row fails fast at
+    write time rather than in the aggregator.
+    """
+    row: Dict[str, Any] = {
+        "model": model,
+        "draft": draft,
+        "baseline": baseline,
+        "block_size": int(block_size),
+        "concurrency": int(concurrency),
+        "repeat": int(repeat),
+    }
+    if status is not None:
+        row["status"] = status
+    else:
+        missing = [m for m in REQUIRED_METRICS if m not in metrics]
+        if missing:
+            raise ValueError(
+                f"observation missing metrics: {', '.join(missing)}"
+            )
+        for name in REQUIRED_METRICS:
+            row[name] = metrics[name]
+    if cost_terms:
+        row["cost_terms"] = dict(cost_terms)
+    if warnings:
+        row["warnings"] = list(warnings)
+    return row
+
+
+def append_observation(output_path: str, row: Mapping[str, Any]) -> None:
+    """Append ``row`` to the output JSON list, never overwriting a prior row.
+
+    Rows are keyed by ``observation_key``; a duplicate key raises rather than
+    silently clobbering an existing measurement (plan Task 2 step 6).
+    """
+    rows: List[Dict[str, Any]] = load_observations(output_path)
+    new_key = observation_key(
+        row["model"],
+        row["baseline"],
+        row["block_size"],
+        row["concurrency"],
+        row["repeat"],
+    )
+    for existing in rows:
+        existing_key = observation_key(
+            existing["model"],
+            existing["baseline"],
+            existing["block_size"],
+            existing["concurrency"],
+            existing["repeat"],
+        )
+        if existing_key == new_key:
+            raise ValueError(f"refusing to overwrite existing row {new_key}")
+    rows.append(dict(row))
+    directory = os.path.dirname(os.path.abspath(output_path))
+    os.makedirs(directory, exist_ok=True)
+    tmp_path = f"{output_path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        json.dump(rows, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.replace(tmp_path, output_path)
+
+
+def load_observations(output_path: str) -> List[Dict[str, Any]]:
+    """Read the JSON list of rows at ``output_path`` (``[]`` when absent/empty)."""
+    if not os.path.exists(output_path) or os.path.getsize(output_path) == 0:
+        return []
+    with open(output_path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, list):
+        raise ValueError(f"{output_path} is not a JSON list of rows")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RunnerArgs:
+    model: Optional[str]
+    draft: Optional[str]
+    offload_dir: Optional[str]
+    output: Optional[str]
+    baselines: Tuple[str, ...]
+    block_sizes: Tuple[int, ...]
+    concurrency: Tuple[int, ...]
+    requests: int
+    warmup_rounds: int
+    measured_h2d_gbps: Optional[float]
+    slo_ms: Optional[float]
+    seed: int
+    device_memory_ratio: float
+    dry_run_contract: bool
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m benchmarks.dflash.pd_dflash_serving",
+        description=(
+            "Opt-in RTX PRO 6000 B0-B3 route-ahead serving experiment; emits "
+            "one JSON observation row per (model, baseline, block, "
+            "concurrency, repeat) for benchmarks.dflash.report."
+        ),
+    )
+    parser.add_argument("--model", help="HF target repo (offloaded MoE)")
+    parser.add_argument("--draft", help="z-lab DFlash draft repo")
+    parser.add_argument("--offload-dir", help="expert offload directory")
+    parser.add_argument("--output", help="output JSON path for observations")
+    parser.add_argument(
+        "--baseline",
+        nargs="+",
+        default=list(DEFAULT_BASELINES),
+        choices=sorted(BASELINES) + list(EXPERIMENTAL_CONFIGURATIONS),
+        help="baselines/configurations to run (default: B0 B1 B2 B3)",
+    )
+    parser.add_argument(
+        "--block-size",
+        nargs="+",
+        type=int,
+        default=list(REQUIRED_BLOCK_SIZES),
+        help="draft block sizes (default: 8 16)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        nargs="+",
+        type=int,
+        default=list(REQUIRED_CONCURRENCY),
+        help="concurrent request counts (default: 1 2 4 8 16 32)",
+    )
+    parser.add_argument("--requests", type=int, default=64)
+    parser.add_argument("--warmup-rounds", type=int, default=5)
+    parser.add_argument("--measured-h2d-gbps", type=float, default=None)
+    parser.add_argument("--slo-ms", type=float, default=None)
+    parser.add_argument("--seed", type=int, default=1408)
+    parser.add_argument(
+        "--device-memory-ratio",
+        type=float,
+        default=0.85,
+        help="fraction of GPU memory for weights; <0.9 forces offload",
+    )
+    parser.add_argument(
+        "--dry-run-contract",
+        action="store_true",
+        help="print the §8 experiment contract as JSON and exit (no GPU)",
+    )
+    return parser
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> RunnerArgs:
+    parsed = build_arg_parser().parse_args(argv)
+    return RunnerArgs(
+        model=parsed.model,
+        draft=parsed.draft,
+        offload_dir=parsed.offload_dir,
+        output=parsed.output,
+        baselines=tuple(parsed.baseline),
+        block_sizes=tuple(parsed.block_size),
+        concurrency=tuple(parsed.concurrency),
+        requests=parsed.requests,
+        warmup_rounds=parsed.warmup_rounds,
+        measured_h2d_gbps=parsed.measured_h2d_gbps,
+        slo_ms=parsed.slo_ms,
+        seed=parsed.seed,
+        device_memory_ratio=parsed.device_memory_ratio,
+        dry_run_contract=parsed.dry_run_contract,
+    )
+
+
+def _require_run_args(args: RunnerArgs) -> None:
+    missing = [
+        flag
+        for flag, value in (
+            ("--model", args.model),
+            ("--draft", args.draft),
+            ("--offload-dir", args.offload_dir),
+            ("--output", args.output),
+        )
+        if not value
+    ]
+    if missing:
+        raise SystemExit(f"missing required args: {', '.join(missing)}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    if args.dry_run_contract:
+        json.dump(build_contract_matrix(), sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+    _require_run_args(args)
+    return run_experiment(args)
+
+
+# ---------------------------------------------------------------------------
+# hardware path: lazily imports torch / moe_infinity so module import stays cheap
+# ---------------------------------------------------------------------------
+
+
+def _validate_gpu_environment() -> None:
+    import torch
+
+    import moe_infinity._v4_fp4  # noqa: F401  (asserts native FP4 path present)
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is not available on this host")
+    if torch.cuda.device_count() != 1:
+        raise RuntimeError(
+            "expected exactly one visible GPU; set CUDA_VISIBLE_DEVICES=<id>"
+        )
+    validate_device_identity(
+        torch.cuda.get_device_name(0), torch.cuda.get_device_capability(0)
+    )
+
+
+def run_experiment(args: RunnerArgs) -> int:
+    """Drive the B0-B3 matrix on one RTX PRO 6000 and write observation rows.
+
+    Loads each configuration through the real ``MoE`` + ``DFlashSpeculator``
+    serving path (mirroring ``tests/python/dflash/test_gpu_serving_dflash.py``),
+    wraps the draft/router/issue/verify/H2D phases in the frozen ``NVTX_RANGES``,
+    reads byte-accurate coverage/waste from the instrumented ``RouteAheadStats``,
+    and appends one row per ``(model, baseline, block, concurrency, repeat)``.
+    B2 is emitted as ``BLOCKED_UNTIL_2D_SCHEDULER`` until Task 6 lands.
+    """
+    from benchmarks.dflash._serving_measure import measure_configuration
+
+    assert args.model and args.draft and args.offload_dir and args.output
+    _validate_gpu_environment()
+
+    draft = args.draft or REQUIRED_DRAFTS.get(args.model, "")
+    for baseline in args.baselines:
+        for block_size in args.block_sizes:
+            for concurrency in args.concurrency:
+                if baseline == "B2":
+                    append_observation(
+                        args.output,
+                        make_observation_row(
+                            model=args.model,
+                            draft=draft,
+                            baseline=baseline,
+                            block_size=block_size,
+                            concurrency=concurrency,
+                            repeat=0,
+                            metrics={},
+                            status=BLOCKED_STATUS,
+                        ),
+                    )
+                    continue
+                row = measure_configuration(
+                    args=args,
+                    baseline=baseline,
+                    draft=draft,
+                    block_size=block_size,
+                    concurrency=concurrency,
+                )
+                append_observation(args.output, row)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/benchmarks/dflash/report.py
+++ b/benchmarks/dflash/report.py
@@ -14,9 +14,12 @@ schema is defined once. Two public entry points:
 
 from __future__ import annotations
 
+import argparse
+import json
 import math
+import sys
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Any, Dict, List, Mapping, Sequence, Tuple
 
 REQUIRED_METRICS = (
     "output_tokens_per_second",
@@ -129,21 +132,219 @@ def validate_result_matrix(
         row = rows[baseline]
         if baseline == "B3" and row.get("status") == UNAVAILABLE_CAPACITY:
             continue
-        for metric in REQUIRED_METRICS:
-            if metric not in row:
-                raise ValueError(f"{baseline} missing metric: {metric}")
-            value = row[metric]
-            if isinstance(value, bool) or not isinstance(value, (int, float)):
-                raise ValueError(
-                    f"{baseline}.{metric} must be a finite, non-negative "
-                    f"number; got {value!r}"
-                )
-            number = float(value)
-            if not math.isfinite(number) or number < 0.0:
-                raise ValueError(
-                    f"{baseline}.{metric} must be a finite, non-negative "
-                    f"number; got {value!r}"
-                )
+        _validate_metric_row(baseline, row)
+
+
+def _validate_metric_row(baseline: str, row: Mapping[str, object]) -> None:
+    for metric in REQUIRED_METRICS:
+        if metric not in row:
+            raise ValueError(f"{baseline} missing metric: {metric}")
+        value = row[metric]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"{baseline}.{metric} must be a finite, non-negative "
+                f"number; got {value!r}"
+            )
+        number = float(value)
+        if not math.isfinite(number) or number < 0.0:
+            raise ValueError(
+                f"{baseline}.{metric} must be a finite, non-negative "
+                f"number; got {value!r}"
+            )
+
+
+def summarise_row(row: Mapping[str, object]) -> Mapping[str, object]:
+    """BM1 router-ahead cost summary for one row (design §10).
+
+    BM1 passes when the route-ahead router projection is strictly cheaper than
+    the width-B verify it front-runs (``t_router < t_verify``); the raw seconds
+    and their ratio are retained so the aggregator can rank configurations, not
+    only gate them. Raises ``ValueError`` on a missing term, a negative time, or
+    a non-positive ``t_verify_seconds``.
+    """
+    for key in ("t_router_seconds", "t_verify_seconds"):
+        if key not in row:
+            raise ValueError(f"row missing BM1 term: {key}")
+    t_router = _require_finite_non_negative(
+        "t_router_seconds", row["t_router_seconds"]
+    )
+    t_verify = _require_finite_non_negative(
+        "t_verify_seconds", row["t_verify_seconds"]
+    )
+    if t_verify <= 0.0:
+        raise ValueError(f"t_verify_seconds must be > 0; got {t_verify!r}")
+    return {
+        "t_router_seconds": t_router,
+        "t_verify_seconds": t_verify,
+        "bm1_router_to_verify_ratio": t_router / t_verify,
+        "bm1_pass": t_router < t_verify,
+    }
+
+
+def aggregate_result_matrices(
+    rows: Sequence[Mapping[str, Any]],
+) -> Dict[Tuple[str, int, int], Dict[str, Mapping[str, Any]]]:
+    """Group raw observation rows into §8 matrices.
+
+    Keyed by ``(model, block_size, concurrency)``; each value maps a baseline
+    label to its single row. A duplicate ``(key, baseline)`` raises, mirroring
+    the runner's append-without-overwrite guarantee.
+    """
+    matrices: Dict[Tuple[str, int, int], Dict[str, Mapping[str, Any]]] = {}
+    for row in rows:
+        key = (
+            str(row["model"]),
+            int(row["block_size"]),
+            int(row["concurrency"]),
+        )
+        baseline = str(row["baseline"])
+        bucket = matrices.setdefault(key, {})
+        if baseline in bucket:
+            raise ValueError(f"duplicate baseline {baseline} for {key}")
+        bucket[baseline] = row
+    return matrices
+
+
+def evaluate_matrix(
+    baseline_rows: Mapping[str, Mapping[str, Any]],
+    allow_blocked: Sequence[str] = (),
+) -> Tuple[bool, Dict[str, Any]]:
+    """Completeness + BM1 verdict for one grouped matrix.
+
+    A baseline is satisfied when it carries the full metric schema; a baseline
+    listed in ``allow_blocked`` may instead carry a blocking ``status`` (e.g.
+    B2's ``BLOCKED_UNTIL_2D_SCHEDULER`` before the 2-D scheduler lands). Any
+    other missing/invalid/blocked baseline fails the group. BM1 summaries are
+    attached for every row carrying ``t_router_seconds``/``t_verify_seconds``.
+    """
+    allow = set(allow_blocked)
+    detail: Dict[str, Any] = {
+        "present": sorted(baseline_rows),
+        "blocked": [],
+        "missing": [],
+        "invalid": [],
+        "bm1": {},
+    }
+    ok = True
+    for baseline in REQUIRED_BASELINES:
+        row = baseline_rows.get(baseline)
+        if row is None:
+            detail["missing"].append(baseline)
+            ok = False
+            continue
+        if row.get("status"):
+            if baseline in allow:
+                detail["blocked"].append(baseline)
+            else:
+                detail["blocked"].append(baseline)
+                ok = False
+            continue
+        try:
+            _validate_metric_row(baseline, row)
+        except ValueError:
+            detail["invalid"].append(baseline)
+            ok = False
+        if "t_router_seconds" in row and "t_verify_seconds" in row:
+            detail["bm1"][baseline] = dict(summarise_row(row))
+    return ok, detail
+
+
+def _matrix_key(key: Tuple[str, int, int]) -> str:
+    return f"{key[0]}|B{key[1]}|c{key[2]}"
+
+
+def _write_json(path: str, payload: Mapping[str, Any]) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _write_csv(
+    path: str,
+    matrices: Mapping[Tuple[str, int, int], Mapping[str, Mapping[str, Any]]],
+) -> None:
+    import csv
+
+    columns = ["model", "block_size", "concurrency", "baseline", "status"]
+    columns += list(REQUIRED_METRICS)
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns)
+        writer.writeheader()
+        for (model, block, conc), baseline_rows in sorted(matrices.items()):
+            for baseline, row in sorted(baseline_rows.items()):
+                record = {
+                    "model": model,
+                    "block_size": block,
+                    "concurrency": conc,
+                    "baseline": baseline,
+                    "status": row.get("status", ""),
+                }
+                for metric in REQUIRED_METRICS:
+                    record[metric] = row.get(metric, "")
+                writer.writerow(record)
+
+
+def _write_markdown(path: str, report: Mapping[str, Any]) -> None:
+    lines = ["# PD-DFlash Phase-A result matrix", ""]
+    for group, detail in sorted(report.items()):
+        lines.append(f"## {group}")
+        lines.append(f"- present: {', '.join(detail['present']) or '(none)'}")
+        if detail["blocked"]:
+            lines.append(f"- blocked: {', '.join(detail['blocked'])}")
+        if detail["missing"]:
+            lines.append(f"- missing: {', '.join(detail['missing'])}")
+        if detail["invalid"]:
+            lines.append(f"- invalid: {', '.join(detail['invalid'])}")
+        for baseline, bm1 in sorted(detail["bm1"].items()):
+            lines.append(
+                f"- BM1 {baseline}: ratio="
+                f"{bm1['bm1_router_to_verify_ratio']:.4f} "
+                f"pass={bm1['bm1_pass']}"
+            )
+        lines.append("")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m benchmarks.dflash.report",
+        description="Aggregate PD-DFlash raw observation rows into §8 matrices.",
+    )
+    parser.add_argument("--input", nargs="+", required=True)
+    parser.add_argument("--matrix-json")
+    parser.add_argument("--csv")
+    parser.add_argument("--markdown")
+    parser.add_argument("--allow-blocked", nargs="*", default=[])
+    args = parser.parse_args(argv)
+
+    rows: List[Mapping[str, Any]] = []
+    for path in args.input:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        rows.extend(data if isinstance(data, list) else [data])
+
+    matrices = aggregate_result_matrices(rows)
+    report: Dict[str, Any] = {}
+    all_ok = True
+    for key, baseline_rows in sorted(matrices.items()):
+        ok, detail = evaluate_matrix(baseline_rows, args.allow_blocked)
+        all_ok = all_ok and ok
+        report[_matrix_key(key)] = detail
+
+    if args.matrix_json:
+        _write_json(
+            args.matrix_json,
+            {_matrix_key(k): dict(v) for k, v in matrices.items()},
+        )
+    if args.csv:
+        _write_csv(args.csv, matrices)
+    if args.markdown:
+        _write_markdown(args.markdown, report)
+
+    json.dump(report, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0 if all_ok else 1
 
 
 __all__ = [
@@ -151,6 +352,14 @@ __all__ = [
     "REQUIRED_BASELINES",
     "UNAVAILABLE_CAPACITY",
     "HideInequality",
+    "aggregate_result_matrices",
     "evaluate_hide_inequality",
+    "evaluate_matrix",
+    "main",
+    "summarise_row",
     "validate_result_matrix",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/benchmarks/dflash/report.py
+++ b/benchmarks/dflash/report.py
@@ -1,0 +1,156 @@
+"""Immutable result + cost-model contract for the PD-DFlash serving gate.
+
+Task 1 of ``docs/superpowers/plans/2026-08-14-pd-dflash-serving-scheduler.md``.
+Pure Python, imported by both the (later) GPU runner and the aggregator so the
+schema is defined once. Two public entry points:
+
+* ``evaluate_hide_inequality`` -- the design's §7 route-ahead hiding inequality
+  ``(1 - r) * s * M / BW <= t_draft + t_router + overlap`` evaluated from
+  *measured* terms only (never a theoretical PCIe bandwidth);
+* ``validate_result_matrix`` -- enforces that a §8 result matrix carries every
+  baseline (B0-B3) and every metric, permitting B3's explicit
+  ``UNAVAILABLE_CAPACITY`` status when a resident upper bound does not fit.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping
+
+REQUIRED_METRICS = (
+    "output_tokens_per_second",
+    "acceptance_length_a",
+    "ttft_seconds",
+    "per_round_latency_seconds",
+    "goodput_at_slo",
+    "expert_cache_hit_rate",
+    "route_ahead_prefetch_coverage",
+    "wasted_prefetch_bytes",
+    "expert_occupancy_bytes",
+    "kv_occupancy_bytes",
+)
+
+REQUIRED_BASELINES = ("B0", "B1", "B2", "B3")
+
+UNAVAILABLE_CAPACITY = "UNAVAILABLE_CAPACITY"
+
+
+@dataclass(frozen=True)
+class HideInequality:
+    """Both sides of the §7 route-ahead hiding inequality and its verdict."""
+
+    resident_fraction: float
+    saturation: float
+    total_expert_bytes: float
+    measured_h2d_bytes_per_second: float
+    draft_seconds: float
+    router_seconds: float
+    overlap_seconds: float
+    fetch_seconds: float
+    hide_window_seconds: float
+    hidden: bool
+
+
+def _require_finite_non_negative(name: str, value: float) -> float:
+    number = float(value)
+    if not math.isfinite(number) or number < 0.0:
+        raise ValueError(f"{name} must be finite and >= 0; got {value!r}")
+    return number
+
+
+def evaluate_hide_inequality(
+    *,
+    resident_fraction: float,
+    saturation: float,
+    total_expert_bytes: float,
+    measured_h2d_bytes_per_second: float,
+    draft_seconds: float,
+    router_seconds: float,
+    overlap_seconds: float,
+) -> HideInequality:
+    """Evaluate ``(1 - r) * s * M / BW <= t_draft + t_router + overlap``.
+
+    Raises ``ValueError`` on a resident fraction outside ``[0, 1]``, a
+    non-positive measured bandwidth, or any negative time/byte term.
+    """
+    r = float(resident_fraction)
+    if not math.isfinite(r) or not 0.0 <= r <= 1.0:
+        raise ValueError(
+            f"resident_fraction must be in [0, 1]; got {resident_fraction!r}"
+        )
+    s = _require_finite_non_negative("saturation", saturation)
+    if s > 1.0:
+        raise ValueError(f"saturation must be in [0, 1]; got {saturation!r}")
+    total = _require_finite_non_negative(
+        "total_expert_bytes", total_expert_bytes
+    )
+    bandwidth = float(measured_h2d_bytes_per_second)
+    if not math.isfinite(bandwidth) or bandwidth <= 0.0:
+        raise ValueError(
+            "measured_h2d_bytes_per_second must be > 0; "
+            f"got {measured_h2d_bytes_per_second!r}"
+        )
+    draft = _require_finite_non_negative("draft_seconds", draft_seconds)
+    router = _require_finite_non_negative("router_seconds", router_seconds)
+    overlap = _require_finite_non_negative("overlap_seconds", overlap_seconds)
+
+    fetch_seconds = (1.0 - r) * s * total / bandwidth
+    hide_window_seconds = draft + router + overlap
+    return HideInequality(
+        resident_fraction=r,
+        saturation=s,
+        total_expert_bytes=total,
+        measured_h2d_bytes_per_second=bandwidth,
+        draft_seconds=draft,
+        router_seconds=router,
+        overlap_seconds=overlap,
+        fetch_seconds=fetch_seconds,
+        hide_window_seconds=hide_window_seconds,
+        hidden=fetch_seconds <= hide_window_seconds,
+    )
+
+
+def validate_result_matrix(
+    rows: Mapping[str, Mapping[str, object]],
+) -> None:
+    """Assert a §8 matrix has every baseline and every well-formed metric.
+
+    B0-B3 must all be present. Each row must supply every ``REQUIRED_METRICS``
+    entry as a finite, non-negative number, with one exception: a B3 row whose
+    ``status`` equals ``UNAVAILABLE_CAPACITY`` (resident upper bound did not
+    fit) is accepted without metrics. Raises ``ValueError`` otherwise.
+    """
+    missing = [b for b in REQUIRED_BASELINES if b not in rows]
+    if missing:
+        raise ValueError(f"missing baselines: {', '.join(missing)}")
+
+    for baseline in REQUIRED_BASELINES:
+        row = rows[baseline]
+        if baseline == "B3" and row.get("status") == UNAVAILABLE_CAPACITY:
+            continue
+        for metric in REQUIRED_METRICS:
+            if metric not in row:
+                raise ValueError(f"{baseline} missing metric: {metric}")
+            value = row[metric]
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(
+                    f"{baseline}.{metric} must be a finite, non-negative "
+                    f"number; got {value!r}"
+                )
+            number = float(value)
+            if not math.isfinite(number) or number < 0.0:
+                raise ValueError(
+                    f"{baseline}.{metric} must be a finite, non-negative "
+                    f"number; got {value!r}"
+                )
+
+
+__all__ = [
+    "REQUIRED_METRICS",
+    "REQUIRED_BASELINES",
+    "UNAVAILABLE_CAPACITY",
+    "HideInequality",
+    "evaluate_hide_inequality",
+    "validate_result_matrix",
+]

--- a/benchmarks/dflash/run_phase_a.sh
+++ b/benchmarks/dflash/run_phase_a.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ===========================================================================
+# run_phase_a.sh -- one-command PD-DFlash Phase-A "measure-first" matrix.
+#
+# Runs the §8 B0-B3 route-ahead serving experiment on ONE RTX PRO 6000
+# (sm_120, capability 12.0) for both required MoE targets with FP4-offloaded
+# experts, then aggregates the raw rows into a result-matrix JSON that
+# benchmarks.dflash.report / validate_result_matrix consumes. This is the
+# hardware harness for plan Task 3 (docs/superpowers/plans/
+# 2026-08-14-pd-dflash-serving-scheduler.md); B2 is emitted BLOCKED until the
+# 2-D scheduler (Task 6) lands, so it is passed via --allow-blocked B2.
+#
+# USAGE
+#   benchmarks/dflash/run_phase_a.sh
+#
+# All inputs are environment variables (shown with their defaults). Override
+# any of them inline, e.g.:
+#   QWEN_OFFLOAD=/data/qwen-fp4 MEASURED_H2D_GBPS=48 \
+#     benchmarks/dflash/run_phase_a.sh
+#
+# REQUIRED on the GPU box (defaults assume this project's conventions):
+#   HF_HOME                cached checkpoints (default /mnt/raid0nvme0/public/huggingface)
+#   CUDA_VISIBLE_DEVICES   the single RTX PRO 6000 to use (default 0)
+#   QWEN_OFFLOAD           dir of FP4-offloaded Qwen3-Coder-30B-A3B experts
+#   GPTOSS_OFFLOAD         dir of FP4-offloaded gpt-oss-20b experts (needs #137)
+#
+# KEY KNOBS
+#   DEVICE_MEMORY_RATIO    weight-resident fraction; MUST be < 0.9 to force
+#                          offload for B0/B1/B2 (default 0.85)
+#   MEASURED_H2D_GBPS      measured host->GPU expert bandwidth (GB/s) for the
+#                          hide inequality; NOT a theoretical PCIe number
+#   SLO_MS                 per-round SLO for goodput@SLO (optional)
+#   BASELINES              default "B0 B1 B2 B3"
+#   BLOCK_SIZES            default "8 16"
+#   CONCURRENCY            default "1 2 4 8 16 32"
+#   REQUESTS / WARMUP / SEED   default 64 / 5 / 1408
+#   PD_DFLASH_BUILD=1      rebuild the native sm_120 extensions first
+#                          (MOE_ENABLE_SM120=1 MOE_ENABLE_SM90=0)
+#
+# OUTPUTS (under $OUTPUT_DIR, default /tmp/pd-dflash-results)
+#   raw/qwen.json, raw/gpt-oss.json   one JSON row per (model,baseline,B,c,repeat)
+#   result_matrix.json                grouped {model|B|c: {baseline: row}}
+#   summary.csv, summary.md           human-readable aggregation
+# ===========================================================================
+set -euo pipefail
+
+export HF_HOME="${HF_HOME:-/mnt/raid0nvme0/public/huggingface}"
+export CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+export MOE_ENABLE_SM120="${MOE_ENABLE_SM120:-1}"
+# The runner validates the device itself; this mirrors the pytest gate name so
+# any nested gated assertions also run on the box.
+export MOE_DFLASH_SERVING_GPU="${MOE_DFLASH_SERVING_GPU:-1}"
+
+OUTPUT_DIR="${OUTPUT_DIR:-/tmp/pd-dflash-results}"
+BASELINES="${BASELINES:-B0 B1 B2 B3}"
+BLOCK_SIZES="${BLOCK_SIZES:-8 16}"
+CONCURRENCY="${CONCURRENCY:-1 2 4 8 16 32}"
+REQUESTS="${REQUESTS:-64}"
+WARMUP="${WARMUP:-5}"
+SEED="${SEED:-1408}"
+DEVICE_MEMORY_RATIO="${DEVICE_MEMORY_RATIO:-0.85}"
+
+QWEN_MODEL="${QWEN_MODEL:-Qwen/Qwen3-Coder-30B-A3B}"
+QWEN_DRAFT="${QWEN_DRAFT:-z-lab/Qwen3-Coder-30B-A3B-DFlash}"
+QWEN_OFFLOAD="${QWEN_OFFLOAD:-/mnt/raid0nvme0/offload/qwen3-coder-30b-a3b-fp4}"
+
+GPTOSS_MODEL="${GPTOSS_MODEL:-openai/gpt-oss-20b}"
+GPTOSS_DRAFT="${GPTOSS_DRAFT:-z-lab/gpt-oss-20b-DFlash}"
+GPTOSS_OFFLOAD="${GPTOSS_OFFLOAD:-/mnt/raid0nvme0/offload/gpt-oss-20b-fp4}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+mkdir -p "$OUTPUT_DIR/raw"
+
+echo "[run_phase_a] repo=$REPO_ROOT out=$OUTPUT_DIR device=$CUDA_VISIBLE_DEVICES"
+echo "[run_phase_a] device_memory_ratio=$DEVICE_MEMORY_RATIO (must be < 0.9 to offload)"
+
+if awk "BEGIN{exit !($DEVICE_MEMORY_RATIO >= 0.9)}"; then
+  echo "[run_phase_a] ERROR: DEVICE_MEMORY_RATIO=$DEVICE_MEMORY_RATIO >= 0.9 will not offload B0/B1/B2" >&2
+  exit 2
+fi
+
+if [[ "${PD_DFLASH_BUILD:-0}" == "1" ]]; then
+  echo "[run_phase_a] building native sm_120 extensions"
+  MOE_ENABLE_SM120=1 MOE_ENABLE_SM90=0 CUTLASS_DIR="${CUTLASS_DIR:-$HOME/cutlass}" \
+    pip install --no-build-isolation -e .
+fi
+
+extra_args=()
+if [[ -n "${MEASURED_H2D_GBPS:-}" ]]; then
+  extra_args+=(--measured-h2d-gbps "$MEASURED_H2D_GBPS")
+fi
+if [[ -n "${SLO_MS:-}" ]]; then
+  extra_args+=(--slo-ms "$SLO_MS")
+fi
+
+run_model() {
+  local model="$1" draft="$2" offload="$3" output="$4"
+  echo "[run_phase_a] === $model -> $output ==="
+  if [[ ! -d "$offload" ]]; then
+    echo "[run_phase_a] WARNING: offload dir '$offload' missing; the runner will" \
+         "refuse B0/B1/B2 unless experts are genuinely offloaded" >&2
+  fi
+  python -m benchmarks.dflash.pd_dflash_serving \
+    --model "$model" \
+    --draft "$draft" \
+    --offload-dir "$offload" \
+    --baseline $BASELINES \
+    --block-size $BLOCK_SIZES \
+    --concurrency $CONCURRENCY \
+    --requests "$REQUESTS" \
+    --warmup-rounds "$WARMUP" \
+    --seed "$SEED" \
+    --device-memory-ratio "$DEVICE_MEMORY_RATIO" \
+    "${extra_args[@]}" \
+    --output "$output"
+}
+
+run_model "$QWEN_MODEL" "$QWEN_DRAFT" "$QWEN_OFFLOAD" "$OUTPUT_DIR/raw/qwen.json"
+run_model "$GPTOSS_MODEL" "$GPTOSS_DRAFT" "$GPTOSS_OFFLOAD" "$OUTPUT_DIR/raw/gpt-oss.json"
+
+echo "[run_phase_a] aggregating result matrix"
+python -m benchmarks.dflash.report \
+  --input "$OUTPUT_DIR/raw/qwen.json" "$OUTPUT_DIR/raw/gpt-oss.json" \
+  --matrix-json "$OUTPUT_DIR/result_matrix.json" \
+  --csv "$OUTPUT_DIR/summary.csv" \
+  --markdown "$OUTPUT_DIR/summary.md" \
+  --allow-blocked B2 || {
+    echo "[run_phase_a] report gate FAILED (missing/invalid baseline); inspect" \
+         "$OUTPUT_DIR/result_matrix.json" >&2
+    exit 1
+  }
+
+echo "[run_phase_a] done:"
+echo "  raw rows:      $OUTPUT_DIR/raw/{qwen,gpt-oss}.json"
+echo "  result matrix: $OUTPUT_DIR/result_matrix.json"
+echo "  summary:       $OUTPUT_DIR/summary.{csv,md}"

--- a/docs/superpowers/notes/2026-08-14-pd-dflash-task6-step5-seam.md
+++ b/docs/superpowers/notes/2026-08-14-pd-dflash-task6-step5-seam.md
@@ -1,0 +1,145 @@
+# PD-DFlash Task 6 Step 5 — engine round-state is BLOCKED on a missing single-round speculator seam
+
+> Status: **BLOCKED (honest gate).** Steps 1–4 of Task 6 are complete and merged
+> here (from #156 + #157). Step 5 (engine DRAFT→VERIFY→DRAFT driving) cannot be
+> implemented within Task 6's authorized files without a per-round control seam
+> on `DFlashSpeculator` that does not exist and that Task 6 does not authorize
+> creating. This note is the "exact seam needed" report the plan/task requires
+> instead of hacking one in.
+
+Plan: `docs/superpowers/plans/2026-08-14-pd-dflash-serving-scheduler.md`, Task 6
+Step 5 (lines 527–529) and the File-Structure/anchor notes (lines 30, 86).
+
+## What is already done (merged base of this branch)
+
+This branch is `origin/feat/pd-dflash-phaseA-runner` (#157, `expert_nbytes`
+instrumentation) with `origin/feat/pd-dflash-serving-scheduler` (#156, the
+DRAFT/VERIFY scheduler) merged in. Together they already deliver:
+
+- **Task 4** — `SequenceStatus.DRAFT` / `VERIFY` states and transitions
+  (`moe_infinity/serving/sequence.py`).
+- **Task 5** — the pure 2-D deficit rule `admit_verify_demands(...)`
+  (`moe_infinity/serving/scheduler.py:50`).
+- **Task 6 Step 3** — `SchedulerOutput.{draft_seq_ids, verify_seq_ids,
+  num_verify_tokens, num_verify_expert_bytes}` (`moe_infinity/serving/batch.py`).
+- **Task 6 Step 4** — `Scheduler.set_verify_demand` / `clear_verify_demand` +
+  `_apply_verify_scheduling` (called at the end of `schedule()`), plus the
+  engine-constructor wiring of `verify_*_budget` / `verify_*_deficit_cap`
+  (`moe_infinity/serving/engine.py:135-147`, added by #156 commit `3cacafe`).
+- **Task 6 Step 1 (scheduler-level)** — the "three speculative sequences"
+  admission scenario is already pinned as
+  `test_scheduler_admits_verify_demands_by_tokens_and_bytes`
+  (`tests/python/serving/test_dflash_deficit_scheduler.py:231`).
+- **#157** — `ExpertPrefetcher.expert_nbytes_map[(layer,expert)]` holds the real
+  registration-time FP4 payload bytes; `RouteAheadStats` records byte-accurate
+  coverage/waste.
+
+The ONLY unfinished piece is **Step 5: the engine must drive per-round
+DRAFT→VERIFY→DRAFT and register each pending verify's EXACT token/byte demand so
+the scheduler decides when VERIFY runs.**
+
+## Why Step 5 is blocked (root cause, not a symptom)
+
+Step 5 requires the engine, **before** running a verify, to register that
+verify's exact demand: `set_verify_demand(seq_id, tokens=B,
+expert_bytes=Σ expert_nbytes[routed union], in_flight=…)`, then run VERIFY only
+for the sequences the scheduler admits (`SchedulerOutput.verify_seq_ids`).
+
+The serving engine's speculative path exposes **only** the whole-request loop:
+
+- `ContinuousBatchingEngine._step_speculative` (`engine.py:326`) calls
+  `speculator.generate(...)` once — the entire DFlash DRAFT→VERIFY→rollback loop
+  for all rounds — then `update_after_step(..., committed_counts=…)`.
+- `SpeculativeGenerator` Protocol (`engine.py:30`) has just `generate()`.
+- `DFlashSpeculator` (`moe_infinity/spec_decode/dflash.py:471`) runs every round
+  inside `_generate_single` (`dflash.py:841`). The per-round state
+  (`target_kv`, `draft_kv`, `context_feature`, `anchor`, `start`, `step_trace`)
+  is **local** to that method. `_run_drafter` (711) and `_verify_target_block`
+  (661) are private and tightly coupled to those locals.
+- Route-ahead is **internal to the verify forward**: `_verify_target_block`
+  opens `route_ahead_context(...)` and `DistributedExpertExecutor.dispatch_local`
+  pins/prefetches the layer's ACTUAL routed expert union during the verify
+  (`_route_ahead_ctx.py`; `docs/serving.md:187`). The exact `expert_nbytes` sum
+  is therefore known only **while/after** the verify runs, surfaced afterward in
+  `RouteAheadStats` — never before it.
+
+Consequences:
+
+1. There is no public per-round API (`grep` across `moe_infinity/` for
+   `draft_round|verify_round|draft_block|verify_block` → none).
+2. The EXACT byte demand of a *pending* verify cannot be obtained without first
+   running that verify's routing — which is exactly what admission is supposed
+   to gate. `generate()` is atomic over all rounds, so the scheduler cannot
+   interpose between draft and verify.
+
+## Why there is no honest non-seam workaround
+
+- **Post-hoc `RouteAheadStats`** gives bytes only *after* the verify already ran
+  → useless for admission ("let Scheduler decide when VERIFY runs").
+- **Fabricating** bytes from expert *count* × average is explicitly forbidden by
+  the plan (Step 4: "exact summed FP4 payload, not expert count") and by the
+  task ("do NOT fabricate a byte estimate").
+- **Re-implementing** the draft/verify/rollback loop inside `engine.py` (driving
+  the private `_run_drafter` / `_verify_target_block` / snapshot / rollback)
+  would be a *second* draft/verify + routing path — forbidden by Step 5 ("Do not
+  add another router or prefetch path") and the design's single-router rule.
+
+## The exact seam required (NOT authorized by Task 6's file list)
+
+A public, per-sequence, single-round control surface on `DFlashSpeculator`
+(`moe_infinity/spec_decode/dflash.py`) that externalizes the `_generate_single`
+loop state, plus a read-only route projection. Sketch:
+
+```python
+class SpecSession:                      # externalized per-sequence round state
+    target_kv; draft_kv; context_feature; anchor; start; emitted; step_trace
+
+def begin_session(prompt_ids, sampling_params, stop_ids) -> SpecSession:
+    # prefill/anchor forward (_forward_target(..., logits_to_keep=1)); seed state
+
+def draft_round(session) -> DraftResult:
+    # one _run_drafter pass -> block; PROJECT the pending verify's routed expert
+    # union via the SAME gate/top-k path the verify will use (NO expert exec,
+    # NO second router — this is the design §10 "BM1" gate+topk_softmax
+    # projection on the B-token block). Returns:
+    #   tokens=block_size,
+    #   expert_union: set[(layer_id, expert_id)],
+    #   expert_bytes = sum(prefetcher.expert_nbytes_map[(l,e)] for (l,e) in union)
+
+def verify_round(session) -> VerifyResult:
+    # one _verify_target_block under route_ahead_context (existing prefetch seam),
+    # accept rule, commit/rollback, append step_trace. Returns:
+    #   accepted_token_ids, accept, committed_count, finished
+```
+
+Engine loop (in the authorized `engine.py`) then becomes, per active
+speculative sequence: `draft_round` → `scheduler.set_verify_demand(seq_id, B,
+expert_bytes, in_flight)` → `schedule()` → for admitted `verify_seq_ids`:
+`verify_round` → `update_after_step(committed_counts=…)` →
+`clear_verify_demand(seq_id)` → status back to DRAFT (or FINISHED); unadmitted
+sequences stay DRAFT and their deficit carries.
+
+The route projection in `draft_round` also touches
+`moe_infinity/distributed/expert_executor.py` (a read-only "route-only" mode of
+the existing dispatch, returning the routed expert ids without executing them).
+
+### Authorization gap
+
+Task 6's File list (plan lines 491–498) is exactly: `serving/batch.py`,
+`serving/scheduler.py`, `serving/engine.py`, and their tests + the benchmark. It
+does **not** include `spec_decode/dflash.py` or `distributed/expert_executor.py`.
+Step 5's wording ("consume the already-built DFlash route-ahead result", "Do not
+add another router or prefetch path") describes *consuming* an existing artifact,
+not creating a per-round draft/verify control API. The plan's own anchor (line
+30) scopes Task 6 to "replaces only that coarse serving admission with
+round-state scheduling." So the seam is (a) genuinely required and (b) outside
+Task 6's authorized scope.
+
+## Recommendation
+
+Add a follow-up task (or amend Task 6's File list) that authorizes the
+`dflash.py` per-round `SpecSession` seam + the read-only route projection in
+`expert_executor.py`, gated behind the same BM1 gate+top-k projection primitive
+the design already specifies. Only then can `engine.py` Step 5 register EXACT
+`expert_nbytes` demand and let the 2-D scheduler govern VERIFY under concurrency
+without a second router or a fabricated byte estimate.

--- a/moe_infinity/distributed/expert_executor.py
+++ b/moe_infinity/distributed/expert_executor.py
@@ -72,6 +72,28 @@ def _call_expert_dispatcher(method, *args, **kwargs):
     return func(*args, **kwargs)
 
 
+def _layer_expert_nbytes(prefetcher, layer_id, expert_ids):
+    """``{expert_id: stored_bytes}`` for this layer's prefetched set, or None.
+
+    Reads the registration-time ``ExpertPrefetcher.expert_nbytes_map`` -- a real
+    ``dict`` only on the offloaded native path. Mocks, resident runs, and any
+    engine without the map yield ``None`` so the A5 recorder keeps byte-accurate
+    absence instead of a fabricated average expert size, and never calls
+    ``int()`` on a mock attribute.
+    """
+    if not expert_ids:
+        return None
+    nbytes_map = getattr(prefetcher, "expert_nbytes_map", None)
+    if not isinstance(nbytes_map, dict) or not nbytes_map:
+        return None
+    entry = {}
+    for expert_id in expert_ids:
+        nbytes = nbytes_map.get((layer_id, expert_id))
+        if nbytes is not None:
+            entry[expert_id] = int(nbytes)
+    return entry or None
+
+
 class DistributedExpertExecutor:
     def __init__(self, archer_config: ArcherConfig):
         self.archer_config = archer_config
@@ -151,8 +173,14 @@ class DistributedExpertExecutor:
         if stats is not None:
             # A5 read-only observation: predicted == the pinned union when
             # the prefetch fired, else [] (coverage 0 for this layer).
+            predicted_ids = union_expert_ids if fired else []
             stats.observe_layer(
-                layer_id, union_expert_ids if fired else [], mask_2d
+                layer_id,
+                predicted_ids,
+                mask_2d,
+                expert_nbytes=_layer_expert_nbytes(
+                    route_prefetcher, layer_id, predicted_ids
+                ),
             )
         return fired
 

--- a/moe_infinity/memory/expert_prefetcher.py
+++ b/moe_infinity/memory/expert_prefetcher.py
@@ -32,6 +32,7 @@ class ExpertPrefetcher(object):
     first_k_dense_replace: int = 0
     archer_engine: Any
     expert_tensor_map: dict[tuple[int, int], int]
+    expert_nbytes_map: dict[tuple[int, int], int]
 
     def __init__(self, config: PretrainedConfig):
         print(config)
@@ -40,6 +41,7 @@ class ExpertPrefetcher(object):
         )
         self.archer_engine: Optional[Any] = None
         self.expert_tensor_map: Dict[Tuple[int, int], int] = {}
+        self.expert_nbytes_map: Dict[Tuple[int, int], int] = {}
         self._last_speculative_prediction: Set[int] = set()
 
     def set_archer_engine(self, archer_engine: Any):

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -291,6 +291,31 @@ def _make_expert_tensor_map(name_id_map, config):
     return result
 
 
+def _make_expert_nbytes_map(model, config):
+    """Sum stored payload bytes per ``(layer_id, expert_id)`` from live params.
+
+    Read while the routed-expert weights still carry their true shape/dtype
+    (before ``setup_archer_hooks`` installs offload placeholders), so
+    ``numel * element_size`` is the exact stored FP4/FP8 payload the route-ahead
+    prefetch fetches -- even a meta-init param preserves shape and dtype. This
+    is read-only measurement metadata for the A5 recorder; it never changes
+    routing, prefetch, or offload placement. gpt-oss stacks its experts into one
+    tensor and never reaches the executor route-ahead seam, so it is skipped.
+    """
+    if getattr(config, "model_type", "") == "gpt_oss":
+        return {}
+    result: dict[tuple[int, int], int] = {}
+    for name, param in model.named_parameters(recurse=True):
+        layer_id, expert_id = parse_expert_id(name, config)
+        if expert_id is None:
+            continue
+        nbytes = int(param.numel()) * int(param.element_size())
+        result[(layer_id, expert_id)] = (
+            result.get((layer_id, expert_id), 0) + nbytes
+        )
+    return result
+
+
 def _identify_fp8_blockwise_pairs(keys):
     key_set = set(keys)
     pairs = []
@@ -1060,6 +1085,9 @@ class OffloadEngine(object):
                 )
                 self.expert_prefetcher.expert_tensor_map = (
                     self.expert_tensor_map
+                )
+                self.expert_prefetcher.expert_nbytes_map = (
+                    _make_expert_nbytes_map(model, self.config)
                 )
 
                 # for deepseek and glm, we need to set the expert_tensor_map for the model

--- a/moe_infinity/serving/batch.py
+++ b/moe_infinity/serving/batch.py
@@ -17,11 +17,17 @@ class SchedulerOutput:
     preempted_seq_ids: list[int] = field(default_factory=list)
     num_prefill_tokens: int = 0
     num_decode_tokens: int = 0
+    draft_seq_ids: list[int] = field(default_factory=list)
+    verify_seq_ids: list[int] = field(default_factory=list)
+    num_verify_tokens: int = 0
+    num_verify_expert_bytes: int = 0
 
     def __post_init__(self) -> None:
         self.prefill_seq_ids = list(self.prefill_seq_ids)
         self.decode_seq_ids = list(self.decode_seq_ids)
         self.preempted_seq_ids = list(self.preempted_seq_ids)
+        self.draft_seq_ids = list(self.draft_seq_ids)
+        self.verify_seq_ids = list(self.verify_seq_ids)
 
 
 @dataclass

--- a/moe_infinity/serving/engine.py
+++ b/moe_infinity/serving/engine.py
@@ -132,6 +132,18 @@ class ContinuousBatchingEngine:
             max_tokens_per_step=self._get_int_config(
                 "max_tokens_per_step", 2048
             ),
+            verify_token_budget=self._get_optional_int_config(
+                "verify_token_budget"
+            ),
+            verify_expert_byte_budget=self._get_optional_int_config(
+                "verify_expert_byte_budget"
+            ),
+            verify_token_deficit_cap=self._get_optional_int_config(
+                "verify_token_deficit_cap"
+            ),
+            verify_expert_byte_deficit_cap=self._get_optional_int_config(
+                "verify_expert_byte_deficit_cap"
+            ),
         )
         self.model_runner = ModelRunner(model, engine, device=self.device)
         self.sampler = Sampler()
@@ -784,6 +796,16 @@ class ContinuousBatchingEngine:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise ValueError(f"{key} must be a float-compatible value")
         return float(value)
+
+    def _get_optional_int_config(self, key: str) -> Optional[int]:
+        if key not in self.config:
+            return None
+        value = self.config[key]
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{key} must be an integer value")
+        return value
 
     def _get_int_config(self, key: str, default: Optional[int] = None) -> int:
         if default is None:

--- a/moe_infinity/serving/scheduler.py
+++ b/moe_infinity/serving/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import deque
+from dataclasses import dataclass
 from math import ceil
 from typing import Optional, Protocol
 
@@ -16,6 +17,93 @@ class CPAwareKVManager(Protocol):
     def predict_prefix_reuse(
         self, request_id: str, token_ids: list[int]
     ) -> float: ...
+
+
+@dataclass(frozen=True)
+class Deficit2D:
+    tokens: int
+    expert_bytes: int
+
+
+@dataclass(frozen=True)
+class VerifyDemand:
+    seq_id: int
+    tokens: int
+    expert_bytes: int
+    in_flight: bool = False
+
+
+@dataclass(frozen=True)
+class VerifyAdmission:
+    seated_ids: tuple[int, ...]
+    admitted_ids: tuple[int, ...]
+    carried: Deficit2D
+
+
+def _reject_negative(label: str, deficit: Deficit2D) -> None:
+    if deficit.tokens < 0 or deficit.expert_bytes < 0:
+        raise ValueError(
+            f"{label} dimensions must be non-negative; got {deficit}"
+        )
+
+
+def admit_verify_demands(
+    demands: list[VerifyDemand],
+    budget: Deficit2D,
+    carried: Deficit2D,
+    deficit_cap: Deficit2D,
+) -> VerifyAdmission:
+    _reject_negative("budget", budget)
+    _reject_negative("carried", carried)
+    _reject_negative("deficit_cap", deficit_cap)
+    for demand in demands:
+        if demand.tokens < 0 or demand.expert_bytes < 0:
+            raise ValueError(
+                f"demand {demand.seq_id} dimensions must be non-negative; "
+                f"got tokens={demand.tokens}, "
+                f"expert_bytes={demand.expert_bytes}"
+            )
+
+    if demands:
+        largest_tokens = max(demand.tokens for demand in demands)
+        largest_bytes = max(demand.expert_bytes for demand in demands)
+        if (
+            deficit_cap.tokens < largest_tokens
+            or deficit_cap.expert_bytes < largest_bytes
+        ):
+            raise ValueError(
+                "deficit_cap must be >= the largest single demand in each "
+                f"dimension; cap={deficit_cap}, largest_tokens="
+                f"{largest_tokens}, largest_expert_bytes={largest_bytes}"
+            )
+
+    seated_ids = tuple(demand.seq_id for demand in demands if demand.in_flight)
+    seated_tokens = sum(demand.tokens for demand in demands if demand.in_flight)
+    seated_bytes = sum(
+        demand.expert_bytes for demand in demands if demand.in_flight
+    )
+
+    pool_tokens = budget.tokens + carried.tokens - seated_tokens
+    pool_bytes = budget.expert_bytes + carried.expert_bytes - seated_bytes
+
+    admitted_ids: list[int] = []
+    for demand in demands:
+        if demand.in_flight:
+            continue
+        if demand.tokens <= pool_tokens and demand.expert_bytes <= pool_bytes:
+            pool_tokens -= demand.tokens
+            pool_bytes -= demand.expert_bytes
+            admitted_ids.append(demand.seq_id)
+
+    carried_out = Deficit2D(
+        tokens=min(max(0, pool_tokens), deficit_cap.tokens),
+        expert_bytes=min(max(0, pool_bytes), deficit_cap.expert_bytes),
+    )
+    return VerifyAdmission(
+        seated_ids=seated_ids,
+        admitted_ids=tuple(admitted_ids),
+        carried=carried_out,
+    )
 
 
 class Scheduler:
@@ -389,4 +477,11 @@ class Scheduler:
 RequestScheduler = Scheduler
 
 
-__all__ = ["Scheduler", "RequestScheduler"]
+__all__ = [
+    "Deficit2D",
+    "RequestScheduler",
+    "Scheduler",
+    "VerifyAdmission",
+    "VerifyDemand",
+    "admit_verify_demands",
+]

--- a/moe_infinity/serving/scheduler.py
+++ b/moe_infinity/serving/scheduler.py
@@ -106,6 +106,55 @@ def admit_verify_demands(
     )
 
 
+@dataclass(frozen=True)
+class _VerifyConfig:
+    enabled: bool
+    budget: Deficit2D
+    deficit_cap: Deficit2D
+
+
+def _resolve_verify_config(
+    *,
+    token_budget: Optional[int],
+    expert_byte_budget: Optional[int],
+    token_deficit_cap: Optional[int],
+    expert_byte_deficit_cap: Optional[int],
+) -> _VerifyConfig:
+    provided = [
+        token_budget,
+        expert_byte_budget,
+        token_deficit_cap,
+        expert_byte_deficit_cap,
+    ]
+    if all(value is None for value in provided):
+        zero = Deficit2D(tokens=0, expert_bytes=0)
+        return _VerifyConfig(enabled=False, budget=zero, deficit_cap=zero)
+    if any(value is None for value in provided):
+        raise ValueError(
+            "verify scheduling requires all four of token_budget, "
+            "expert_byte_budget, token_deficit_cap, and "
+            "expert_byte_deficit_cap, or none of them"
+        )
+    for name, value in (
+        ("verify_token_budget", token_budget),
+        ("verify_expert_byte_budget", expert_byte_budget),
+        ("verify_token_deficit_cap", token_deficit_cap),
+        ("verify_expert_byte_deficit_cap", expert_byte_deficit_cap),
+    ):
+        if value < 0:
+            raise ValueError(f"{name} must be >= 0, got {value}")
+    return _VerifyConfig(
+        enabled=True,
+        budget=Deficit2D(
+            tokens=int(token_budget), expert_bytes=int(expert_byte_budget)
+        ),
+        deficit_cap=Deficit2D(
+            tokens=int(token_deficit_cap),
+            expert_bytes=int(expert_byte_deficit_cap),
+        ),
+    )
+
+
 class Scheduler:
     kv_cache: PagedKVCache
     max_batch_size: int
@@ -116,6 +165,11 @@ class Scheduler:
         kv_cache: PagedKVCache,
         max_batch_size: int = 32,
         max_tokens_per_step: int = 2048,
+        *,
+        verify_token_budget: Optional[int] = None,
+        verify_expert_byte_budget: Optional[int] = None,
+        verify_token_deficit_cap: Optional[int] = None,
+        verify_expert_byte_deficit_cap: Optional[int] = None,
     ) -> None:
         if max_batch_size <= 0:
             raise ValueError(
@@ -137,6 +191,15 @@ class Scheduler:
         self._sequence_map: dict[int, SequenceData] = {}
         self._request_map: dict[str, SequenceGroup] = {}
         self._cp_kv_manager: Optional[CPAwareKVManager] = None
+
+        self._verify_config = _resolve_verify_config(
+            token_budget=verify_token_budget,
+            expert_byte_budget=verify_expert_byte_budget,
+            token_deficit_cap=verify_token_deficit_cap,
+            expert_byte_deficit_cap=verify_expert_byte_deficit_cap,
+        )
+        self._verify_demands: dict[int, VerifyDemand] = {}
+        self._carried_verify_deficit = Deficit2D(tokens=0, expert_bytes=0)
 
     def set_cp_kv_manager(self, manager: CPAwareKVManager) -> None:
         self._cp_kv_manager = manager
@@ -237,21 +300,78 @@ class Scheduler:
             scheduled_tokens += prefill_tokens
             output.num_prefill_tokens += prefill_tokens
 
+        capacity_reached = False
         for group in self._running:
+            if capacity_reached:
+                break
             for sequence in group.sequences:
                 if sequence.status is not SequenceStatus.DECODE:
                     continue
-                if scheduled_seqs >= self.max_batch_size:
-                    return output
-                if scheduled_tokens >= self.max_tokens_per_step:
-                    return output
+                if (
+                    scheduled_seqs >= self.max_batch_size
+                    or scheduled_tokens >= self.max_tokens_per_step
+                ):
+                    capacity_reached = True
+                    break
 
                 output.decode_seq_ids.append(sequence.seq_id)
                 output.num_decode_tokens += 1
                 scheduled_seqs += 1
                 scheduled_tokens += 1
 
+        self._apply_verify_scheduling(output)
         return output
+
+    def set_verify_demand(
+        self,
+        seq_id: int,
+        tokens: int,
+        expert_bytes: int,
+        in_flight: bool,
+    ) -> None:
+        self._verify_demands[seq_id] = VerifyDemand(
+            seq_id=seq_id,
+            tokens=tokens,
+            expert_bytes=expert_bytes,
+            in_flight=in_flight,
+        )
+
+    def clear_verify_demand(self, seq_id: int) -> None:
+        _ = self._verify_demands.pop(seq_id, None)
+
+    @property
+    def carried_verify_deficit(self) -> Deficit2D:
+        return self._carried_verify_deficit
+
+    def _apply_verify_scheduling(self, output: SchedulerOutput) -> None:
+        if not self._verify_config.enabled or not self._verify_demands:
+            return
+
+        demands = list(self._verify_demands.values())
+        admission = admit_verify_demands(
+            demands,
+            self._verify_config.budget,
+            self._carried_verify_deficit,
+            self._verify_config.deficit_cap,
+        )
+        self._carried_verify_deficit = admission.carried
+
+        verify_ids = [*admission.seated_ids, *admission.admitted_ids]
+        verify_set = set(verify_ids)
+        output.verify_seq_ids = list(verify_ids)
+        output.draft_seq_ids = [
+            demand.seq_id
+            for demand in demands
+            if demand.seq_id not in verify_set
+        ]
+        output.num_verify_tokens = sum(
+            demand.tokens for demand in demands if demand.seq_id in verify_set
+        )
+        output.num_verify_expert_bytes = sum(
+            demand.expert_bytes
+            for demand in demands
+            if demand.seq_id in verify_set
+        )
 
     def update_after_step(
         self,

--- a/moe_infinity/serving/sequence.py
+++ b/moe_infinity/serving/sequence.py
@@ -10,6 +10,8 @@ class SequenceStatus(Enum):
     WAITING = "waiting"
     PREFILL = "prefill"
     DECODE = "decode"
+    DRAFT = "draft"
+    VERIFY = "verify"
     FINISHED = "finished"
     SWAPPED = "swapped"
     CANCELLED = "cancelled"
@@ -65,6 +67,7 @@ class SequenceData:
             },
             SequenceStatus.PREFILL: {
                 SequenceStatus.DECODE,
+                SequenceStatus.DRAFT,
                 SequenceStatus.FINISHED,
                 SequenceStatus.SWAPPED,
                 SequenceStatus.CANCELLED,
@@ -74,10 +77,23 @@ class SequenceData:
                 SequenceStatus.SWAPPED,
                 SequenceStatus.CANCELLED,
             },
+            SequenceStatus.DRAFT: {
+                SequenceStatus.VERIFY,
+                SequenceStatus.FINISHED,
+                SequenceStatus.SWAPPED,
+                SequenceStatus.CANCELLED,
+            },
+            SequenceStatus.VERIFY: {
+                SequenceStatus.DRAFT,
+                SequenceStatus.FINISHED,
+                SequenceStatus.SWAPPED,
+                SequenceStatus.CANCELLED,
+            },
             SequenceStatus.SWAPPED: {
                 SequenceStatus.WAITING,
                 SequenceStatus.PREFILL,
                 SequenceStatus.DECODE,
+                SequenceStatus.DRAFT,
                 SequenceStatus.FINISHED,
                 SequenceStatus.CANCELLED,
             },

--- a/moe_infinity/spec_decode/_route_ahead_stats.py
+++ b/moe_infinity/spec_decode/_route_ahead_stats.py
@@ -30,7 +30,16 @@ after ``generate()``.
 
 from __future__ import annotations
 
-from typing import Dict, List, NamedTuple, Sequence, Tuple, Union
+from typing import (
+    Dict,
+    List,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import torch
 
@@ -49,6 +58,11 @@ class RouteAheadStepSummary(NamedTuple):
     covered: int  # sum |P_l ∩ A_l|
     kept: int  # sum |U_keep_l| -- union over only the kept prefix rows
     wasted: int  # sum |P_l \ U_keep_l| -- rejected-token prefetch waste
+    # Byte-accurate counterparts, scored over the PREFETCHED set only; None
+    # when the caller supplied no payload sizes (mock / resident paths).
+    predicted_bytes: Optional[int] = None  # stored bytes of P_l
+    kept_bytes: Optional[int] = None  # bytes of P_l the kept prefix still used
+    wasted_bytes: Optional[int] = None  # bytes of P_l \ U_keep_l (waste)
 
     @property
     def coverage(self) -> float:
@@ -80,7 +94,13 @@ class RouteAheadStats:
         self.covered_experts: int = 0
         self.kept_experts: int = 0
         self.wasted_experts: int = 0
-        self._pending: List[Tuple[int, List[int], torch.Tensor]] = []
+        self.predicted_prefetch_bytes: int = 0
+        self.kept_prefetch_bytes: int = 0
+        self.wasted_prefetch_bytes: int = 0
+        self._bytes_seen: bool = False
+        self._pending: List[
+            Tuple[int, List[int], torch.Tensor, Optional[Dict[int, int]]]
+        ] = []
 
     # ------------------------------------------------------------------
     # recorder interface (speculator + executor seam drive these)
@@ -95,6 +115,7 @@ class RouteAheadStats:
         layer_id: int,
         predicted_ids: Sequence[int],
         router_mask: Union[torch.Tensor, Sequence[Sequence[int]]],
+        expert_nbytes: Optional[Mapping[int, int]] = None,
     ) -> None:
         """Record one dispatched layer of the in-flight verify step.
 
@@ -105,6 +126,12 @@ class RouteAheadStats:
         verify-read union. The mask is snapshotted to CPU (a no-op view when
         already on CPU) so the kept-prefix waste can be computed later, once
         the accept length is known. Read-only: the mask is never modified.
+
+        ``expert_nbytes`` optionally maps each prefetched expert id to its
+        exact stored payload bytes; when given, ``commit_step`` reports
+        byte-accurate predicted/kept/wasted alongside the counts. ``None``
+        (mocks, resident-expert runs) keeps every byte field ``None`` -- the
+        recorder never fabricates an average expert size.
         """
         mask = (
             router_mask
@@ -117,8 +144,13 @@ class RouteAheadStats:
                 f"got shape {tuple(mask.shape)}"
             )
         mask_cpu = mask.detach().to(torch.bool).cpu()
+        nbytes = (
+            {int(e): int(n) for e, n in expert_nbytes.items()}
+            if expert_nbytes is not None
+            else None
+        )
         self._pending.append(
-            (int(layer_id), [int(e) for e in predicted_ids], mask_cpu)
+            (int(layer_id), [int(e) for e in predicted_ids], mask_cpu, nbytes)
         )
 
     def commit_step(self, kept_rows: int) -> RouteAheadStepSummary:
@@ -138,11 +170,14 @@ class RouteAheadStats:
             return RouteAheadStepSummary(0, 0, 0, 0, 0, 0)
 
         predicted = actual = covered = kept = wasted = 0
-        for _layer_id, predicted_ids, mask in pending:
+        predicted_b = kept_b = wasted_b = 0
+        step_has_bytes = False
+        for _layer_id, predicted_ids, mask, nbytes in pending:
             full_union = union_experts_from_mask(mask)
             rows = max(0, min(int(kept_rows), int(mask.shape[0])))
             kept_union = union_experts_from_mask(mask[:rows]) if rows else []
             predicted_set = set(predicted_ids)
+            kept_set = set(kept_union)
             predicted += len(predicted_set)
             actual += len(full_union)
             # Same set semantics as the A1 ``prefetch_coverage``; the count
@@ -150,6 +185,15 @@ class RouteAheadStats:
             covered += len(predicted_set & set(full_union))
             kept += len(kept_union)
             wasted += len(rejected_expert_ids(predicted_ids, kept_union))
+            if nbytes is not None:
+                step_has_bytes = True
+                predicted_b += sum(nbytes.get(e, 0) for e in predicted_set)
+                kept_b += sum(
+                    nbytes.get(e, 0) for e in predicted_set & kept_set
+                )
+                wasted_b += sum(
+                    nbytes.get(e, 0) for e in predicted_set - kept_set
+                )
 
         self.steps += 1
         self.layers_observed += len(pending)
@@ -158,8 +202,21 @@ class RouteAheadStats:
         self.covered_experts += covered
         self.kept_experts += kept
         self.wasted_experts += wasted
+        if step_has_bytes:
+            self._bytes_seen = True
+            self.predicted_prefetch_bytes += predicted_b
+            self.kept_prefetch_bytes += kept_b
+            self.wasted_prefetch_bytes += wasted_b
         return RouteAheadStepSummary(
-            len(pending), predicted, actual, covered, kept, wasted
+            len(pending),
+            predicted,
+            actual,
+            covered,
+            kept,
+            wasted,
+            predicted_b if step_has_bytes else None,
+            kept_b if step_has_bytes else None,
+            wasted_b if step_has_bytes else None,
         )
 
     # ------------------------------------------------------------------
@@ -190,8 +247,13 @@ class RouteAheadStats:
         """Zero all counters and drop any uncommitted records."""
         self.__init__()
 
-    def as_dict(self) -> Dict[str, Union[int, float]]:
-        """Flat snapshot of the counters plus the two derived ratios."""
+    def as_dict(self) -> Dict[str, Union[int, float, None]]:
+        """Flat snapshot of the counters, byte totals, and derived ratios.
+
+        The three ``*_prefetch_bytes`` entries are ``None`` until a step is
+        committed with per-expert payload sizes, so uninstrumented and
+        resident runs report byte-accurate absence rather than a fake zero.
+        """
         return {
             "steps": self.steps,
             "layers_observed": self.layers_observed,
@@ -202,6 +264,15 @@ class RouteAheadStats:
             "wasted_experts": self.wasted_experts,
             "coverage": self.coverage,
             "waste_ratio": self.waste_ratio,
+            "predicted_prefetch_bytes": (
+                self.predicted_prefetch_bytes if self._bytes_seen else None
+            ),
+            "kept_prefetch_bytes": (
+                self.kept_prefetch_bytes if self._bytes_seen else None
+            ),
+            "wasted_prefetch_bytes": (
+                self.wasted_prefetch_bytes if self._bytes_seen else None
+            ),
         }
 
 

--- a/tests/python/dflash/test_pd_dflash_report.py
+++ b/tests/python/dflash/test_pd_dflash_report.py
@@ -1,0 +1,162 @@
+"""CPU-only contract tests for the PD-DFlash serving experiment report.
+
+Task 1 of ``docs/superpowers/plans/2026-08-14-pd-dflash-serving-scheduler.md``
+("Freeze the experiment schema and cost-model decision"). These tests pin the
+immutable result contract *before* any GPU runner exists:
+
+* ``evaluate_hide_inequality`` computes the route-ahead hiding inequality from
+  the design's §7 terms only -- never a theoretical PCIe number -- and reports
+  both sides plus the boolean verdict;
+* ``validate_result_matrix`` requires the full B0-B3 baseline set and every §8
+  metric (permitting B3's explicit ``UNAVAILABLE_CAPACITY`` status), and treats
+  ``wasted_prefetch_bytes`` as a byte quantity rather than an expert count.
+
+All pure Python; no CUDA, no checkpoint, no network.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from benchmarks.dflash.report import (
+    REQUIRED_METRICS,
+    evaluate_hide_inequality,
+    validate_result_matrix,
+)
+
+
+def _full_matrix() -> dict[str, dict[str, float]]:
+    return {
+        baseline: {metric: 1.0 for metric in REQUIRED_METRICS}
+        for baseline in ("B0", "B1", "B2", "B3")
+    }
+
+
+# ---------------------------------------------------------------------------
+# hide inequality: measured terms only (design §7)
+# ---------------------------------------------------------------------------
+
+
+def test_hide_inequality_uses_measured_terms():
+    result = evaluate_hide_inequality(
+        resident_fraction=0.5,
+        saturation=1.0,
+        total_expert_bytes=14_000_000_000,
+        measured_h2d_bytes_per_second=50_000_000_000,
+        draft_seconds=0.04,
+        router_seconds=0.01,
+        overlap_seconds=0.10,
+    )
+    assert result.fetch_seconds == 0.14
+    # 0.04 + 0.01 + 0.10 is 0.15000000000000002 in IEEE-754 double, so the
+    # plan's literal ``== 0.15`` is asserted via approx (documented deviation).
+    assert result.hide_window_seconds == pytest.approx(0.15)
+    assert result.hidden is True
+
+
+def test_hide_inequality_false_when_fetch_exceeds_window():
+    result = evaluate_hide_inequality(
+        resident_fraction=0.0,
+        saturation=1.0,
+        total_expert_bytes=14_000_000_000,
+        measured_h2d_bytes_per_second=50_000_000_000,
+        draft_seconds=0.04,
+        router_seconds=0.01,
+        overlap_seconds=0.10,
+    )
+    # fetch = 14e9 / 50e9 = 0.28 s > 0.15 s window -> exposed, not hidden.
+    assert result.fetch_seconds == pytest.approx(0.28)
+    assert result.hidden is False
+
+
+def test_hide_inequality_rejects_impossible_terms():
+    base = dict(
+        resident_fraction=0.5,
+        saturation=1.0,
+        total_expert_bytes=14_000_000_000,
+        measured_h2d_bytes_per_second=50_000_000_000,
+        draft_seconds=0.04,
+        router_seconds=0.01,
+        overlap_seconds=0.10,
+    )
+    with pytest.raises(ValueError, match="resident_fraction"):
+        evaluate_hide_inequality(**{**base, "resident_fraction": 1.5})
+    with pytest.raises(ValueError, match="resident_fraction"):
+        evaluate_hide_inequality(**{**base, "resident_fraction": -0.1})
+    with pytest.raises(ValueError, match="measured_h2d_bytes_per_second"):
+        evaluate_hide_inequality(**{**base, "measured_h2d_bytes_per_second": 0})
+    with pytest.raises(ValueError, match="overlap_seconds"):
+        evaluate_hide_inequality(**{**base, "overlap_seconds": -0.01})
+
+
+# ---------------------------------------------------------------------------
+# result matrix: B0-B3 present, every §8 metric present and well-formed
+# ---------------------------------------------------------------------------
+
+
+def test_result_matrix_requires_b0_through_b3_and_every_section8_metric():
+    rows = _full_matrix()
+    validate_result_matrix(rows)
+    del rows["B2"]
+    with pytest.raises(ValueError, match="missing baselines: B2"):
+        validate_result_matrix(rows)
+
+
+def test_result_matrix_requires_each_metric_present():
+    rows = _full_matrix()
+    del rows["B1"]["route_ahead_prefetch_coverage"]
+    with pytest.raises(ValueError, match="route_ahead_prefetch_coverage"):
+        validate_result_matrix(rows)
+
+
+def test_result_matrix_rejects_non_finite_or_negative_metric():
+    rows = _full_matrix()
+    rows["B0"]["ttft_seconds"] = float("nan")
+    with pytest.raises(ValueError, match="ttft_seconds"):
+        validate_result_matrix(rows)
+
+    rows = _full_matrix()
+    rows["B0"]["wasted_prefetch_bytes"] = -1
+    with pytest.raises(ValueError, match="wasted_prefetch_bytes"):
+        validate_result_matrix(rows)
+
+
+def test_b3_may_be_reported_unavailable_capacity():
+    rows = _full_matrix()
+    rows["B3"] = {"status": "UNAVAILABLE_CAPACITY"}
+    validate_result_matrix(rows)
+
+
+def test_b3_without_status_still_requires_every_metric():
+    rows = _full_matrix()
+    rows["B3"] = {"status": "OK"}
+    with pytest.raises(ValueError, match="B3"):
+        validate_result_matrix(rows)
+
+
+def test_wasted_prefetch_is_bytes_not_expert_count():
+    rows = _full_matrix()
+    rows["B1"]["wasted_prefetch_bytes"] = 12_582_912
+    validate_result_matrix(rows)
+    assert rows["B1"]["wasted_prefetch_bytes"] == 12_582_912
+    assert "wasted_prefetch_bytes" in REQUIRED_METRICS
+
+
+def test_required_metrics_are_frozen_and_complete():
+    assert isinstance(REQUIRED_METRICS, tuple)
+    assert REQUIRED_METRICS == (
+        "output_tokens_per_second",
+        "acceptance_length_a",
+        "ttft_seconds",
+        "per_round_latency_seconds",
+        "goodput_at_slo",
+        "expert_cache_hit_rate",
+        "route_ahead_prefetch_coverage",
+        "wasted_prefetch_bytes",
+        "expert_occupancy_bytes",
+        "kv_occupancy_bytes",
+    )
+    assert len(set(REQUIRED_METRICS)) == len(REQUIRED_METRICS)
+    assert math.isfinite(1.0)

--- a/tests/python/dflash/test_pd_dflash_report.py
+++ b/tests/python/dflash/test_pd_dflash_report.py
@@ -22,7 +22,10 @@ import pytest
 
 from benchmarks.dflash.report import (
     REQUIRED_METRICS,
+    aggregate_result_matrices,
     evaluate_hide_inequality,
+    evaluate_matrix,
+    summarise_row,
     validate_result_matrix,
 )
 
@@ -142,6 +145,111 @@ def test_wasted_prefetch_is_bytes_not_expert_count():
     validate_result_matrix(rows)
     assert rows["B1"]["wasted_prefetch_bytes"] == 12_582_912
     assert "wasted_prefetch_bytes" in REQUIRED_METRICS
+
+
+# ---------------------------------------------------------------------------
+# BM1 router-ahead cost aggregation (design §10)
+# ---------------------------------------------------------------------------
+
+
+def complete_row(**overrides) -> dict[str, float]:
+    row: dict[str, float] = {metric: 1.0 for metric in REQUIRED_METRICS}
+    row["t_router_seconds"] = 0.002
+    row["t_verify_seconds"] = 0.020
+    row.update(overrides)
+    return row
+
+
+def test_bm1_reports_router_cost_against_verify():
+    row = complete_row(t_router_seconds=0.002, t_verify_seconds=0.020)
+    summary = summarise_row(row)
+    assert summary["bm1_router_to_verify_ratio"] == 0.1
+    assert summary["bm1_pass"] is True
+
+
+def test_bm1_fails_when_router_not_cheaper_than_verify():
+    summary = summarise_row(
+        complete_row(t_router_seconds=0.03, t_verify_seconds=0.02)
+    )
+    assert summary["bm1_pass"] is False
+    assert summary["bm1_router_to_verify_ratio"] == 1.5
+
+
+def test_bm1_retains_raw_terms_and_rejects_bad_inputs():
+    summary = summarise_row(complete_row())
+    assert summary["t_router_seconds"] == 0.002
+    assert summary["t_verify_seconds"] == 0.020
+    with pytest.raises(ValueError, match="t_verify_seconds"):
+        summarise_row(complete_row(t_verify_seconds=0.0))
+    with pytest.raises(ValueError, match="t_router_seconds"):
+        summarise_row(complete_row(t_router_seconds=-0.1))
+    with pytest.raises(ValueError, match="t_router_seconds"):
+        summarise_row({"t_verify_seconds": 0.02})
+
+
+# ---------------------------------------------------------------------------
+# aggregation: group raw rows into §8 matrices, allow blocked B2
+# ---------------------------------------------------------------------------
+
+
+def _obs_row(baseline: str, **overrides) -> dict[str, object]:
+    row: dict[str, object] = {
+        "model": "M",
+        "draft": "d",
+        "baseline": baseline,
+        "block_size": 16,
+        "concurrency": 8,
+        "repeat": 0,
+    }
+    row.update({metric: 1.0 for metric in REQUIRED_METRICS})
+    row.update(overrides)
+    return row
+
+
+def _blocked_b2() -> dict[str, object]:
+    return {
+        "model": "M",
+        "draft": "d",
+        "baseline": "B2",
+        "block_size": 16,
+        "concurrency": 8,
+        "repeat": 0,
+        "status": "BLOCKED_UNTIL_2D_SCHEDULER",
+    }
+
+
+def test_aggregate_groups_rows_and_rejects_duplicate_baseline():
+    matrices = aggregate_result_matrices(
+        [_obs_row(b) for b in ("B0", "B1", "B3")]
+    )
+    assert set(matrices) == {("M", 16, 8)}
+    assert set(matrices[("M", 16, 8)]) == {"B0", "B1", "B3"}
+    with pytest.raises(ValueError, match="duplicate baseline"):
+        aggregate_result_matrices([_obs_row("B0"), _obs_row("B0")])
+
+
+def test_evaluate_matrix_allows_blocked_b2_only_when_permitted():
+    rows = {b: _obs_row(b) for b in ("B0", "B1", "B3")}
+    rows["B2"] = _blocked_b2()
+    ok, detail = evaluate_matrix(rows, allow_blocked=["B2"])
+    assert ok is True and detail["blocked"] == ["B2"]
+    not_ok, detail2 = evaluate_matrix(rows, allow_blocked=[])
+    assert not_ok is False and "B2" in detail2["blocked"]
+
+
+def test_evaluate_matrix_flags_missing_baseline_and_attaches_bm1():
+    partial, missing = evaluate_matrix(
+        {b: _obs_row(b) for b in ("B0", "B1")}, []
+    )
+    assert partial is False and set(missing["missing"]) == {"B2", "B3"}
+
+    full = {
+        b: _obs_row(b, t_router_seconds=0.002, t_verify_seconds=0.020)
+        for b in ("B0", "B1", "B2", "B3")
+    }
+    ok, detail = evaluate_matrix(full, [])
+    assert ok is True
+    assert detail["bm1"]["B1"]["bm1_pass"] is True
 
 
 def test_required_metrics_are_frozen_and_complete():

--- a/tests/python/dflash/test_pd_dflash_serving_contract.py
+++ b/tests/python/dflash/test_pd_dflash_serving_contract.py
@@ -1,0 +1,186 @@
+"""CPU-only contract tests for the PD-DFlash serving runner scaffolding.
+
+Task 2 of ``docs/superpowers/plans/2026-08-14-pd-dflash-serving-scheduler.md``.
+Exercises the pure, torch-free surface of ``pd_dflash_serving`` -- the §8
+contract matrix, device/offload guards, the byte-schema observation row, and the
+append-without-overwrite JSON writer -- so the runner logic is regression-locked
+without a GPU. No CUDA, checkpoint, or network.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchmarks.dflash.pd_dflash_serving import (
+    BLOCKED_STATUS,
+    REQUIRED_CONCURRENCY,
+    REQUIRED_DRAFTS,
+    REQUIRED_MODELS,
+    append_observation,
+    build_contract_matrix,
+    load_observations,
+    main,
+    make_observation_row,
+    parse_args,
+    require_offloaded,
+    validate_device_identity,
+)
+from benchmarks.dflash.report import REQUIRED_METRICS
+
+
+def _full_metrics() -> dict[str, float]:
+    return {metric: 1.0 for metric in REQUIRED_METRICS}
+
+
+# ---------------------------------------------------------------------------
+# §8 contract matrix
+# ---------------------------------------------------------------------------
+
+
+def test_contract_matrix_pins_models_drafts_sweeps_and_metrics():
+    contract = build_contract_matrix()
+    assert set(contract["models"]) == set(REQUIRED_MODELS)
+    assert contract["drafts"] == dict(REQUIRED_DRAFTS)
+    assert set(contract["block_sizes"]) == {8, 16}
+    assert set(contract["concurrency"]) == set(REQUIRED_CONCURRENCY)
+    assert set(contract["baselines"]) == {"B0", "B1", "B2", "B3"}
+    assert tuple(contract["required_metrics"]) == REQUIRED_METRICS
+    assert contract["nvtx_ranges"][0] == "dflash_draft"
+
+
+def test_dry_run_contract_cli_is_cpu_safe(capsys):
+    assert main(["--dry-run-contract"]) == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == build_contract_matrix()
+
+
+# ---------------------------------------------------------------------------
+# device + offload guards
+# ---------------------------------------------------------------------------
+
+
+def test_validate_device_identity_accepts_rtx_pro_6000():
+    validate_device_identity("NVIDIA RTX PRO 6000 Blackwell", (12, 0))
+
+
+def test_validate_device_identity_rejects_wrong_name_or_capability():
+    with pytest.raises(RuntimeError, match="RTX PRO 6000"):
+        validate_device_identity("NVIDIA H100 PCIe", (9, 0))
+    with pytest.raises(RuntimeError, match="capability"):
+        validate_device_identity("NVIDIA RTX PRO 6000", (9, 0))
+
+
+def test_require_offloaded_refuses_resident_b0_b1_b2():
+    for baseline in ("B0", "B1", "B2"):
+        with pytest.raises(RuntimeError, match="offloaded"):
+            require_offloaded(baseline, 0)
+        require_offloaded(baseline, 1)
+    # B3 is the resident upper bound: zero offloaded experts is legal.
+    require_offloaded("B3", 0)
+
+
+# ---------------------------------------------------------------------------
+# observation row schema
+# ---------------------------------------------------------------------------
+
+
+def test_observation_row_requires_full_metric_schema():
+    row = make_observation_row(
+        model="Qwen/Qwen3-Coder-30B-A3B",
+        draft="z-lab/Qwen3-Coder-30B-A3B-DFlash",
+        baseline="B1",
+        block_size=16,
+        concurrency=8,
+        repeat=0,
+        metrics=_full_metrics(),
+    )
+    for metric in REQUIRED_METRICS:
+        assert metric in row
+    assert row["baseline"] == "B1" and row["block_size"] == 16
+
+
+def test_observation_row_rejects_missing_metric():
+    incomplete = _full_metrics()
+    del incomplete["wasted_prefetch_bytes"]
+    with pytest.raises(ValueError, match="wasted_prefetch_bytes"):
+        make_observation_row(
+            model="m",
+            draft="d",
+            baseline="B0",
+            block_size=8,
+            concurrency=1,
+            repeat=0,
+            metrics=incomplete,
+        )
+
+
+def test_blocked_row_carries_status_and_no_metrics():
+    row = make_observation_row(
+        model="m",
+        draft="d",
+        baseline="B2",
+        block_size=8,
+        concurrency=1,
+        repeat=0,
+        metrics={},
+        status=BLOCKED_STATUS,
+    )
+    assert row["status"] == BLOCKED_STATUS
+    assert "output_tokens_per_second" not in row
+
+
+# ---------------------------------------------------------------------------
+# append-without-overwrite JSON writer
+# ---------------------------------------------------------------------------
+
+
+def test_append_observation_appends_distinct_and_refuses_duplicates(tmp_path):
+    out = str(tmp_path / "raw.json")
+    base = dict(
+        model="m",
+        draft="d",
+        baseline="B0",
+        block_size=8,
+        concurrency=1,
+        repeat=0,
+        metrics=_full_metrics(),
+    )
+    append_observation(out, make_observation_row(**base))
+    append_observation(out, make_observation_row(**{**base, "concurrency": 2}))
+    assert len(load_observations(out)) == 2
+
+    with pytest.raises(ValueError, match="refusing to overwrite"):
+        append_observation(out, make_observation_row(**base))
+    assert len(load_observations(out)) == 2
+
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_defaults_cover_the_full_matrix():
+    args = parse_args(
+        [
+            "--model",
+            "Qwen/Qwen3-Coder-30B-A3B",
+            "--draft",
+            "z-lab/Qwen3-Coder-30B-A3B-DFlash",
+            "--offload-dir",
+            "/tmp/offload",
+            "--output",
+            "/tmp/out.json",
+        ]
+    )
+    assert args.baselines == ("B0", "B1", "B2", "B3")
+    assert args.block_sizes == (8, 16)
+    assert args.concurrency == (1, 2, 4, 8, 16, 32)
+    assert args.seed == 1408
+    assert args.device_memory_ratio < 0.9
+
+
+def test_run_requires_model_draft_offload_output():
+    with pytest.raises(SystemExit, match="missing required args"):
+        main(["--output", "/tmp/out.json"])

--- a/tests/python/dflash/test_pd_dflash_serving_gpu.py
+++ b/tests/python/dflash/test_pd_dflash_serving_gpu.py
@@ -1,0 +1,52 @@
+"""Opt-in RTX PRO 6000 gate for the PD-DFlash B0-B3 serving runner.
+
+Task 2 of ``docs/superpowers/plans/2026-08-14-pd-dflash-serving-scheduler.md``.
+Collection is side-effect free: the module imports only the CPU-safe runner
+scaffolding and the single test is skipped unless ``MOE_DFLASH_SERVING_GPU=1``,
+so ``pytest`` never initialises CUDA, loads a checkpoint, hits the network, or
+creates offload state when the gate is absent (``1 skipped``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from benchmarks.dflash.pd_dflash_serving import (
+    REQUIRED_CONCURRENCY,
+    REQUIRED_DRAFTS,
+    REQUIRED_MODELS,
+    main,
+)
+
+RUN_GPU = os.environ.get("MOE_DFLASH_SERVING_GPU") == "1"
+pytestmark = [
+    pytest.mark.gpu,
+    pytest.mark.integration,
+    pytest.mark.skipif(not RUN_GPU, reason="set MOE_DFLASH_SERVING_GPU=1"),
+]
+
+
+def test_dry_run_contract_matches_required_matrix(capsys):
+    assert main(["--dry-run-contract"]) == 0
+    contract = json.loads(capsys.readouterr().out)
+
+    assert "Qwen/Qwen3-Coder-30B-A3B" in contract["models"]
+    assert "openai/gpt-oss-20b" in contract["models"]
+    assert set(contract["models"]) == set(REQUIRED_MODELS)
+
+    assert (
+        contract["drafts"]["Qwen/Qwen3-Coder-30B-A3B"]
+        == "z-lab/Qwen3-Coder-30B-A3B-DFlash"
+    )
+    assert (
+        contract["drafts"]["openai/gpt-oss-20b"] == "z-lab/gpt-oss-20b-DFlash"
+    )
+    assert contract["drafts"] == dict(REQUIRED_DRAFTS)
+
+    assert set(contract["block_sizes"]) == {8, 16}
+    assert set(contract["concurrency"]) == set(REQUIRED_CONCURRENCY)
+    assert set(contract["concurrency"]) == {1, 2, 4, 8, 16, 32}
+    assert set(contract["baselines"]) == {"B0", "B1", "B2", "B3"}

--- a/tests/python/dflash/test_route_ahead_metrics.py
+++ b/tests/python/dflash/test_route_ahead_metrics.py
@@ -259,6 +259,95 @@ def test_empty_union_dispatch_is_vacuous_noop():
 
 
 # ---------------------------------------------------------------------------
+# (b2) byte-accurate waste: payload bytes, not expert counts (Phase A Task 2)
+# ---------------------------------------------------------------------------
+
+
+def test_waste_accounts_payload_bytes_not_only_ids():
+    stats = RouteAheadStats()
+    stats.begin_step()
+    stats.observe_layer(
+        0,
+        predicted_ids=[0, 1],
+        router_mask=torch.tensor([[1, 0], [0, 1]], dtype=torch.bool),
+        expert_nbytes={0: 1024, 1: 4096},
+    )
+    summary = stats.commit_step(kept_rows=1)
+    assert summary.wasted == 1
+    assert summary.wasted_bytes == 4096
+    assert stats.as_dict()["wasted_prefetch_bytes"] == 4096
+
+
+def test_byte_fields_split_predicted_into_kept_and_wasted():
+    stats = RouteAheadStats()
+    stats.begin_step()
+    stats.observe_layer(
+        0,
+        predicted_ids=[0, 1],
+        router_mask=torch.tensor([[1, 0], [0, 1]], dtype=torch.bool),
+        expert_nbytes={0: 1024, 1: 4096},
+    )
+    summary = stats.commit_step(kept_rows=1)
+    # Kept prefix (row 0) routes expert 0 only, so expert 1's 4096 B is wasted;
+    # bytes are restricted to the PREFETCHED set, so predicted == kept + wasted.
+    assert summary.predicted_bytes == 5120
+    assert summary.kept_bytes == 1024
+    assert summary.wasted_bytes == 4096
+    assert summary.predicted_bytes == summary.kept_bytes + summary.wasted_bytes
+    assert stats.as_dict()["predicted_prefetch_bytes"] == 5120
+    assert stats.as_dict()["kept_prefetch_bytes"] == 1024
+
+
+def test_byte_accounting_is_none_without_payload_sizes():
+    # Backward-compatible: mocks / resident paths pass no ``expert_nbytes``, so
+    # the byte fields stay None -- never a fabricated average expert size.
+    stats = RouteAheadStats()
+    stats.begin_step()
+    stats.observe_layer(0, UNION, ROUTER_MASK)
+    summary = stats.commit_step(kept_rows=1)
+    assert summary.wasted == 3  # counts unaffected (experts {2, 5, 7})
+    assert summary.predicted_bytes is None
+    assert summary.kept_bytes is None
+    assert summary.wasted_bytes is None
+    assert stats.as_dict()["wasted_prefetch_bytes"] is None
+    # A fresh recorder also reports None -- the zero-overhead default.
+    assert RouteAheadStats().as_dict()["wasted_prefetch_bytes"] is None
+
+
+def test_executor_seam_forwards_expert_payload_bytes():
+    stats = RouteAheadStats()
+    prefetcher, _engine = _make_real_prefetcher()
+    prefetcher.expert_nbytes_map = {
+        (LAYER_ID, e): (e + 1) * 1024 for e in UNION
+    }
+    stats.begin_step()
+    with route_ahead_context(prefetcher=prefetcher, stats=stats):
+        _dispatch(_make_executor())
+    summary = stats.commit_step(kept_rows=1)
+
+    kept = {0, 1}  # ROUTER_MASK row 0 routes experts {0, 1}
+    wasted = set(UNION) - kept
+    assert summary.predicted_bytes == sum((e + 1) * 1024 for e in UNION)
+    assert summary.kept_bytes == sum((e + 1) * 1024 for e in kept)
+    assert summary.wasted_bytes == sum((e + 1) * 1024 for e in wasted)
+    assert stats.as_dict()["wasted_prefetch_bytes"] == summary.wasted_bytes
+
+
+def test_executor_seam_bytes_absent_for_mock_prefetcher():
+    # A MagicMock prefetcher has no real ``expert_nbytes_map`` dict, so the
+    # seam records None byte fields and never crashes on ``int(mock)``.
+    stats = RouteAheadStats()
+    prefetcher = MagicMock(name="ExpertPrefetcher")
+    stats.begin_step()
+    with route_ahead_context(prefetcher=prefetcher, stats=stats):
+        _dispatch(_make_executor())
+    summary = stats.commit_step(kept_rows=3)
+    assert summary.covered == len(UNION)
+    assert summary.wasted_bytes is None
+    assert stats.as_dict()["wasted_prefetch_bytes"] is None
+
+
+# ---------------------------------------------------------------------------
 # (c) default-off / zero-overhead: no handle, no recording, legacy behavior
 # ---------------------------------------------------------------------------
 

--- a/tests/python/serving/test_batch.py
+++ b/tests/python/serving/test_batch.py
@@ -97,6 +97,33 @@ def test_scheduler_output_creation() -> None:
     assert output.num_decode_tokens == 1
 
 
+def test_scheduler_output_verify_fields_default_empty() -> None:
+    output = SchedulerOutput(prefill_seq_ids=[1], decode_seq_ids=[2])
+
+    assert output.draft_seq_ids == []
+    assert output.verify_seq_ids == []
+    assert output.num_verify_tokens == 0
+    assert output.num_verify_expert_bytes == 0
+
+
+def test_scheduler_output_verify_fields_are_copied() -> None:
+    draft_ids = [5, 6]
+    verify_ids = [7]
+    output = SchedulerOutput(
+        draft_seq_ids=draft_ids,
+        verify_seq_ids=verify_ids,
+        num_verify_tokens=16,
+        num_verify_expert_bytes=4096,
+    )
+
+    assert output.draft_seq_ids == [5, 6]
+    assert output.verify_seq_ids == [7]
+    assert output.num_verify_tokens == 16
+    assert output.num_verify_expert_bytes == 4096
+    assert output.draft_seq_ids is not draft_ids
+    assert output.verify_seq_ids is not verify_ids
+
+
 def test_batch_builder_prefill_only() -> None:
     cache = _make_cache()
     sequences = {

--- a/tests/python/serving/test_dflash_deficit_scheduler.py
+++ b/tests/python/serving/test_dflash_deficit_scheduler.py
@@ -6,6 +6,7 @@ import types
 from pathlib import Path
 
 import pytest
+import torch
 
 ROOT = Path(__file__).resolve().parents[3]
 ROOT_STR = str(ROOT)
@@ -33,11 +34,11 @@ def _load_module(module_name: str, file_path: Path):
 _ensure_package("moe_infinity", ROOT / "moe_infinity")
 _ensure_package("moe_infinity.serving", ROOT / "moe_infinity" / "serving")
 
-_ = _load_module(
+_SEQUENCE_MODULE = _load_module(
     "moe_infinity.serving.sequence",
     ROOT / "moe_infinity" / "serving" / "sequence.py",
 )
-_ = _load_module(
+_KV_CACHE_MODULE = _load_module(
     "moe_infinity.serving.kv_cache",
     ROOT / "moe_infinity" / "serving" / "kv_cache.py",
 )
@@ -53,6 +54,44 @@ _SCHEDULER_MODULE = _load_module(
 Deficit2D = _SCHEDULER_MODULE.Deficit2D
 VerifyDemand = _SCHEDULER_MODULE.VerifyDemand
 admit_verify_demands = _SCHEDULER_MODULE.admit_verify_demands
+Scheduler = _SCHEDULER_MODULE.Scheduler
+PagedKVCache = _KV_CACHE_MODULE.PagedKVCache
+SamplingParams = _SEQUENCE_MODULE.SamplingParams
+SequenceData = _SEQUENCE_MODULE.SequenceData
+SequenceGroup = _SEQUENCE_MODULE.SequenceGroup
+
+
+def _make_cache(*, num_blocks: int = 8) -> object:
+    return PagedKVCache(
+        num_blocks=num_blocks,
+        block_size=4,
+        num_layers=1,
+        num_heads=2,
+        head_dim=8,
+        dtype=torch.float16,
+        device=torch.device("cpu"),
+    )
+
+
+def _make_group(request_id: str, seq_id: int, prompt_len: int) -> object:
+    sequence = SequenceData(
+        seq_id=seq_id,
+        prompt_token_ids=list(range(prompt_len)),
+        sampling_params=SamplingParams(),
+    )
+    return SequenceGroup(request_id=request_id, sequences=[sequence])
+
+
+def _verify_scheduler() -> object:
+    return Scheduler(
+        _make_cache(),
+        max_batch_size=8,
+        max_tokens_per_step=128,
+        verify_token_budget=64,
+        verify_expert_byte_budget=200,
+        verify_token_deficit_cap=64,
+        verify_expert_byte_deficit_cap=360,
+    )
 
 
 def test_inflight_is_seated_before_new_rounds() -> None:
@@ -187,3 +226,57 @@ def test_admission_is_side_effect_free() -> None:
     assert demands[0] == VerifyDemand(1, tokens=8, expert_bytes=40)
     assert budget == Deficit2D(16, 80)
     assert carried == Deficit2D(0, 0)
+
+
+def test_scheduler_admits_verify_demands_by_tokens_and_bytes() -> None:
+    scheduler = _verify_scheduler()
+    scheduler.set_verify_demand(1, tokens=16, expert_bytes=80, in_flight=True)
+    scheduler.set_verify_demand(2, tokens=16, expert_bytes=80, in_flight=False)
+    scheduler.set_verify_demand(3, tokens=16, expert_bytes=180, in_flight=False)
+
+    output = scheduler.schedule()
+
+    assert output.verify_seq_ids == [1, 2]
+    assert output.draft_seq_ids == [3]
+    assert output.num_verify_tokens == 32
+    assert output.num_verify_expert_bytes == 160
+    assert scheduler.carried_verify_deficit == Deficit2D(32, 40)
+
+
+def test_scheduler_verify_is_disabled_without_budgets() -> None:
+    scheduler = Scheduler(
+        _make_cache(), max_batch_size=8, max_tokens_per_step=128
+    )
+    scheduler.set_verify_demand(1, tokens=16, expert_bytes=80, in_flight=True)
+
+    output = scheduler.schedule()
+
+    assert output.verify_seq_ids == []
+    assert output.draft_seq_ids == []
+    assert output.num_verify_tokens == 0
+    assert output.num_verify_expert_bytes == 0
+
+
+def test_scheduler_clear_verify_demand_removes_it() -> None:
+    scheduler = _verify_scheduler()
+    scheduler.set_verify_demand(1, tokens=16, expert_bytes=80, in_flight=True)
+    scheduler.set_verify_demand(2, tokens=16, expert_bytes=80, in_flight=False)
+    scheduler.clear_verify_demand(2)
+
+    output = scheduler.schedule()
+
+    assert output.verify_seq_ids == [1]
+    assert output.draft_seq_ids == []
+
+
+def test_ordinary_prefill_output_has_empty_verify_lists() -> None:
+    scheduler = _verify_scheduler()
+    scheduler.add_request(_make_group("req-1", 1, 3))
+
+    output = scheduler.schedule()
+
+    assert output.prefill_seq_ids == [1]
+    assert output.draft_seq_ids == []
+    assert output.verify_seq_ids == []
+    assert output.num_verify_tokens == 0
+    assert output.num_verify_expert_bytes == 0

--- a/tests/python/serving/test_dflash_deficit_scheduler.py
+++ b/tests/python/serving/test_dflash_deficit_scheduler.py
@@ -1,0 +1,189 @@
+# pyright: reportAny=false
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+ROOT_STR = str(ROOT)
+if ROOT_STR not in sys.path:
+    sys.path.insert(0, ROOT_STR)
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+
+def _load_module(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ensure_package("moe_infinity", ROOT / "moe_infinity")
+_ensure_package("moe_infinity.serving", ROOT / "moe_infinity" / "serving")
+
+_ = _load_module(
+    "moe_infinity.serving.sequence",
+    ROOT / "moe_infinity" / "serving" / "sequence.py",
+)
+_ = _load_module(
+    "moe_infinity.serving.kv_cache",
+    ROOT / "moe_infinity" / "serving" / "kv_cache.py",
+)
+_ = _load_module(
+    "moe_infinity.serving.batch",
+    ROOT / "moe_infinity" / "serving" / "batch.py",
+)
+_SCHEDULER_MODULE = _load_module(
+    "moe_infinity.serving.scheduler",
+    ROOT / "moe_infinity" / "serving" / "scheduler.py",
+)
+
+Deficit2D = _SCHEDULER_MODULE.Deficit2D
+VerifyDemand = _SCHEDULER_MODULE.VerifyDemand
+admit_verify_demands = _SCHEDULER_MODULE.admit_verify_demands
+
+
+def test_inflight_is_seated_before_new_rounds() -> None:
+    demands = [
+        VerifyDemand(1, tokens=16, expert_bytes=80, in_flight=False),
+        VerifyDemand(2, tokens=16, expert_bytes=80, in_flight=True),
+    ]
+    out = admit_verify_demands(
+        demands,
+        budget=Deficit2D(tokens=16, expert_bytes=80),
+        carried=Deficit2D(tokens=0, expert_bytes=0),
+        deficit_cap=Deficit2D(tokens=32, expert_bytes=160),
+    )
+    assert out.seated_ids == (2,)
+    assert out.admitted_ids == ()
+
+
+def test_both_dimensions_must_fit_and_unused_budget_carries() -> None:
+    demands = [VerifyDemand(1, tokens=8, expert_bytes=90, in_flight=False)]
+    out = admit_verify_demands(
+        demands,
+        budget=Deficit2D(tokens=16, expert_bytes=80),
+        carried=Deficit2D(tokens=0, expert_bytes=0),
+        deficit_cap=Deficit2D(tokens=32, expert_bytes=160),
+    )
+    assert out.admitted_ids == ()
+    assert out.carried == Deficit2D(tokens=16, expert_bytes=80)
+
+
+def test_carried_deficit_is_capped() -> None:
+    out = admit_verify_demands(
+        [], Deficit2D(16, 80), Deficit2D(30, 150), Deficit2D(32, 160)
+    )
+    assert out.carried == Deficit2D(32, 160)
+
+
+def test_inflight_seated_then_remaining_budget_admits_new() -> None:
+    demands = [
+        VerifyDemand(1, tokens=8, expert_bytes=40, in_flight=True),
+        VerifyDemand(2, tokens=8, expert_bytes=40, in_flight=False),
+    ]
+    out = admit_verify_demands(
+        demands, Deficit2D(16, 80), Deficit2D(0, 0), Deficit2D(32, 160)
+    )
+    assert out.seated_ids == (1,)
+    assert out.admitted_ids == (2,)
+    assert out.carried == Deficit2D(0, 0)
+
+
+def test_new_rounds_are_admitted_fcfs_until_pool_exhausts() -> None:
+    demands = [
+        VerifyDemand(1, tokens=8, expert_bytes=40, in_flight=False),
+        VerifyDemand(2, tokens=8, expert_bytes=40, in_flight=False),
+        VerifyDemand(3, tokens=8, expert_bytes=40, in_flight=False),
+    ]
+    out = admit_verify_demands(
+        demands, Deficit2D(16, 80), Deficit2D(0, 0), Deficit2D(32, 160)
+    )
+    assert out.seated_ids == ()
+    assert out.admitted_ids == (1, 2)
+    assert out.carried == Deficit2D(0, 0)
+
+
+def test_large_demand_admits_once_carry_accumulates() -> None:
+    demand = VerifyDemand(1, tokens=24, expert_bytes=120, in_flight=False)
+    budget = Deficit2D(16, 80)
+    cap = Deficit2D(32, 160)
+
+    first = admit_verify_demands([demand], budget, Deficit2D(0, 0), cap)
+    assert first.admitted_ids == ()
+    assert first.carried == Deficit2D(16, 80)
+
+    second = admit_verify_demands([demand], budget, first.carried, cap)
+    assert second.admitted_ids == (1,)
+    assert second.carried == Deficit2D(8, 40)
+
+
+def test_seating_beyond_quantum_floors_carry_at_zero() -> None:
+    demands = [VerifyDemand(1, tokens=40, expert_bytes=200, in_flight=True)]
+    out = admit_verify_demands(
+        demands, Deficit2D(16, 80), Deficit2D(0, 0), Deficit2D(64, 320)
+    )
+    assert out.seated_ids == (1,)
+    assert out.admitted_ids == ()
+    assert out.carried == Deficit2D(0, 0)
+
+
+def test_negative_dimensions_are_rejected() -> None:
+    with pytest.raises(ValueError):
+        admit_verify_demands(
+            [], Deficit2D(-1, 0), Deficit2D(0, 0), Deficit2D(32, 160)
+        )
+    with pytest.raises(ValueError):
+        admit_verify_demands(
+            [VerifyDemand(1, tokens=-1, expert_bytes=0)],
+            Deficit2D(16, 80),
+            Deficit2D(0, 0),
+            Deficit2D(32, 160),
+        )
+
+
+def test_cap_must_cover_largest_single_demand_in_each_dimension() -> None:
+    with pytest.raises(ValueError, match="largest single demand"):
+        admit_verify_demands(
+            [VerifyDemand(1, tokens=40, expert_bytes=10)],
+            Deficit2D(16, 80),
+            Deficit2D(0, 0),
+            Deficit2D(32, 160),
+        )
+    with pytest.raises(ValueError, match="largest single demand"):
+        admit_verify_demands(
+            [VerifyDemand(1, tokens=10, expert_bytes=200)],
+            Deficit2D(16, 80),
+            Deficit2D(0, 0),
+            Deficit2D(32, 160),
+        )
+
+
+def test_admission_is_side_effect_free() -> None:
+    demands = [
+        VerifyDemand(1, tokens=8, expert_bytes=40, in_flight=False),
+        VerifyDemand(2, tokens=8, expert_bytes=40, in_flight=True),
+    ]
+    budget = Deficit2D(16, 80)
+    carried = Deficit2D(0, 0)
+    cap = Deficit2D(32, 160)
+
+    first = admit_verify_demands(demands, budget, carried, cap)
+    second = admit_verify_demands(demands, budget, carried, cap)
+
+    assert first == second
+    assert demands[0] == VerifyDemand(1, tokens=8, expert_bytes=40)
+    assert budget == Deficit2D(16, 80)
+    assert carried == Deficit2D(0, 0)

--- a/tests/python/serving/test_sequence.py
+++ b/tests/python/serving/test_sequence.py
@@ -4,6 +4,8 @@ import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
+
 _MODULE_PATH = (
     Path(__file__).resolve().parents[3]
     / "moe_infinity"
@@ -76,3 +78,97 @@ def test_sampling_params_defaults() -> None:
     assert params.max_tokens == 256
     assert params.stop == []
     assert params.repetition_penalty == 1.0
+
+
+def _fresh_sequence(seq_id: int = 100) -> object:
+    return SequenceData(
+        seq_id=seq_id,
+        prompt_token_ids=[1, 2],
+        sampling_params=SamplingParams(),
+    )
+
+
+def test_dflash_draft_verify_round_loop() -> None:
+    sequence = _fresh_sequence()
+
+    sequence.set_status(SequenceStatus.PREFILL)
+    sequence.set_status(SequenceStatus.DRAFT)
+    sequence.set_status(SequenceStatus.VERIFY)
+    sequence.set_status(SequenceStatus.DRAFT)
+    sequence.set_status(SequenceStatus.VERIFY)
+
+    assert SequenceStatus.DRAFT.value == "draft"
+    assert SequenceStatus.VERIFY.value == "verify"
+    assert sequence.status is SequenceStatus.VERIFY
+
+
+def test_verify_can_finish() -> None:
+    sequence = _fresh_sequence()
+
+    sequence.set_status(SequenceStatus.PREFILL)
+    sequence.set_status(SequenceStatus.DRAFT)
+    sequence.set_status(SequenceStatus.VERIFY)
+    sequence.set_status(SequenceStatus.FINISHED)
+
+    assert sequence.status is SequenceStatus.FINISHED
+
+
+def test_draft_and_verify_swap_then_recover_to_draft() -> None:
+    sequence = _fresh_sequence()
+
+    sequence.set_status(SequenceStatus.PREFILL)
+    sequence.set_status(SequenceStatus.DRAFT)
+    sequence.set_status(SequenceStatus.SWAPPED)
+    sequence.set_status(SequenceStatus.DRAFT)
+    sequence.set_status(SequenceStatus.VERIFY)
+    sequence.set_status(SequenceStatus.SWAPPED)
+
+    assert sequence.status is SequenceStatus.SWAPPED
+
+
+def test_draft_and_verify_can_cancel() -> None:
+    draft_seq = _fresh_sequence(seq_id=101)
+    draft_seq.set_status(SequenceStatus.PREFILL)
+    draft_seq.set_status(SequenceStatus.DRAFT)
+    draft_seq.set_status(SequenceStatus.CANCELLED)
+    assert draft_seq.status is SequenceStatus.CANCELLED
+
+    verify_seq = _fresh_sequence(seq_id=102)
+    verify_seq.set_status(SequenceStatus.PREFILL)
+    verify_seq.set_status(SequenceStatus.DRAFT)
+    verify_seq.set_status(SequenceStatus.VERIFY)
+    verify_seq.set_status(SequenceStatus.CANCELLED)
+    assert verify_seq.status is SequenceStatus.CANCELLED
+
+
+def test_ordinary_prefill_still_decodes() -> None:
+    sequence = _fresh_sequence()
+
+    sequence.set_status(SequenceStatus.PREFILL)
+    sequence.set_status(SequenceStatus.DECODE)
+
+    assert sequence.status is SequenceStatus.DECODE
+
+
+def test_waiting_cannot_enter_verify() -> None:
+    sequence = _fresh_sequence()
+
+    with pytest.raises(ValueError, match="invalid transition"):
+        sequence.set_status(SequenceStatus.VERIFY)
+
+
+def test_waiting_cannot_enter_draft() -> None:
+    sequence = _fresh_sequence()
+
+    with pytest.raises(ValueError, match="invalid transition"):
+        sequence.set_status(SequenceStatus.DRAFT)
+
+
+def test_ordinary_decode_cannot_enter_verify() -> None:
+    sequence = _fresh_sequence()
+
+    sequence.set_status(SequenceStatus.PREFILL)
+    sequence.set_status(SequenceStatus.DECODE)
+
+    with pytest.raises(ValueError, match="invalid transition"):
+        sequence.set_status(SequenceStatus.VERIFY)


### PR DESCRIPTION
## WIP / DRAFT — do not merge

**Stacks on #156 (serving DRAFT/VERIFY scheduler) + #157 (`expert_nbytes` byte instrumentation).**
This branch = `feat/pd-dflash-phaseA-runner` (#157) with `feat/pd-dflash-serving-scheduler` (#156) merged in. It must **not** be merged before both of those, and — see below — not until the Step‑5 seam follow‑up lands.

### TL;DR (honest gate)

Task 6 **Steps 1–4 are already complete** in the #156+#157 stack. The remaining **Step 5** (engine `DRAFT→VERIFY→DRAFT` driving with *exact* per‑round expert‑byte demand) is **BLOCKED**: it genuinely requires a public single‑round control seam on `DFlashSpeculator` that does **not** exist and that **Task 6 does not authorize creating**. Per the plan's honest‑gating rule, this PR **reports the exact seam** instead of hacking one in. The unique change here is:

- the prepared, conflict‑resolved stacked base, and
- `docs/superpowers/notes/2026-08-14-pd-dflash-task6-step5-seam.md` — the exact seam spec.

No production code was changed by this PR beyond the merge itself.

### What the stack already provides (verified here)

| Piece | Where | Source |
|---|---|---|
| `SequenceStatus.DRAFT`/`VERIFY` (Task 4) | `serving/sequence.py` | #156 |
| Pure 2‑D deficit `admit_verify_demands` (Task 5) | `serving/scheduler.py:50` | #156 |
| `SchedulerOutput.{draft,verify}_seq_ids`, `num_verify_{tokens,expert_bytes}` (Task 6 S3) | `serving/batch.py` | #156 |
| `set_verify_demand`/`clear_verify_demand` + `_apply_verify_scheduling` + engine budget wiring (Task 6 S4) | `serving/scheduler.py:325`, `serving/engine.py:135` | #156 |
| Task 6 S1 "three speculative sequences" admission (scheduler‑level) | `tests/python/serving/test_dflash_deficit_scheduler.py:231` | #156 |
| `ExpertPrefetcher.expert_nbytes_map` exact FP4 payload bytes | `memory/expert_prefetcher.py`, `runtime/model_offload.py`, `distributed/expert_executor.py` | #157 |

Merge conflicts were limited to two Task‑1 files (`benchmarks/dflash/report.py`, `tests/python/dflash/test_pd_dflash_report.py`); resolved **KEEP‑BOTH** — #157's versions are strict supersets of #156's identical Task‑1 contract (verified: zero #156‑unique lines dropped), so both sides' behavior is preserved.

### Why Step 5 is blocked (root cause)

Step 5 requires registering a pending verify's **exact** demand *before* it runs: `set_verify_demand(seq_id, tokens=B, expert_bytes=Σ expert_nbytes[routed union], …)`, then running VERIFY only for admitted `verify_seq_ids`. But:

- The serving engine only exposes the whole‑request loop — `_step_speculative` → `speculator.generate()` (all rounds atomically); `SpeculativeGenerator` Protocol has just `generate()`.
- `DFlashSpeculator` runs every round inside `_generate_single`; per‑round state (`target_kv`, `draft_kv`, `context_feature`, `anchor`, `start`, `step_trace`) is **local**; `_run_drafter`/`_verify_target_block` are private.
- Route‑ahead is **internal to the verify forward** (`route_ahead_context` → `DistributedExpertExecutor.dispatch_local`), so a verify's exact `expert_nbytes` sum is only known **during/after** it runs (surfaced post‑hoc in `RouteAheadStats`) — never before, which is when admission needs it.

No honest workaround exists: post‑hoc stats can't gate admission; fabricating bytes from expert **count** is forbidden (plan Step 4 + task); re‑implementing the draft/verify loop in the engine would be a forbidden **second router/prefetch path**.

### The exact seam required (NOT in Task 6's file list)

A public, per‑sequence, single‑round surface on `spec_decode/dflash.py` that externalizes the `_generate_single` state, plus a read‑only route projection in `distributed/expert_executor.py`:

```python
begin_session(prompt_ids, sampling_params, stop_ids) -> SpecSession   # prefill/anchor
draft_round(session)  -> DraftResult   # one _run_drafter; PROJECT routed expert union via the
                                       # same gate/top-k path the verify uses (design §10 BM1),
                                       # no expert exec, no 2nd router; returns tokens=B,
                                       # expert_union, expert_bytes=Σ expert_nbytes_map[union]
verify_round(session) -> VerifyResult  # one _verify_target_block under route_ahead_context;
                                       # accept/commit/rollback; accepted_ids, committed_count, finished
```

Task 6's authorized files are only `serving/{batch,scheduler,engine}.py` (+ tests + benchmark) — **not** `spec_decode/dflash.py` or `distributed/expert_executor.py`; and Step 5's wording ("consume the *already‑built* route‑ahead result", "Do not add another router or prefetch path") describes consuming an artifact, not adding a per‑round draft/verify API. Full detail: `docs/superpowers/notes/2026-08-14-pd-dflash-task6-step5-seam.md`.

**Recommendation:** authorize a follow‑up (or amend Task 6's file list) for the `dflash.py` `SpecSession` seam + the read‑only route projection, gated behind the BM1 gate+top‑k projection the design already specifies. Then `engine.py` Step 5 can register EXACT `expert_nbytes` demand and let the 2‑D scheduler govern VERIFY under concurrency.

### Verification (this base)

- `tests/python/serving/test_dflash_deficit_scheduler.py`, `test_batch.py`, `test_sequence.py`, `test_scheduler.py`, `tests/python/dflash/test_pd_dflash_report.py` → **54 passed**
- `tests/python/dflash/test_route_ahead_metrics.py`, `test_route_ahead_wire.py` → **36 passed**
- gpt‑oss offload no‑regression `tests/test_gpt_oss_offload_topology.py` → **5 passed**
- ruff check + ruff‑format + LSP diagnostics on changed/resolved files → clean
- `test_gpt_oss_mxfp4_dispatch.py` GPU/native failures are `moe_infinity._v4_fp4` not being built in this CPU env (environmental, unrelated to this PR)

_No `_store`/native rebuild: no C++ changed._
