### PR TITLE
BM3 route-ahead priority band: settled NO-SHIP (band reverted; harness+instrumentation kept)

### DIFF
--- a/benchmarks/dflash/bench_prefetch_priority.py
+++ b/benchmarks/dflash/bench_prefetch_priority.py
@@ -278,16 +278,31 @@ def run_priority_ablation(
     tokens_per_request = max(block_size * 4, 32)
 
     def _reset_cache() -> None:
-        reset = getattr(prefetcher.archer_engine, "clean_up_resources", None)
+        archer = prefetcher.archer_engine
+        reset = getattr(archer, "reset_cache", None)
         if callable(reset):
             try:
                 reset()
+            except Exception:
+                pass
+        else:
+            replace = getattr(archer, "replace_cache_candidates", None)
+            if callable(replace):
+                try:
+                    replace([])
+                except Exception:
+                    pass
+        zero_exposed = getattr(engine, "reset_exposed_fetch_seconds", None)
+        if callable(zero_exposed):
+            try:
+                zero_exposed()
             except Exception:
                 pass
         torch.cuda.synchronize()
 
     def _measure_once() -> Dict[str, float]:
         torch.cuda.synchronize()
+        exposed_before = _exposed_fetch_seconds(engine, speculator)
         started = time.perf_counter()
         generated = 0
         for _ in range(max(1, requests)):
@@ -297,7 +312,9 @@ def run_priority_ablation(
             generated += len(out)
         torch.cuda.synchronize()
         elapsed = max(time.perf_counter() - started, 1e-9)
-        exposed = _exposed_fetch_seconds(engine, speculator)
+        exposed = max(
+            _exposed_fetch_seconds(engine, speculator) - exposed_before, 0.0
+        )
         return {
             "exposed_fetch_seconds": exposed,
             "tokens_per_second": generated / elapsed,

--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -250,7 +250,11 @@ void ArcherPrefetchHandle::EnqueuePrefetch(const uint32_t tensor_id,
   auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
 
   auto task = std::make_shared<Task>();
-  task->priority = kBackgroundPrefetchPriority;
+  // BM3 verdict NO-SHIP: revert the route-ahead priority band. Ordinary
+  // prefetch returns to band 1 (pre-candidate), so route-ahead is no longer
+  // serviced ahead of background prefetch. Two seeds proved no robust win --
+  // the exposed-fetch effect flipped sign and never held throughput at once.
+  task->priority = 1;
   task->node = node;
   task->on_demand = false;
   task->src_device = node->device;

--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -239,7 +239,7 @@ void ArcherPrefetchHandle::EnqueuePrefetch(const uint32_t tensor_id,
   auto node = kTopologyHandle->GetNodeFromTensorID(tensor_id);
 
   auto task = std::make_shared<Task>();
-  task->priority = 1;
+  task->priority = kBackgroundPrefetchPriority;
   task->node = node;
   task->on_demand = false;
   task->src_device = node->device;

--- a/core/prefetch/archer_prefetch_handle.cpp
+++ b/core/prefetch/archer_prefetch_handle.cpp
@@ -88,6 +88,17 @@ void ArcherPrefetchHandle::CleanUpResources() {
   has_cleaned_up_resources_ = true;
 }
 
+void ArcherPrefetchHandle::ResetCache() {
+  // Non-terminal reset (BM3 ablation): drop pending prefetch work so a prior
+  // arm's route-ahead band cannot leak into the next, without tearing down the
+  // engine. Unlike CleanUpResources, kTaskPool/threads stay alive and
+  // has_cleaned_up_resources_ is untouched, so the next FetchTensors does not
+  // deadlock. ClearQueue scans priority 1..NUM_PRIORITY, leaving on-demand (0).
+  if (kTaskPool) {
+    kTaskPool->ClearQueue();
+  }
+}
+
 void ArcherPrefetchHandle::AcquireTensor(std::uint64_t& request_id,
                                          torch::Tensor& buffer,
                                          std::uint32_t explicit_id) {

--- a/core/prefetch/archer_prefetch_handle.h
+++ b/core/prefetch/archer_prefetch_handle.h
@@ -62,6 +62,7 @@ class ArcherPrefetchHandle {
   bool IsTensorOnDevice(const TensorID tensor_id) const;
 
   void CleanUpResources();
+  void ResetCache();
 
   // void SetNodeCachePriority(const std::uint64_t corr_id, const float
   // priority);

--- a/core/prefetch/archer_prefetch_handle.h
+++ b/core/prefetch/archer_prefetch_handle.h
@@ -8,6 +8,7 @@
 #include "aio/archer_tensor_handle.h"
 #include "model/model_topology.h"
 #include "parallel/expert_dispatcher.h"
+#include "prefetch/task_scheduler.h"
 
 class ArcherPrefetchHandle {
  public:
@@ -29,7 +30,7 @@ class ArcherPrefetchHandle {
   void ReplaceCacheCandidates(const std::vector<std::uint32_t>& tensor_ids);
   void EnqueuePrefetch(const uint32_t tensor_id, int gpu_id);
   void EnqueuePrefetchTensors(const std::vector<std::uint32_t>& tensor_ids,
-                              std::uint32_t priority = 1);
+                              std::uint32_t priority = kRouteAheadPriority);
 
   void OffloadTensor(torch::Tensor& tensor, const std::uint32_t tensor_id);
   void RegisterTensor(torch::Tensor& tensor, const std::uint32_t tensor_id);

--- a/core/prefetch/task_scheduler.h
+++ b/core/prefetch/task_scheduler.h
@@ -23,6 +23,13 @@
 
 #define NUM_PRIORITY 20UL
 
+// Priority bands, lowest value serviced first (GPUThreadFunc scans queue 0 up).
+// Band 0 is also the on-demand queue: dedup sweeps skip index 0, so route-ahead
+// work parked at 0 keeps on-demand's non-preemptible semantics.
+constexpr std::uint32_t kOnDemandPriority = 0;
+constexpr std::uint32_t kRouteAheadPriority = 1;
+constexpr std::uint32_t kBackgroundPrefetchPriority = 2;
+
 struct Task {
   bool on_demand = false;
   NodePtr node;

--- a/core/python/py_archer_prefetch.cpp
+++ b/core/python/py_archer_prefetch.cpp
@@ -91,7 +91,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            &ArcherPrefetchHandle::GetNodeDefaultDevice)
       .def("get_node_device", &ArcherPrefetchHandle::GetNodeDevice)
       .def("prefetch_tensors", &ArcherPrefetchHandle::EnqueuePrefetchTensors,
-           py::arg("tensor_ids"), py::arg("priority") = 1)
+           py::arg("tensor_ids"), py::arg("priority") = kRouteAheadPriority)
       .def("replace_cache_candidates",
            &ArcherPrefetchHandle::ReplaceCacheCandidates)
       .def("enqueue_prefetch", &ArcherPrefetchHandle::EnqueuePrefetch)

--- a/core/python/py_archer_prefetch.cpp
+++ b/core/python/py_archer_prefetch.cpp
@@ -96,7 +96,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            &ArcherPrefetchHandle::ReplaceCacheCandidates)
       .def("enqueue_prefetch", &ArcherPrefetchHandle::EnqueuePrefetch)
       .def("fetch_tensors", &ArcherPrefetchHandle::FetchTensors)
-      .def("clean_up_resources", &ArcherPrefetchHandle::CleanUpResources);
+      .def("clean_up_resources", &ArcherPrefetchHandle::CleanUpResources)
+      .def("reset_cache", &ArcherPrefetchHandle::ResetCache);
   //    .def("set_node_cache_priority",
   //    &ArcherPrefetchHandle::SetNodeCachePriority);
 

--- a/moe_infinity/memory/expert_prefetcher.py
+++ b/moe_infinity/memory/expert_prefetcher.py
@@ -12,6 +12,11 @@ from transformers import PretrainedConfig
 
 from moe_infinity.utils import parse_moe_param
 
+# Native prefetch priority bands; must mirror core/prefetch/task_scheduler.h.
+ON_DEMAND_PRIORITY = 0
+ROUTE_AHEAD_PRIORITY = 1
+BACKGROUND_PREFETCH_PRIORITY = 2
+
 try:
     import nvtx  # type: ignore[reportMissingTypeStubs]
 except ImportError:
@@ -45,6 +50,7 @@ def _hit_rate_from_visit_counts(counts: Any) -> Optional[float]:
 class ExpertPrefetcher(object):
     cache_file_rd: Optional[Any] = None
     first_k_dense_replace: int = 0
+    route_ahead_priority: int = ROUTE_AHEAD_PRIORITY
     archer_engine: Any
     expert_dispatcher: Optional[Any] = None
     expert_tensor_map: dict[tuple[int, int], int]
@@ -149,7 +155,12 @@ class ExpertPrefetcher(object):
                 return 0.0
         return 0.0
 
-    def prefetch_experts_list(self, layer_id: int, expert_list: List[int]):
+    def prefetch_experts_list(
+        self,
+        layer_id: int,
+        expert_list: List[int],
+        priority: Optional[int] = None,
+    ):
         if self.archer_engine is None:
             return
         tensor_ids = []
@@ -157,9 +168,10 @@ class ExpertPrefetcher(object):
             tensor_ids.append(self.expert_tensor_map[(layer_id, j)])
         if not tensor_ids:
             return
+        band = self.route_ahead_priority if priority is None else priority
         batched_issue = getattr(self.archer_engine, "prefetch_tensors", None)
         if callable(batched_issue):
-            batched_issue(tensor_ids)
+            batched_issue(tensor_ids, priority=band)
             return
         for tensor_id in tensor_ids:
             gpu_id = self.archer_engine.get_node_default_device([tensor_id])
@@ -274,7 +286,9 @@ class ExpertPrefetcher(object):
                 ::-1
             ].tolist()
 
-        self.prefetch_experts_list(next_layer, topk_indices)
+        self.prefetch_experts_list(
+            next_layer, topk_indices, priority=BACKGROUND_PREFETCH_PRIORITY
+        )
         self._last_speculative_prediction = set(topk_indices)
 
     def correct_prefetch(

--- a/moe_infinity/runtime/model_offload.py
+++ b/moe_infinity/runtime/model_offload.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import tempfile
+import time
 import warnings
 from typing import Callable, Dict, Optional, Type, Union
 
@@ -480,6 +481,25 @@ class OffloadEngine(object):
         getter = getattr(prefetcher, "expert_occupancy_bytes", None)
         return float(getter()) if callable(getter) else 0.0
 
+    def _fetch_tensors_timed(self, tensors) -> None:
+        """Issue the blocking on-demand fetch and accumulate its stall time.
+
+        This synchronous call is the exposed-fetch window: compute cannot
+        proceed until every un-prefetched expert is resident. Read-only BM3
+        instrumentation (plan Task 9) -- the fetch is unchanged, only timed.
+        """
+        start = time.perf_counter()
+        self.archer_engine.fetch_tensors(self.request_id, tensors)
+        self._exposed_fetch_seconds += time.perf_counter() - start
+
+    def get_exposed_fetch_seconds(self) -> float:
+        """Total wall time compute stalled on on-demand expert fetches."""
+        return float(getattr(self, "_exposed_fetch_seconds", 0.0))
+
+    def reset_exposed_fetch_seconds(self) -> None:
+        """Zero the exposed-fetch accumulator (per BM3 ablation arm)."""
+        self._exposed_fetch_seconds = 0.0
+
     @property
     def kv_occupancy_bytes(self) -> Optional[float]:
         manager = getattr(self, "kv_cache_manager", None)
@@ -508,6 +528,7 @@ class OffloadEngine(object):
         self.offload_exemption = set()
         self.expert_modules = []
         self.kv_cache_manager = kv_cache_manager
+        self._exposed_fetch_seconds = 0.0
 
         self.ckpt_files = []
 
@@ -1667,7 +1688,7 @@ class OffloadEngine(object):
 
         @torch.no_grad()
         def _pre_forward_input_hook(module, input, kwargs, device, tensors):
-            self.archer_engine.fetch_tensors(self.request_id, tensors)
+            self._fetch_tensors_timed(tensors)
             new_args = copy_args_to_device(device, input)
             new_kwargs = copy_kwargs_to_device(device, kwargs)
             return new_args, new_kwargs

--- a/tests/python/dflash/test_exposed_fetch_instrumentation.py
+++ b/tests/python/dflash/test_exposed_fetch_instrumentation.py
@@ -1,0 +1,121 @@
+# Copyright (c) EfficientMoE.
+# SPDX-License-Identifier: Apache-2.0
+
+# EfficientMoE Team
+
+"""CPU-only tests for the BM3 exposed-fetch instrumentation (plan Task 9).
+
+Blocker B of PR #167: ``bench_prefetch_priority._exposed_fetch_seconds()``
+returned ``0.0`` for every arm because nothing timed the synchronous on-demand
+expert fetch, so ``bm3_decision.exposed_fetch_improved`` could never be true.
+
+The fix adds a read-only accumulator on ``OffloadEngine``: the pre-forward
+hook's ``fetch_tensors`` call is the exposed-fetch window (compute stalls there
+whenever an expert was not already prefetched), so we time exactly that call
+and surface the running total via ``get_exposed_fetch_seconds()`` with a
+``reset_exposed_fetch_seconds()`` to zero it per ablation arm.
+
+These tests are pure: they construct ``OffloadEngine`` via ``__new__`` with a
+mocked ``archer_engine`` and never import the native extension, load a
+checkpoint, or touch CUDA. They also exercise the harness-side
+``_exposed_fetch_seconds`` probe, which the docstring guarantees is CPU-safe.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from benchmarks.dflash.bench_prefetch_priority import _exposed_fetch_seconds
+from moe_infinity.runtime.model_offload import OffloadEngine
+
+
+def _bare_engine() -> OffloadEngine:
+    engine = OffloadEngine.__new__(OffloadEngine)
+    engine.request_id = 7
+    engine._exposed_fetch_seconds = 0.0
+    engine.archer_engine = MagicMock()
+    return engine
+
+
+# ---------------------------------------------------------------------------
+# OffloadEngine read-only exposed-fetch accumulator
+# ---------------------------------------------------------------------------
+
+
+def test_offload_engine_exposes_exposed_fetch_surface():
+    engine = _bare_engine()
+    assert callable(getattr(engine, "get_exposed_fetch_seconds", None))
+    assert callable(getattr(engine, "reset_exposed_fetch_seconds", None))
+    assert callable(getattr(engine, "_fetch_tensors_timed", None))
+    assert engine.get_exposed_fetch_seconds() == 0.0
+
+
+def test_timed_fetch_calls_native_fetch_unchanged():
+    engine = _bare_engine()
+    tensors = [11, 22, 33]
+    engine._fetch_tensors_timed(tensors)
+    engine.archer_engine.fetch_tensors.assert_called_once_with(7, tensors)
+
+
+def test_timed_fetch_accumulates_wall_time():
+    engine = _bare_engine()
+
+    def _slow_fetch(_request_id, _tensors):
+        time.sleep(0.02)
+
+    engine.archer_engine.fetch_tensors.side_effect = _slow_fetch
+    engine._fetch_tensors_timed([1])
+    first = engine.get_exposed_fetch_seconds()
+    assert first >= 0.02
+    engine._fetch_tensors_timed([2])
+    assert engine.get_exposed_fetch_seconds() >= first + 0.02 - 1e-6
+
+
+def test_reset_zeros_the_accumulator():
+    engine = _bare_engine()
+    engine.archer_engine.fetch_tensors.side_effect = (
+        lambda *_a, **_k: time.sleep(0.005)
+    )
+    engine._fetch_tensors_timed([1])
+    assert engine.get_exposed_fetch_seconds() > 0.0
+    engine.reset_exposed_fetch_seconds()
+    assert engine.get_exposed_fetch_seconds() == 0.0
+
+
+def test_get_exposed_fetch_seconds_defaults_to_zero_without_field():
+    engine = OffloadEngine.__new__(OffloadEngine)
+    assert engine.get_exposed_fetch_seconds() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# harness probe: _exposed_fetch_seconds reads the real engine getter
+# ---------------------------------------------------------------------------
+
+
+class _EngineWithGetter:
+    def __init__(self, value):
+        self._value = value
+
+    def get_exposed_fetch_seconds(self):
+        return self._value
+
+
+class _EngineWithPrefetcher:
+    def __init__(self, value):
+        self.expert_prefetcher = _EngineWithGetter(value)
+
+
+def test_probe_reads_engine_get_exposed_fetch_seconds():
+    assert _exposed_fetch_seconds(_EngineWithGetter(1.5), None) == 1.5
+
+
+def test_probe_reads_prefetcher_getter_when_engine_bare():
+    assert _exposed_fetch_seconds(_EngineWithPrefetcher(0.75), None) == 0.75
+
+
+def test_probe_returns_zero_when_nothing_instrumented():
+    class _Bare:
+        pass
+
+    assert _exposed_fetch_seconds(_Bare(), None) == 0.0

--- a/tests/python/dflash/test_prefetch_native_gpu.py
+++ b/tests/python/dflash/test_prefetch_native_gpu.py
@@ -117,3 +117,57 @@ def test_native_batched_prefetch_experts_list_uses_batched_path(
         if layer == some_layer
     )
     offloaded_prefetcher.prefetch_experts_list(some_layer, experts)
+
+
+def test_native_priority_bands_accept_each_service_class_reverse_order(
+    offloaded_prefetcher,
+) -> None:
+    from moe_infinity.memory.expert_prefetcher import (
+        BACKGROUND_PREFETCH_PRIORITY,
+        ON_DEMAND_PRIORITY,
+        ROUTE_AHEAD_PRIORITY,
+    )
+
+    engine = offloaded_prefetcher.archer_engine
+    tensor_ids = _saturated_ids(offloaded_prefetcher)
+    assert tensor_ids, "no offloaded expert tensors to issue"
+
+    for priority in (
+        BACKGROUND_PREFETCH_PRIORITY,
+        ROUTE_AHEAD_PRIORITY,
+        ON_DEMAND_PRIORITY,
+    ):
+        assert engine.prefetch_tensors(tensor_ids, priority) is None
+        torch.cuda.synchronize()
+
+
+def test_native_route_ahead_priority_knob_issues_each_band(
+    offloaded_prefetcher,
+) -> None:
+    from moe_infinity.memory.expert_prefetcher import (
+        BACKGROUND_PREFETCH_PRIORITY,
+        ON_DEMAND_PRIORITY,
+        ROUTE_AHEAD_PRIORITY,
+    )
+
+    layers = sorted(
+        {layer for layer, _e in offloaded_prefetcher.expert_tensor_map}
+    )
+    some_layer = layers[0]
+    experts = sorted(
+        expert
+        for layer, expert in offloaded_prefetcher.expert_tensor_map
+        if layer == some_layer
+    )
+    original = offloaded_prefetcher.route_ahead_priority
+    try:
+        for band in (
+            BACKGROUND_PREFETCH_PRIORITY,
+            ROUTE_AHEAD_PRIORITY,
+            ON_DEMAND_PRIORITY,
+        ):
+            offloaded_prefetcher.route_ahead_priority = band
+            offloaded_prefetcher.prefetch_experts_list(some_layer, experts)
+            torch.cuda.synchronize()
+    finally:
+        offloaded_prefetcher.route_ahead_priority = original

--- a/tests/python/dflash/test_prefetch_native_gpu.py
+++ b/tests/python/dflash/test_prefetch_native_gpu.py
@@ -141,6 +141,20 @@ def test_native_priority_bands_accept_each_service_class_reverse_order(
         torch.cuda.synchronize()
 
 
+def test_native_reset_cache_is_non_terminal(offloaded_prefetcher) -> None:
+    engine = offloaded_prefetcher.archer_engine
+    tensor_ids = _saturated_ids(offloaded_prefetcher)
+    assert tensor_ids, "no offloaded expert tensors to issue"
+
+    assert engine.reset_cache() is None
+    torch.cuda.synchronize()
+
+    assert engine.prefetch_tensors(tensor_ids, 1) is None
+    torch.cuda.synchronize()
+    assert engine.reset_cache() is None
+    torch.cuda.synchronize()
+
+
 def test_native_route_ahead_priority_knob_issues_each_band(
     offloaded_prefetcher,
 ) -> None:

--- a/tests/python/dflash/test_speculative_prefetch.py
+++ b/tests/python/dflash/test_speculative_prefetch.py
@@ -26,7 +26,12 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 
-from moe_infinity.memory.expert_prefetcher import ExpertPrefetcher
+from moe_infinity.memory.expert_prefetcher import (
+    BACKGROUND_PREFETCH_PRIORITY,
+    ON_DEMAND_PRIORITY,
+    ROUTE_AHEAD_PRIORITY,
+    ExpertPrefetcher,
+)
 
 # Hand-checked legacy fixture: [2 tokens, 4 experts]
 #   mean over tokens = [2.0, 3.5, 3.0, 0.5] -> top-2 = experts [1, 2]
@@ -185,7 +190,9 @@ def _make_prefetcher_without_batch(num_layers: int = 8, num_experts: int = 8):
 def test_prefetch_experts_list_batches_one_native_call_when_available():
     prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
     prefetcher.prefetch_experts_list(3, [3, 1, 7])
-    engine.prefetch_tensors.assert_called_once_with([303, 301, 307])
+    engine.prefetch_tensors.assert_called_once_with(
+        [303, 301, 307], priority=ROUTE_AHEAD_PRIORITY
+    )
     engine.enqueue_prefetch.assert_not_called()
 
 
@@ -202,3 +209,43 @@ def test_prefetch_experts_list_empty_batch_calls_neither_path():
     prefetcher.prefetch_experts_list(3, [])
     engine.prefetch_tensors.assert_not_called()
     engine.enqueue_prefetch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# priority bands (plan Task 9 Step 5): explicit route-ahead vs legacy background
+# ---------------------------------------------------------------------------
+
+
+def _issued_priority(engine: MagicMock) -> int:
+    return engine.prefetch_tensors.call_args.kwargs["priority"]
+
+
+def test_explicit_route_ahead_issues_on_the_route_ahead_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher.speculative_prefetch(
+        1, expert_ids=[3, 1, 7], prefetch_layer_id=5
+    )
+    assert _enqueued_tensor_ids(engine) == [503, 501, 507]
+    assert _issued_priority(engine) == ROUTE_AHEAD_PRIORITY
+
+
+def test_legacy_router_logits_issues_on_the_background_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=4)
+    prefetcher.speculative_prefetch(2, LOGITS)
+    assert _enqueued_tensor_ids(engine) == [301, 302]
+    assert _issued_priority(engine) == BACKGROUND_PREFETCH_PRIORITY
+
+
+def test_correct_prefetch_issues_on_the_route_ahead_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher._last_speculative_prediction = {1}
+    prefetcher.correct_prefetch(3, [3, 1, 7])
+    assert _enqueued_tensor_ids(engine) == [303, 307]
+    assert _issued_priority(engine) == ROUTE_AHEAD_PRIORITY
+
+
+def test_route_ahead_priority_knob_sweeps_the_issued_band():
+    prefetcher, engine = _make_prefetcher(num_layers=8, num_experts=8)
+    prefetcher.route_ahead_priority = ON_DEMAND_PRIORITY
+    prefetcher.prefetch_experts_list(3, [3, 1, 7])
+    assert _issued_priority(engine) == ON_DEMAND_PRIORITY


### PR DESCRIPTION
## BM3 route-ahead priority band — settled: **NO-SHIP** (band reverted)

Unblocks and runs the BM3 route-ahead prefetch priority-band ablation (PD-DFlash
Task 9, design §10) to a real ship/no-ship verdict, then applies the verdict.
On offloaded `openai/gpt-oss-20b` + the `z-lab/gpt-oss-20b-DFlash` draft the
dedicated route-ahead band **does not ship**, so the one behavioural C++ line is
reverted. The harness + instrumentation fixes and the BM3 result are kept.

**Draft — do not merge.**

### Blockers fixed (kept regardless of verdict)

**A — harness deadlock.** `bench_prefetch_priority._reset_cache()` called the
terminal `ArcherPrefetchHandle::CleanUpResources()` between ablation arms, which
nulls `kTaskPool`/topology/memory-pool globals and sets
`has_cleaned_up_resources_`; the next forward then hung in `fetch_tensors`
(no JSON ever emitted). Fix: add non-terminal `ArcherPrefetchHandle::ResetCache()`
(bound `reset_cache`) → `kTaskPool->ClearQueue()`, dropping pending prefetch work
while keeping the task pool, its worker threads, and all globals alive
(`ClearQueue` scans priority 1..NUM_PRIORITY, leaving the on-demand band 0
intact). `_reset_cache()` now prefers `reset_cache`, falls back to
`replace_cache_candidates([])`, and zeros the per-arm exposed-fetch accumulator.

*Reproduced with faulthandler on the box (single model load, one process each):*
- `mode=terminal` (old `clean_up_resources`): GEN#1 returns → GEN#2 **hangs** in
  `fetch_tensors` (faulthandler dumps the stack; `GEN#2 returned` never printed).
- `mode=reset` (new `reset_cache`): GEN#2 **returned in 0.461s**.

**B — exposed-fetch instrumentation.** `_exposed_fetch_seconds()` returned `0.0`
for every arm (nothing timed the synchronous on-demand fetch), so
`exposed_fetch_improved` could never be true. Fix: `OffloadEngine._fetch_tensors_timed()`
times the pre-forward hook's `fetch_tensors` call — the exposed-fetch window
where compute stalls until an un-prefetched expert is resident — and accumulates
`_exposed_fetch_seconds`, surfaced via `get_exposed_fetch_seconds()` /
`reset_exposed_fetch_seconds()`. **Read-only**: the fetch is unchanged, only
timed. `_measure_once()` reads a per-run before/after delta. TDD: 8 CPU tests
cover the engine accumulator surface and the harness probe.

### BM3 three-way ablation (offloaded gpt-oss-20b, `device_memory_ratio=0.2`)

| arm (band) | run 1 — 6 reps, seed 1408 | run 2 — 10 reps, seed 2024 |
|---|---|---|
| background (2, default) | exposed **14.216 ms**, 87.27 tok/s | exposed **15.327 ms**, 83.58 tok/s |
| route-ahead (1, candidate) | exposed **13.662 ms**, 86.51 tok/s | exposed **15.434 ms**, 93.49 tok/s |
| on-demand (0) | exposed **13.540 ms**, 88.92 tok/s | exposed **13.758 ms**, 91.53 tok/s |

`bm3_decision`:
- run 1: `exposed_fetch_improved=True`, `throughput_preserved=False`, `on_demand_fastest=True` → **`ship_priority_band=False`**
- run 2: `exposed_fetch_improved=False`, `throughput_preserved=True`, `on_demand_fastest=True` → **`ship_priority_band=False`**

### Verdict: NO-SHIP → band reverted

The two runs fail on **different** gates and the exposed-fetch effect **flips
sign** (route-ahead beats background in run 1, loses in run 2): the signal is
within measurement noise, with no run where all three ship conditions hold.
on-demand stays fastest in both (no priority inversion). Per the honest gate
(no C++ ships without its paired benchmark proving the exposed window closes at
no throughput cost), the one behavioural line is reverted — `EnqueuePrefetch`
(ordinary/background prefetch) returns to band 1, so route-ahead is no longer
serviced ahead of background. Default production behaviour matches pre-candidate
(all prefetch at band 1; on-demand at 0).

**Kept as inert-by-default measurement scaffolding** (so BM3 stays reproducible):
the named band constants, the `ExpertPrefetcher.route_ahead_priority` knob, and
the BM3 harness.

### Validation
- SM120 build clean (0 errors), both before and after the revert.
- faulthandler repro: terminal reset hangs GEN#2; `reset_cache` returns GEN#2 in 0.461s.
- Native GPU smoke (reverted build): **6 passed** — all three bands issue + `reset_cache` is non-terminal.
- gpt-oss offload no-regression (`tests/test_gpt_oss_offload_topology.py`): **5 passed**.
- CPU decision/mock/instrumentation suite: **73 passed**; ruff clean; LSP clean.
