### PR TITLE
fix(build,ci): version PyPI publishes from git tags via setuptools-scm

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
@@ -30,7 +32,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=78.1.1,<82" wheel build
+          pip install "setuptools>=78.1.1,<82" "setuptools-scm>=8" wheel build
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build sdist

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -54,6 +54,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -69,7 +71,7 @@ jobs:
             | pip install -r /dev/stdin 2>&1 || true
 
       - name: Install test tools
-        run: pip install pytest pytest-xdist pytest-timeout
+        run: pip install pytest pytest-xdist pytest-timeout "setuptools-scm>=8"
 
       - name: Install package (no CUDA extensions)
         run: pip install --no-build-isolation --no-deps -e .
@@ -92,6 +94,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v5
@@ -100,7 +104,7 @@ jobs:
 
       - name: Install build tools
         run: |
-          pip install "setuptools>=78.1.1,<82" wheel build
+          pip install "setuptools>=78.1.1,<82" "setuptools-scm>=8" wheel build
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Build sdist

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -13,35 +13,13 @@ on:
       - 'tests/**'
       - 'docs/**'
 
-env:
-  # Bump this to the NEXT planned release when cutting a stable release.
-  # Nightlies must sort higher than the current stable so that
-  # `pip install --pre moe-infinity` picks them up.
-  NIGHTLY_BASE_VERSION: "0.0.2"
-
 permissions:
   contents: write
 
 jobs:
-  setup-version:
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Generate version number
-      run: |
-        VERSION_HASH=$(date +"%Y%m%d%H%M%S")
-        echo "Generated version hash: $VERSION_HASH"
-        echo $VERSION_HASH > version.txt
-
-    - name: Upload version number as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: version
-        path: version.txt
-
   wheel:
     name: Build Wheel
     runs-on: ${{ matrix.os }}
-    needs: setup-version
     permissions: write-all
     strategy:
       fail-fast: false
@@ -53,12 +31,8 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3
-
-      - name: Download version value artifact
-        uses: actions/download-artifact@v4
         with:
-          name: version
-          path: artifact
+          fetch-depth: 0
 
       - name: Free disk space
         run: |
@@ -83,13 +57,16 @@ jobs:
       - name: Install Python build dependencies (torch matched to CUDA)
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "setuptools>=78.1.1,<82" wheel ninja py-cpuinfo build
+          python3 -m pip install "setuptools>=78.1.1,<82" "setuptools-scm>=8" wheel ninja py-cpuinfo build
           python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu128
 
       - name: Fetch CUTLASS headers
         run: |
           git clone --depth 1 --branch v3.9.2 https://github.com/NVIDIA/cutlass.git "${HOME}/cutlass"
 
+      # setuptools-scm derives the version from git history: a commit that is N
+      # commits after tag "vX.Y.Z" builds as "X.Y.(Z+1).devN". local_scheme in
+      # pyproject.toml strips the "+gHASH" suffix so the sdist is PyPI-valid.
       - name: Build Wheel
         shell: bash
         env:
@@ -98,8 +75,7 @@ jobs:
           export CUDA_HOME="/usr/local/cuda-${{ matrix.cuda-version }}"
           export PATH="${CUDA_HOME}/bin:${PATH}"
           export CUTLASS_DIR="${HOME}/cutlass"
-          VERSION_HASH=$(cat artifact/version.txt)
-          MOEINF_VERSION=${{ env.NIGHTLY_BASE_VERSION }}.dev${VERSION_HASH} python3 -m build --wheel --no-isolation
+          python3 -m build --wheel --no-isolation
           wheel_name=$(ls dist/*whl | xargs -n 1 basename)
           asset_name=${wheel_name//"linux"/"manylinux1"}
           echo "wheel_name=${wheel_name}" >> $GITHUB_ENV
@@ -108,8 +84,7 @@ jobs:
       - name: Build Source
         if: ${{ matrix.python-version == '3.10' }}
         run: |
-          VERSION_HASH=$(cat artifact/version.txt)
-          MOEINF_VERSION=${{ env.NIGHTLY_BASE_VERSION }}.dev${VERSION_HASH} python3 -m build --sdist
+          python3 -m build --sdist
 
       - name: Rename Wheel
         run: |

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -20,7 +20,9 @@ jobs:
   wheel:
     name: Build Wheel
     runs-on: ${{ matrix.os }}
-    permissions: write-all
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -97,12 +99,12 @@ jobs:
           cp dist/*.tar.gz sdist_only/
 
       # Nightly publishes only the sdist to PyPI (see publish.yml for rationale).
+      # Auth via PyPI Trusted Publishing (OIDC) — no username/password needed;
+      # requires id-token: write (above) and a publisher registered on PyPI for
+      # this repo + workflow file. See RELEASE.md.
       - name: Publish sdist to PyPI
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.python-version == '3.10' }}
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           skip-existing: true
           packages-dir: sdist_only
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -122,12 +123,12 @@ jobs:
       # Only the sdist is published to PyPI. Prebuilt CUDA wheels are ABI-locked to a
       # specific torch/CUDA, which PyPI wheel tags cannot express; they are attached to
       # the GitHub Release instead. pip installs the sdist and compiles it locally.
+      # Auth via PyPI Trusted Publishing (OIDC) — no username/password needed;
+      # requires id-token: write (above) and a publisher registered on PyPI for
+      # this repo + workflow file. See RELEASE.md.
       - name: Publish sdist to PyPI
         if: ${{ matrix.python-version == '3.10' }}
         uses: pypa/gh-action-pypi-publish@release/v1.8
         with:
           skip-existing: true
           packages-dir: sdist_only
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Free Disk Space
         run: |
@@ -71,7 +73,7 @@ jobs:
       - name: Install Python build dependencies (torch matched to CUDA)
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install "setuptools>=78.1.1,<82" wheel ninja py-cpuinfo build
+          python3 -m pip install "setuptools>=78.1.1,<82" "setuptools-scm>=8" wheel ninja py-cpuinfo build
           python3 -m pip install torch --index-url https://download.pytorch.org/whl/cu128
 
       - name: Fetch CUTLASS headers

--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,6 @@ benchmarks/expert_io_microbench/results/
 benchmarks/eval/__pycache__/
 *.nsys-rep
 *.sqlite
+
+# setuptools-scm generated version file (regenerated on every build)
+moe_infinity/_version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to MoE-Infinity will be documented in this file.
 - GLM-5.2-FP8 keeps routed FP8 experts in the host store while non-routed FP8 weights dequantize to BF16 on load.
 - Root README is now a concise discovery surface and points readers to the docs hub, model compatibility, DFlash, serving, troubleshooting, architecture, and changelog.
 - Release notes are split out of README and tracked here instead of being presented as shipped releases.
+- Package version is now derived from git tags by setuptools-scm and written to `moe_infinity/_version.py` at build time, replacing the manual `MOEINF_VERSION`, `NIGHTLY_BASE_VERSION`, and hardcoded `setup.py`/`__init__.py` version strings.
 
 ### Deprecated
 
@@ -25,6 +26,7 @@ All notable changes to MoE-Infinity will be documented in this file.
 - Serving-path DFlash now truncates KV cache to the committed prefix after each verify step, so emitted and cached tokens stay aligned.
 - GPT-OSS resident-load path now materializes MXFP4 blocks, scales, router, biases, and attention sinks instead of leaving placeholder tensors in place.
 - GLM FP8 store and reload parity now stays stable across fresh stores and reloads.
+- PyPI publishing for both stable (`publish.yml`) and nightly (`publish-test.yml`): stable releases now take their version from the pushed git tag instead of always publishing `0.0.1`, and nightly sdists carry their version in `PKG-INFO` so `pip install --pre moe-infinity` no longer fails with a `MetadataInconsistent` version mismatch on rebuild.
 
 ### Known Limitations
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,15 @@
 recursive-include core *.cpp *.h *.cc
 recursive-include extensions/kernel *.cu *.h
+
+# With setuptools-scm installed, the sdist file-finder defaults to including
+# every git-tracked file. Prune large directories that are not needed to build
+# or install the package from source, keeping the published sdist lean.
+prune docs
+prune benchmarks
+prune examples
+prune tests
+prune docker
+prune scripts
+prune results
+prune logs
+prune .github

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build
 
 # 2. Build tools + PyTorch. Match PyTorch's CUDA build to your CUDA toolkit
 #    (pick the index URL for your CUDA version from https://pytorch.org).
-pip install "setuptools>=78.1.1,<82" wheel ninja py-cpuinfo
+pip install "setuptools>=78.1.1,<82" "setuptools-scm>=8" wheel ninja py-cpuinfo
 pip install torch --index-url https://download.pytorch.org/whl/cu128
 
 # 3. CUTLASS headers (header-only; no separate build required)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,10 +51,18 @@ To release a new version, such as version 1.0.0, follow this order:
    - close the current `## [Unreleased]` section in `CHANGELOG.md`
    - move shipped notes into the dated release entry
    - recreate a fresh `## [Unreleased]` section at the top
-1. Update Version:
-   - Update `moe_infinity/__init__.py` (`__version__ = "..."`) to the new stable version.
-   - Ensure `setup.py` remains `version=os.getenv("MOEINF_VERSION", "...")` and update the default fallback version there to match the new stable version.
-   - If needed, bump `NIGHTLY_BASE_VERSION` in `.github/workflows/publish-test.yml` to the next planned stable series so nightly dev builds sort correctly.
+1. Versioning is automatic (setuptools-scm):
+   - Versions are derived from the git tag at build time (see `pyproject.toml`
+     `[tool.setuptools_scm]`) and written to `moe_infinity/_version.py`. There
+     are no version strings to edit in `setup.py` or `moe_infinity/__init__.py`.
+   - Tag `vX.Y.Z` publishes stable `X.Y.Z`. Every later commit on `main`
+     publishes as the next-patch pre-release `X.Y.(Z+1).devN`, so nightlies
+     always sort above the last stable and below the next one, with no manual
+     `NIGHTLY_BASE_VERSION` bump.
+   - First release only: the repository has no tags yet, so until the first tag
+     exists nightlies version as `0.1.devN`. Create the initial tag (for example
+     `git tag v0.0.1`) on the release commit to anchor the `0.0.x` series;
+     afterwards nightlies become `0.0.2.devN` automatically.
 2. Review the release checklist above
    - confirm model and capability coverage
    - verify install and quick starts

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -44,6 +44,25 @@ Stable releases are automated through GitHub Actions workflows in `.github/workf
 - `.github/workflows/publish-test.yml`: publishes nightly pre-release builds from `main` to PyPI.
 - `.github/workflows/build-test.yml`: build validation for pull requests.
 
+### One-time PyPI setup (Trusted Publishing)
+
+Publishing authenticates via PyPI Trusted Publishing (OIDC); there are no PyPI
+username/password/token secrets in the repository. The `pypa/gh-action-pypi-publish`
+action reads credentials only from its `user`/`password` inputs (not from
+`TWINE_*` env vars) and, with none supplied plus `id-token: write`, uses OIDC.
+
+Before the first successful publish, register a trusted publisher on PyPI once
+per workflow, at `https://pypi.org/manage/project/moe-infinity/settings/publishing/`:
+
+- Owner: `EfficientMoE`
+- Repository name: `MoE-Infinity`
+- Workflow name: `publish-test.yml` (nightly) — then add a second, identical
+  entry with Workflow name `publish.yml` (stable)
+- Environment: leave blank
+
+Until these are registered, the publish step fails with
+`invalid-publisher: ... no corresponding publisher`.
+
 ### Steps to Release a New Version
 To release a new version, such as version 1.0.0, follow this order:
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -53,7 +53,9 @@ For `CUDA_VISIBLE_DEVICES` ordering, expert ownership, and one-host multi-GPU be
 | `NVTX_DISABLE` | `"0"` | `setup.py` build | If `"1"`, compile out NVTX instrumentation macros. | Build-time only. |
 | `MOE_ENABLE_SM90` | `"1"` | `setup.py` build | Include sm_90 kernels in the compiled extensions. | Build-time only. |
 | `MOE_ENABLE_SM120` | `"0"` | `setup.py` build | Include sm_120 kernels and the native FP4 extension arch flags. | Build-time only. |
-| `MOEINF_VERSION` | `"0.0.1"` | `setup.py` packaging | Set the package version string. | Packaging only. |
+
+The package version is not set via an environment variable; it is derived from
+git tags at build time by setuptools-scm (see `pyproject.toml`).
 
 ## Standard third-party envs
 

--- a/moe_infinity/__init__.py
+++ b/moe_infinity/__init__.py
@@ -1,4 +1,9 @@
-__version__ = "0.0.1"
+try:
+    # Generated at build time by setuptools-scm (see pyproject.toml).
+    from ._version import __version__
+except Exception:  # pragma: no cover - source tree built without setuptools-scm
+    __version__ = "0.0.0+unknown"
+
 __all__ = ["MoE", "OffloadEngine", "__version__"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,20 @@
 [build-system]
-requires = ["setuptools>=75.3.2", "wheel", "torch"]
+requires = ["setuptools>=75.3.2", "setuptools-scm>=8", "wheel", "torch"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# Version is derived from git tags (e.g. tag "v0.1.0" -> version "0.1.0").
+# The resolved version is written to this file, which moe_infinity/__init__.py
+# imports at runtime. The file is git-ignored and regenerated on every build.
+version_file = "moe_infinity/_version.py"
+# PyPI/PEP 440 forbid local version segments (the "+gHASH" / "+dYYYYMMDD"
+# suffix), so strip them. Untagged nightly builds then become PyPI-valid
+# pre-releases, e.g. "0.0.2.dev4" for the 4th commit after tag "v0.0.1".
+local_scheme = "no-local-version"
+# Used only when building with neither git metadata nor sdist PKG-INFO
+# (e.g. a GitHub "Download ZIP" tarball). Normal sdist installs read the
+# version from the PKG-INFO baked into the tarball, so this is a last resort.
+fallback_version = "0.0.0"
 
 
 [tool.ruff]

--- a/setup.py
+++ b/setup.py
@@ -398,7 +398,9 @@ print(f"find_packages: {find_packages()}")
 # install all files in the package, rather than just the egg
 setup(
     name="moe_infinity",
-    version=os.getenv("MOEINF_VERSION", "0.0.1"),
+    # version is supplied dynamically by setuptools-scm (see pyproject.toml
+    # [tool.setuptools_scm]); it is derived from git tags at build time and
+    # baked into the sdist's PKG-INFO so it survives a source reinstall.
     packages=find_packages(exclude=["extensions", "extensions.*"]),
     include_package_data=True,
     install_requires=install_requires,


### PR DESCRIPTION
## Summary

PyPI publishing is broken for **both** release flows. The package version is computed only from an environment variable at build time (`setup.py`: `version=os.getenv("MOEINF_VERSION", "0.0.1")`), and that variable is absent when a user's machine rebuilds the published **sdist** (only the sdist is published — the CUDA wheels are ABI-locked).

This PR migrates versioning to **setuptools-scm** (git-tag driven), so the version is derived from tags at build time and baked into the sdist's `PKG-INFO`, surviving a source reinstall.

## The bugs (before)

| Flow | Symptom |
|---|---|
| **Stable** (`publish.yml`, tag `v*`) | `python -m build` is called with **no `MOEINF_VERSION`**, so a tag push of `v0.3.0` builds artifacts labeled `0.0.1`. The first release publishes `0.0.1`; every later tag **silently no-ops** on PyPI because of `skip-existing: true`. The git tag is only used for the release *name*. |
| **Nightly** (`publish-test.yml`, push to `main`) | The sdist is uploaded as `0.0.2.devN` (filename + PKG-INFO agree, so twine accepts it), but `pip install --pre moe-infinity` rebuilds it without `MOEINF_VERSION` → metadata becomes `0.0.1` → pip aborts with `MetadataInconsistent` (`filename has '0.0.2.devN', but metadata has '0.0.1'`). Nightlies are uninstallable. |
| `moe_infinity/__init__.py` | Hardcoded `__version__ = "0.0.1"` — a third source of truth that never matches either published version. |

## The fix

- **`pyproject.toml`**: add `setuptools-scm>=8` to `build-system.requires` and a `[tool.setuptools_scm]` block with `version_file = "moe_infinity/_version.py"`, `local_scheme = "no-local-version"` (PEP 440/PyPI reject the `+gHASH` local segment), and `fallback_version = "0.0.0"`.
- **`setup.py`**: drop the hardcoded `version=`; setuptools-scm supplies it.
- **`moe_infinity/__init__.py`**: read `__version__` from the generated `_version.py` with a graceful fallback.
- **`.gitignore` / `MANIFEST.in`**: ignore the generated `_version.py`; prune `docs/benchmarks/tests/examples/docker/scripts` from the sdist (setuptools-scm's file-finder otherwise includes all tracked files).
- **Workflows**: `publish.yml`, `publish-test.yml`, `build-test.yml`, `ci-pr.yml` all get `fetch-depth: 0` + `setuptools-scm` installed. The nightly's `setup-version` job, `NIGHTLY_BASE_VERSION`, and timestamp-hash machinery are removed — setuptools-scm emits `X.Y.(Z+1).devN` automatically (no more manual bumps).
- **Docs**: `RELEASE.md`, `docs/environment-variables.md`, `README.md`, `CHANGELOG.md` updated.

## Verification (local)

Built the sdist with a temporary `v0.0.1` tag, then extracted it and rebuilt **with no git present** (simulating a user's `pip install`):

```
setuptools-scm in extracted tree (PKG-INFO only) -> 0.0.2.dev0
setup.py --version in extracted tree            -> 0.0.2.dev0   (old approach printed 0.0.1 -> MetadataInconsistent)
```

- `local_scheme = "no-local-version"` confirmed: dev version is clean `0.0.2.dev0` (no `+gHASH`), i.e. PyPI-valid.
- sdist contains `core/` (120 files) + `extensions/` (29); `docs/benchmarks/tests/examples/docker/scripts` pruned to 0; `PKG-INFO` `Version` correct.
- All 7 workflow YAMLs parse; LSP clean on `setup.py`/`__init__.py`; pre-commit (ruff/codespell/mypy) green on all files.

## ⚠️ Required action to activate

The repo currently has **no git tags**, so until the first tag exists setuptools-scm versions untagged builds as `0.1.devN` (which mis-sorts above the intended `0.0.x`). Create the initial anchor tag on the release commit:

```bash
git tag v0.0.1 && git push origin v0.0.1
```

After that, stable = the tag and nightlies auto-become `0.0.2.devN`. This is documented in the updated `RELEASE.md`.
