### PR TITLE
WIP: PD-DFlash Task 9 — route-ahead priority band recovered; BM3 BLOCKED (not justified, do not merge)

### DIFF
--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -239,7 +239,7 @@ void ArcherPrefetchHandle::EnqueuePrefetch(const uint32_t tensor_id,
   auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
 
   auto task = std::make_shared<Task>();
-  task->priority = 1;
+  task->priority = kBackgroundPrefetchPriority;
   task->node = node;
   task->on_demand = false;
   task->src_device = node->device;

--- a/core/prefetch/archer_prefetch_handle.h
+++ b/core/prefetch/archer_prefetch_handle.h
@@ -8,6 +8,7 @@
 #include "aio/archer_tensor_handle.h"
 #include "model/model_topology.h"
 #include "parallel/expert_dispatcher.h"
+#include "prefetch/task_scheduler.h"
 
 class ArcherPrefetchHandle {
  public:
@@ -29,7 +30,7 @@ class ArcherPrefetchHandle {
   void ReplaceCacheCandidates(const std::vector<std::uint32_t>& tensor_ids);
   void EnqueuePrefetch(const uint32_t tensor_id, int gpu_id);
   void EnqueuePrefetchTensors(const std::vector<std::uint32_t>& tensor_ids,
-                              std::uint32_t priority = 1);
+                              std::uint32_t priority = kRouteAheadPriority);
 
   void OffloadTensor(torch::Tensor& tensor, const std::uint32_t tensor_id);
   void RegisterTensor(torch::Tensor& tensor, const std::uint32_t tensor_id);

--- a/core/prefetch/task_scheduler.h
+++ b/core/prefetch/task_scheduler.h
@@ -23,6 +23,13 @@
 
 #define NUM_PRIORITY 20UL
 
+// Priority bands, lowest value serviced first (GPUThreadFunc scans queue 0 up).
+// Band 0 is also the on-demand queue: dedup sweeps skip index 0, so route-ahead
+// work parked at 0 keeps on-demand's non-preemptible semantics.
+constexpr std::uint32_t kOnDemandPriority = 0;
+constexpr std::uint32_t kRouteAheadPriority = 1;
+constexpr std::uint32_t kBackgroundPrefetchPriority = 2;
+
 struct Task {
   bool on_demand = false;
   NodePtr node;

--- a/core/python/py_archer_prefetch.cpp
+++ b/core/python/py_archer_prefetch.cpp
@@ -91,7 +91,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            &ArcherPrefetchHandle::GetNodeDefaultDevice)
       .def("get_node_device", &ArcherPrefetchHandle::GetNodeDevice)
       .def("prefetch_tensors", &ArcherPrefetchHandle::EnqueuePrefetchTensors,
-           py::arg("tensor_ids"), py::arg("priority") = 1)
+           py::arg("tensor_ids"), py::arg("priority") = kRouteAheadPriority)
       .def("replace_cache_candidates",
            &ArcherPrefetchHandle::ReplaceCacheCandidates)
       .def("enqueue_prefetch", &ArcherPrefetchHandle::EnqueuePrefetch)

--- a/moe_infinity/memory/expert_prefetcher.py
+++ b/moe_infinity/memory/expert_prefetcher.py
@@ -12,6 +12,11 @@ from transformers import PretrainedConfig
 
 from moe_infinity.utils import parse_moe_param
 
+# Native prefetch priority bands; must mirror core/prefetch/task_scheduler.h.
+ON_DEMAND_PRIORITY = 0
+ROUTE_AHEAD_PRIORITY = 1
+BACKGROUND_PREFETCH_PRIORITY = 2
+
 try:
     import nvtx  # type: ignore[reportMissingTypeStubs]
 except ImportError:
@@ -45,6 +50,7 @@ def _hit_rate_from_visit_counts(counts: Any) -> Optional[float]:
 class ExpertPrefetcher(object):
     cache_file_rd: Optional[Any] = None
     first_k_dense_replace: int = 0
+    route_ahead_priority: int = ROUTE_AHEAD_PRIORITY
     archer_engine: Any
     expert_dispatcher: Optional[Any] = None
     expert_tensor_map: dict[tuple[int, int], int]
@@ -149,7 +155,12 @@ class ExpertPrefetcher(object):
                 return 0.0
         return 0.0
 
-    def prefetch_experts_list(self, layer_id: int, expert_list: List[int]):
+    def prefetch_experts_list(
+        self,
+        layer_id: int,
+        expert_list: List[int],
+        priority: Optional[int] = None,
+    ):
         if self.archer_engine is None:
             return
         tensor_ids = []
@@ -157,9 +168,10 @@ class ExpertPrefetcher(object):
             tensor_ids.append(self.expert_tensor_map[(layer_id, j)])
         if not tensor_ids:
             return
+        band = self.route_ahead_priority if priority is None else priority
         batched_issue = getattr(self.archer_engine, "prefetch_tensors", None)
         if callable(batched_issue):
-            batched_issue(tensor_ids)
+            batched_issue(tensor_ids, priority=band)
             return
         for tensor_id in tensor_ids:
             gpu_id = self.archer_engine.get_node_default_device([tensor_id])
@@ -274,7 +286,9 @@ class ExpertPrefetcher(object):
                 ::-1
             ].tolist()
 
-        self.prefetch_experts_list(next_layer, topk_indices)
+        self.prefetch_experts_list(
+            next_layer, topk_indices, priority=BACKGROUND_PREFETCH_PRIORITY
+        )
         self._last_speculative_prediction = set(topk_indices)
 
     def correct_prefetch(

--- a/tests/python/dflash/test_prefetch_native_gpu.py
+++ b/tests/python/dflash/test_prefetch_native_gpu.py
@@ -117,3 +117,57 @@ def test_native_batched_prefetch_experts_list_uses_batched_path(
         if layer == some_layer
     )
     offloaded_prefetcher.prefetch_experts_list(some_layer, experts)
+
+
+def test_native_priority_bands_accept_each_service_class_reverse_order(
+    offloaded_prefetcher,
+) -> None:
+    from moe_infinity.memory.expert_prefetcher import (
+        BACKGROUND_PREFETCH_PRIORITY,
+        ON_DEMAND_PRIORITY,
+        ROUTE_AHEAD_PRIORITY,
+    )
+
+    engine = offloaded_prefetcher.archer_engine
+    tensor_ids = _saturated_ids(offloaded_prefetcher)
+    assert tensor_ids, "no offloaded expert tensors to issue"
+
+    for priority in (
+        BACKGROUND_PREFETCH_PRIORITY,
+        ROUTE_AHEAD_PRIORITY,
+        ON_DEMAND_PRIORITY,
+    ):
+        assert engine.prefetch_tensors(tensor_ids, priority) is None
+        torch.cuda.synchronize()
+
+
+def test_native_route_ahead_priority_knob_issues_each_band(
+    offloaded_prefetcher,
+) -> None:
+    from moe_infinity.memory.expert_prefetcher import (
+        BACKGROUND_PREFETCH_PRIORITY,
+        ON_DEMAND_PRIORITY,
+        ROUTE_AHEAD_PRIORITY,
+    )
+
+    layers = sorted(
+        {layer for layer, _e in offloaded_prefetcher.expert_tensor_map}
+    )
+    some_layer = layers[0]
+    experts = sorted(
+        expert
+        for layer, expert in offloaded_prefetcher.expert_tensor_map
+        if layer == some_layer
+    )
+    original = offloaded_prefetcher.route_ahead_priority
+    try:
+        for band in (
+            BACKGROUND_PREFETCH_PRIORITY,
+            ROUTE_AHEAD_PRIORITY,
+            ON_DEMAND_PRIORITY,
+        ):
+            offloaded_prefetcher.route_ahead_priority = band
+            offloaded_prefetcher.prefetch_experts_list(some_layer, experts)
+            torch.cuda.synchronize()
+    finally:
+        offloaded_prefetcher.route_ahead_priority = original

--- a/tests/python/dflash/test_speculative_prefetch.py
+++ b/tests/python/dflash/test_speculative_prefetch.py
@@ -26,7 +26,12 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from moe_infinity.memory.expert_prefetcher import ExpertPrefetcher
+from moe_infinity.memory.expert_prefetcher import (
+    BACKGROUND_PREFETCH_PRIORITY,
+    ON_DEMAND_PRIORITY,
+    ROUTE_AHEAD_PRIORITY,
+    ExpertPrefetcher,
+)
 
 # Hand-checked legacy fixture: [2 tokens, 4 experts]
 #   mean over tokens = [2.0, 3.5, 3.0, 0.5] -> top-2 = experts [1, 2]
@@ -185,7 +190,9 @@ def _make_prefetcher_without_batch(num_layers: int = 8, num_experts: int = 8):
 def test_prefetch_experts_list_batches_one_native_call_when_available():
     prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
     prefetcher.prefetch_experts_list(3, [3, 1, 7])
-    engine.prefetch_tensors.assert_called_once_with([303, 301, 307])
+    engine.prefetch_tensors.assert_called_once_with(
+        [303, 301, 307], priority=ROUTE_AHEAD_PRIORITY
+    )
     engine.enqueue_prefetch.assert_not_called()
 
 
@@ -202,3 +209,43 @@ def test_prefetch_experts_list_empty_batch_calls_neither_path():
     prefetcher.prefetch_experts_list(3, [])
     engine.prefetch_tensors.assert_not_called()
     engine.enqueue_prefetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# priority bands (plan Task 9 Step 5): explicit route-ahead vs legacy background
+# ---------------------------------------------------------------------------
+
+
+def _issued_priority(engine: MagicMock) -> int:
+    return engine.prefetch_tensors.call_args.kwargs["priority"]
+
+
+def test_explicit_route_ahead_issues_on_the_route_ahead_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher.speculative_prefetch(
+        1, expert_ids=[3, 1, 7], prefetch_layer_id=5
+    )
+    assert _enqueued_tensor_ids(engine) == [503, 501, 507]
+    assert _issued_priority(engine) == ROUTE_AHEAD_PRIORITY
+
+
+def test_legacy_router_logits_issues_on_the_background_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=4)
+    prefetcher.speculative_prefetch(2, LOGITS)
+    assert _enqueued_tensor_ids(engine) == [301, 302]
+    assert _issued_priority(engine) == BACKGROUND_PREFETCH_PRIORITY
+
+
+def test_correct_prefetch_issues_on_the_route_ahead_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher._last_speculative_prediction = {1}
+    prefetcher.correct_prefetch(3, [3, 1, 7])
+    assert _enqueued_tensor_ids(engine) == [303, 307]
+    assert _issued_priority(engine) == ROUTE_AHEAD_PRIORITY
+
+
+def test_route_ahead_priority_knob_sweeps_the_issued_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher.route_ahead_priority = ON_DEMAND_PRIORITY
+    prefetcher.prefetch_experts_list(3, [3, 1, 7])
+    assert _issued_priority(engine) == ON_DEMAND_PRIORITY


### PR DESCRIPTION
**WIP / DRAFT — do not merge.** Off `origin/dev`. Reviewable recovery of the Task 9 route-ahead priority-band candidate. **BM3 did not produce a ship/no-ship verdict** (blocked — see below), so per the plan's iron rule the band is **NOT shipped**. No false win either way.

## What this recovers
PR #161 states the priority-band C++ was *"implemented locally, built (sm_120), and validated … then reverted"* (Python-only shipped) because its DFlash draft was absent, so BM3 could not run. The draft `z-lab/gpt-oss-20b-DFlash` is now cached.

The reverted candidate was **never committed** — verified via `git log`/pickaxe (`-S kRouteAheadPriority`), `fsck --lost-found`, `reflog`, and all stashes: no add commit, no revert commit, no dangling commit. The only hit was the plan doc's example code block. So the revert was a working-tree discard, and I **re-implemented it from the plan spec** (Task 9 Steps 4–5), building on the already-shipped `EnqueuePrefetchTensors(tensor_ids, priority=1)` (Task 8).

## The candidate (7 files, +131/-8)
**C++** — `core/prefetch/task_scheduler.h`, `archer_prefetch_handle.{h,cpp}`, `core/python/py_archer_prefetch.cpp`:
- Named bands `kOnDemandPriority=0`, `kRouteAheadPriority=1`, `kBackgroundPrefetchPriority=2` (`NUM_PRIORITY` stays 20).
- Ordinary `EnqueuePrefetch` now enqueues at **background (2)** (was 1); the batched `EnqueuePrefetchTensors` + `prefetch_tensors` binding default to the dedicated **route-ahead (1)** band.

**Python** — `moe_infinity/memory/expert_prefetcher.py`:
- Adds `ExpertPrefetcher.route_ahead_priority` (the exact knob `bench_prefetch_priority.py` drives). Explicit route-ahead `prefetch_experts_list` issues at that band; legacy `speculative_prefetch` issues at background.

**Tests** — `test_prefetch_native_gpu.py`, `test_speculative_prefetch.py`:
- Native GPU smoke asserts all three bands + the knob issue without raising; CPU mock tests assert explicit=route-ahead / legacy=background mapping.

## BM3 — BLOCKED (could not reach a verdict)
Two independent issues **on `dev`**, both unrelated to this candidate (a 1-line `EnqueuePrefetch` priority change + a Python knob; the native smoke swept all three bands with no hang):

- **(A) Harness deadlock.** `bench_prefetch_priority.run_priority_ablation._reset_cache()` calls the **terminal** `archer_engine.clean_up_resources()` between arms. After the first measured generation the offload engine is torn down (`has_cleaned_up_resources_=true`, `StopExec`), so the next forward hangs forever in `fetch_tensors` → `_pre_forward_input_hook` (`moe_infinity/runtime/model_offload.py:1670`, from `init code commit`). Reproduced with a faulthandler stack dump; GEN#1 completes in ~1 s, GEN#2 (post-reset) never returns and no `bm3.json` is written. It is a **native** wait (even `os._exit` couldn't reap it).
- **(B) Exposed-fetch is uninstrumented.** `bm3_decision`'s condition (1) needs `route_ahead.exposed_fetch < default.exposed_fetch`, but no `exposed_fetch_seconds`/`get_exposed_fetch_seconds`/`on_demand_fetch_seconds` accessor exists on the engine/prefetcher and `route_ahead_stats.as_dict()` has no such key, so `_exposed_fetch_seconds()` returns `0.0` for **every** arm → `exposed_fetch_improved = (0.0 < 0.0) = False`. **`ship_priority_band` is structurally unmeasurable on dev** (can never be true), regardless of hardware or the now-cached draft.

Because BM3 cannot prove the route-ahead band lowers exposed fetch, and the plan forbids shipping any C++ hop without that proof, the band is **not shipped**. I did not fabricate a `ship=true` (no evidence) nor a measured `ship=false` (the metric is unmeasured).

## Validation (evidence, not a ship claim)
- **Build:** SM120 (`MOE_ENABLE_SM120=1`) clean, 0 errors; `_store.so` rebuilt; binding confirmed `prefetch_tensors(..., priority=1)`, `ExpertPrefetcher.route_ahead_priority=1`.
- **Native priority-band smoke (offloaded gpt-oss-20b):** `tests/python/dflash/test_prefetch_native_gpu.py` → **5 passed** (3 existing + 2 new: all-three-bands + knob sweep).
- **CPU decision/mock tests:** `test_prefetch_perf_reports.py` + `test_speculative_prefetch.py` → **60 passed**.
- **gpt-oss offload no-regression:** `tests/test_gpt_oss_offload_topology.py` + `tests/python/unit/test_gpt_oss_mxfp4_dispatch.py` → **9 passed** (matches #161).
- ruff (check + format), clang-format, codespell, LSP: clean.

## To actually run BM3 later (out of scope here)
Fix `_reset_cache()` to reset cache state without the terminal `clean_up_resources()` (Blocker A), and instrument `exposed_fetch_seconds` (Blocker B, e.g. an on-demand-fetch stall accumulator on the prefetcher or a native accessor). Then rerun `python -m benchmarks.dflash.bench_prefetch_priority` on offloaded gpt-oss-20b + `z-lab/gpt-oss-20b-DFlash`.
